### PR TITLE
Update URL for epel-release RPM

### DIFF
--- a/doc/components/prerequisites.html
+++ b/doc/components/prerequisites.html
@@ -296,7 +296,7 @@ Install as: various daemon users or as system rpms/packages
         module in order to guarantee the correct packages.
         The following commands will enable the repositories:
         <pre>
-        rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+        rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
         yum install yum-priorities
         yum install http://repo.grid.iu.edu/osg/3.2/osg-3.2-el6-release-latest.rpm </pre>
         Next, you can install the CA certificates and OSG client:


### PR DESCRIPTION
The old location for the epel-release RPM no longer works; changed it to a new URL that is a symlink that is guaranteed to be updated.