### PR TITLE
Don't set LD_LIBRARY_PATH in condor_startup.sh for job or daemons

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -150,11 +150,6 @@ echo "USER_JOB_WRAPPER = \$(LOCAL_DIR)/$condor_job_wrapper" >> "$CONDOR_CONFIG"
 # glidein_variables = list of additional variables startd is to publish
 glidein_variables=""
 
-# job_env = environment to pass to the job
-# Make sure we do not leak LD_LIBRARY_PATH to the job incorrectly
-job_env="LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-
-
 #
 # Set a variable read from a file
 #
@@ -985,9 +980,6 @@ if [ "$print_debug" -ne "0" ]; then
   echo 1>&2
   #env 1>&2
 fi
-
-#Set the LD_LIBRARY_PATH so condor uses dynamically linked libraries correctly
-export LD_LIBRARY_PATH=$CONDOR_DIR/lib:$CONDOR_DIR/lib/condor:$LD_LIBRARY_PATH
 
 #
 # The config is complete at this point


### PR DESCRIPTION
The HTCondor binaries set RUNPATH in the elf header to point to a path, relative to the binaries, where their shared libraries live.  As such, we don't need to set LD_LIBRARY_PATH for the daemons.  (Aside, as the condor_startup.sh is today, it sets LD_LIBRARY_PATH to a directory where the shared libraries haven't existed for many HTCondor releases). More importantly, we really don't want to set LD_LIBRARY_PATH in the STARTER_JOB_ENVIRONMENT condor config setting, which passes that environment variable along to the job.  This is breaking LIGO singularity jobs because the STARTER_JOB_ENVIRONMENT's LD_LIBRARY_PATH is overriding the container's LD_LIBRARY_PATH, and the latter is the one we want.