### PR TITLE
Adding GPU monitor as default for pilots

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -790,6 +790,8 @@ EOF
                     cat >> "$CONDOR_CONFIG" <<EOF
 # Declare resource: ${i}
 MACHINE_RESOURCE_${res_name} = ${res_num}
+use feature : GPUs
+use feature : GPUsMonitor
 EOF
                 fi
                 if [ "x$res_opt" == "xextra" ]; then

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -778,6 +778,7 @@ EOF
                     cat >> "$CONDOR_CONFIG" <<EOF
 # Declare GPUs resource, auto-discovered: ${i}
 use feature : GPUs
+use feature : GPUsMonitor
 GPU_DISCOVERY_EXTRA = -extra
 # Protect against no GPUs found
 if defined MACHINE_RESOURCE_${res_name}


### PR DESCRIPTION
The GPU monitor was fixed by HTCOndor https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=6857 so we should be deplying this by default