### PR TITLE
fix replace_range function to allow hyphens in the hostname

### DIFF
--- a/creation/web_base/collector_setup.sh
+++ b/creation/web_base/collector_setup.sh
@@ -29,7 +29,7 @@ function replace_range {
     # that can contain a port range or a range in the sock names
     # The output replaces ranges N1-N2 with $RANDOM_INTEGER(N1,N2)
     # The Frontend is verifying the correctnes when checking the configuration
-    echo "$(echo "$1" | sed -E 's;^([^?:]+):([0-9]+)-([0-9]+);\1:\$RANDOM_INTEGER(\2,\3);;s;^([^?\-]+)\?(.*&)*sock=([^&\-]*[^0-9&]+)([0-9]+)-([0-9]+)(&.*)*$;\1?\2sock=\3\$RANDOM_INTEGER(\4,\5)\6;')"
+    echo "$(echo "$1" | sed -E 's;^([^?:]+):([0-9]+)-([0-9]+);\1:\$RANDOM_INTEGER(\2,\3);;s;^([^?]+)\?(.*&)*sock=([^&\-]*[^0-9&]+)([0-9]+)-([0-9]+)(&.*)*$;\1?\2sock=\3\$RANDOM_INTEGER(\4,\5)\6;')"
 }
 
 function select_collector {


### PR DESCRIPTION
This change fixes the problem of getting an incorrect GLIDEIN_Collector string when shared port format is used and the hostname includes hyphens, e.g., htcondor-ucsd.osgdev.chtc.io:9618?sock=collector9620-9622

