### PR TITLE
Add missing filename to grep line

### DIFF
--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -64,7 +64,7 @@ findversion_debian() {
   #Codename:    oneiric
 
   dist_id_line="`grep "DISTRIB_ID" /etc/lsb-release`"
-  dist_rel_line="`grep "DISTRIB_RELEASE" `"
+  dist_rel_line="`grep "DISTRIB_RELEASE" /etc/lsb-release`"
   if [[ ${dist_id_line} == *"Debian"* ]]; then
     [ ${dist_rel_line:16:3} = "10\." ] && condor_os='linux-debian10' && return
     [ ${dist_rel_line:16:2} = "9\." ] && condor_os='linux-debian9' && return


### PR DESCRIPTION
This was causing the subsequent `${dist_rel_line:16:2}` expressions to evaluate to empty.