### PR TITLE
Adding a httpd subpackage

### DIFF
--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -74,10 +74,15 @@ For those familiar with the Condor system, it is used for
 scheduling and job control. This package is for a one-node
 vofrontend install (userschedd, submit, vofrontend).
 
-
-%package vofrontend-standalone
-Summary:        The VOFrontend for glideinWMS submission host
+%package vofrontend-httpd
+Summary:  The Apache http configuration for GWMS frontend.
 Requires: httpd
+%description vofrontend-httpd
+This subpackage includes the minimal configuration to start apache to
+serve the frontend files to the pilot.
+
+%packagae vofrontend-core
+Summary: The intelligence logic for GWMS.
 Requires: condor >= 8.4.0
 Requires: python-rrdtool
 Requires: m2crypto
@@ -92,6 +97,15 @@ Requires: glideinwms-common-tools = %{version}-%{release}
 Requires(post): /sbin/service
 Requires(post): /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
+%description vofrontend-core
+This subpackage includes all the phyton scripts need to run a
+frontend.
+
+
+%package vofrontend-standalone
+Summary:        The VOFrontend for glideinWMS submission host
+Requires: glideinwms-vofrontend-httpd =%{version}-%{release}
+Requires: glideinwms-vofrontend-core =%{version}-%{release}
 %description vofrontend-standalone
 The purpose of the glideinWMS is to provide a simple way
 to access the Grid, Cloud and HPC resources. GlideinWMS is a Glidein
@@ -756,7 +770,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, gfactory, gfactory) %config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/gwms-factory/glideinWMS.xml
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-factory
 
-%files vofrontend-standalone
+%files vofrontend-core
 %defattr(-,frontend,frontend,-)
 %doc LICENSE
 %doc ACKNOWLEDGMENTS.txt
@@ -811,7 +825,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_initrddir}/gwms-renew-proxies
 %attr(0644, root, root) %{_sysconfdir}/cron.d/gwms-renew-proxies
 %endif
-%config(noreplace) %{_sysconfdir}/httpd/conf.d/gwms-frontend.conf
 %attr(-, frontend, frontend) %dir %{_sysconfdir}/gwms-frontend
 %attr(-, frontend, frontend) %dir %{_sysconfdir}/gwms-frontend/plugin.d
 %attr(-, frontend, frontend) %dir %{_sysconfdir}/gwms-frontend/hooks.reconfig.pre
@@ -820,6 +833,9 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, frontend, frontend) %config(noreplace) %{_sysconfdir}/gwms-frontend/proxies.ini
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-frontend
 %attr(-, frontend, frontend) %{web_base}/../creation
+
+%files vofrontend-httpd
+%config(noreplace) %{_sysconfdir}/httpd/conf.d/gwms-frontend.conf
 
 
 %files factory-condor

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -98,7 +98,7 @@ Requires(post): /sbin/service
 Requires(post): /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
 %description vofrontend-core
-This subpackage includes all the phyton scripts need to run a
+This subpackage includes all the python scripts need to run a
 frontend.
 
 %package vofrontend-standalone

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -72,7 +72,7 @@ access the Grid, Cloud and HPC resources. GlideinWMS is a Glidein Based
 WMS (Workload Management System) that works on top of Condor.
 For those familiar with the Condor system, it is used for
 scheduling and job control. This package is for a one-node
-vofrontend install (userschedd, submit, vofrontend).
+vofrontend install (userschedd, usercollector, vofrontend).
 
 %package vofrontend-httpd
 Summary:  The Apache http configuration for GWMS frontend.
@@ -101,7 +101,6 @@ Requires(post): /sbin/chkconfig
 This subpackage includes all the phyton scripts need to run a
 frontend.
 
-
 %package vofrontend-standalone
 Summary:        The VOFrontend for glideinWMS submission host
 Requires: glideinwms-vofrontend-httpd =%{version}-%{release}
@@ -113,7 +112,6 @@ Based WMS (Workload Management System) that works on top of
 Condor. For those familiar with the Condor system, it is used
 for scheduling and job control.
 This package is for a standalone vofrontend install
-
 
 %package usercollector
 Summary:        The VOFrontend glideinWMS collector host

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -81,7 +81,7 @@ Requires: httpd
 This subpackage includes the minimal configuration to start apache to
 serve the frontend files to the pilot.
 
-%packagae vofrontend-core
+%package vofrontend-core
 Summary: The intelligence logic for GWMS.
 Requires: condor >= 8.4.0
 Requires: python-rrdtool
@@ -1334,4 +1334,3 @@ rm -rf $RPM_BUILD_ROOT
   configuration variables.
 - Removed the rm's to delete the frontend-temp and log directories at uninstall,
   they removed files when updating, not wanted.  Let RPM handle those.
-


### PR DESCRIPTION
This pull request breaks the `vofrontend-standalone` subpackage into three packages:
1. vofrontend-core: For the python files
1. vofrontend-httpd: For the apache related configuration and requirements.
1. vofrontend-standalone: A meta package that requires: vofrontend-core and vofrontend-httpd

This is to natively break down the frontend system into miniservice for containerization.