### PR TITLE
Call 'od' to limit data from /dev/urandom

### DIFF
--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -885,7 +885,7 @@ dir_id() {
 if command -v uuidgen >/dev/null 2>&1; then
     glidein_uuid="$(uuidgen)"
 else
-    glidein_uuid="$(od -x /dev/urandom | head -1 | awk '{OFS="-"; print $2$3,$4,$5,$6,$7$8$9}')"
+    glidein_uuid="$(od -x -w32 -N32 /dev/urandom | awk 'NR==1{OFS="-"; print $2$3,$4,$5,$6,$7$8$9}')"
 fi
 
 startup_time="$(date +%s)"


### PR DESCRIPTION
@mambelli This *may* fix an issue we're seeing on Ubuntu 20 worker nodes where glideins appear to be stuck indefinitely in startup. On closer inspection, I saw the following:

```
condor     220    25  0 Feb09 ?        00:00:06 condor_starter -f -local-name slot_type_1
nobody     222   220  0 Feb09 ?        00:00:00 /bin/bash /var/lib/condor/execute/dir_220
nobody     257   222  0 Feb09 ?        00:00:00 /bin/bash /var/lib/condor/execute/dir_220
nobody     258   257 99 Feb09 ?        1-05:06:38 od -x /dev/urandom
```

I'll ask Edita to apply the patch to see if it fixes things. I tested the `od` flags on CentOS 7/8 and Ubuntu bionic/focal