### PR TITLE
Do not shutdown a glidein if it is claimed/idle.

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -607,7 +607,7 @@ DS${I}_IDLE_TAIL = ((GLIDEIN_Max_Tail =!= UNDEFINED) && \\
         ifThenElse(\$(DS${I}_IS_HTCONDOR_NEW), \$(DS${I}_IDLE_TAIL_NEW), \$(DS${I}_IDLE_TAIL_PRE82)))
 DS${I}_IDLE_RETIRE = (\$(DS${I}_NOT_PARTITIONABLE) && (GLIDEIN_ToRetire =!= UNDEFINED) && \\
        (CurrentTime > GLIDEIN_ToRetire ))
-DS${I}_IDLE = ( (Slot${I}_Activity == "Idle") && \\
+DS${I}_IDLE = ( (Slot${I}_Activity == "Idle") && (Slot${I}_State =!= "Claimed") && \\
         (\$(DS${I}_IDLE_NOJOB) || \$(DS${I}_IDLE_TAIL) || \$(DS${I}_IDLE_RETIRE)) )
 
 DS${I} = (\$(DS${I}_TO_DIE) || \\


### PR DESCRIPTION
If a glidein is in the claimed/idle state, we shouldn't shut it down.  It could just be an indicator that the schedd has a long queue for launching shadows - in such a case, shutting down the glidein will only increase churn and the queue length.
