### PR TITLE
Add Ganglia metrics appropriate for the user collector.

### DIFF
--- a/install/templates/01_gwms_ganglia.config
+++ b/install/templates/01_gwms_ganglia.config
@@ -1,0 +1,17 @@
+
+###########################################################
+# Ganglia configuration for user collector
+###########################################################
+
+DAEMON_LIST   = $(DAEMON_LIST), GANGLIAD
+
+# Send data for all non-pilots, even if they aren't already
+# in Ganglia.
+GANGLIA_SEND_DATA_FOR_ALL_HOSTS = True
+
+# By default, condor_gangliad queries for all ads in the
+# collector (equivalent to "condor_status -l -any").  This
+# is too expensive, so we drop any Ganglia reporting about
+# glideins.
+GANGLIAD_REQUIREMENTS = MyType =!= "Machine"
+

--- a/install/templates/01_gwms_metrics.config
+++ b/install/templates/01_gwms_metrics.config
@@ -1,0 +1,79 @@
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Glideins_RequestIdle", strcat(GLIDEIN_Site, "_Glideins_RequestIdle"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Total glideins requested idle", strcat("Glideins requested idle at ", GLIDEIN_Site));
+  Desc   = ifThenElse(GLIDEIN_Site is null, "The total number of requested idle glideins", strcat("The number of requested idle glideins at ", GLIDEIN_Site, " for this frontend"));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value  = GlideClientMonitorGlideinsRequestIdle;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "glideins";
+  TargetType = "glideresource";
+]
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Glideins_Idle", strcat(GLIDEIN_Site, "_Glideins_Idle"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Total glideins idle", strcat("Glideins idle at ", GLIDEIN_Site));
+  Desc   = ifThenElse(GLIDEIN_Site is null, "The total number of idle glideins", strcat("The number of glideins idle at ", GLIDEIN_Site, " for this frontend"));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value  = GlideClientMonitorGlideinsIdle;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "glideins";
+  TargetType = "glideresource";
+]
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Glideins_RequestMaxRun", strcat(GLIDEIN_Site, "_Glideins_RequestMaxRun"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Max requested glideins", strcat("Max glideins requested at ", GLIDEIN_Site));
+  Desc   = ifThenElse(GLIDEIN_Site is null, "The total number of max requested glideins", strcat("The maximum number of glideins requested at ", GLIDEIN_Site, " for this frontend"));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value  = GlideClientMonitorGlideinsRequestMaxRun;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "glideins";
+  TargetType = "glideresource";
+]
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Glideins_Running", strcat(GLIDEIN_Site, "_Glideins_Running"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Total glideins running", strcat("Glideins running at ", GLIDEIN_Site));
+  Desc   = ifThenElse(GLIDEIN_Site is null, "The total number of glideins running", strcat("The number of glideins running at ", GLIDEIN_Site, " for this frontend"));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value  = GlideClientMonitorGlideinsRunning;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "glideins";
+  TargetType = "glideresource";
+]
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Jobs_Idle", strcat(GLIDEIN_Site, "_Jobs_Idle"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Total jobs idle", strcat(GLIDEIN_Site, " Jobs Idle"));
+  Desc = ifThenElse(GLIDEIN_Site is null, "The total number of idle jobs", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value = GlideClientMonitorJobsIdleMatching;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "jobs";
+  TargetType = "glideresource";
+]
+[
+  Name   = ifThenElse(GLIDEIN_Site is null, "Total_Jobs_Running", strcat(GLIDEIN_Site, "_Jobs_Running"));
+  Title  = ifThenElse(GLIDEIN_Site is null, "Total jobs running", strcat(GLIDEIN_Site, " Jobs Running"));
+  Desc = ifThenElse(GLIDEIN_Site is null, "The total number of running jobs", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Group  = ifThenElse(GLIDEIN_Site is null, "Aggregate frontend metrics", strcat("Frontend metrics for ", GLIDEIN_Site));
+  Value = GlideClientMonitorJobsRunningHere;
+  Requirements = GLIDEIN_Site isnt null;
+  Aggregate = "sum";
+  Verbosity = 0;
+  Units  = "jobs";
+  TargetType = "glideresource";
+]
+[
+  Name   = "Pool Slot Count";
+  Value  = HostsTotal;
+  Desc   = "Number of slots in the pool";
+  Units  = "slots";
+  TargetType = "Collector";
+]


### PR DESCRIPTION
We can provide a few simple metrics by default for the user collector.

This isn't meant to replace the existing monitoring by any means - just a convenient addition to those already using Ganglia.

(This would need corresponding changes to the glideinWMS RPMs)
