### PR TITLE
Bump VOMS proxy key bitsize to 2048

### DIFF
--- a/creation/templates/proxies.ini
+++ b/creation/templates/proxies.ini
@@ -48,14 +48,14 @@ proxy_key = /etc/grid-security/gwms-frontend/pilotkey.pem
 #     path to the certificate used to sign the proxy's VOMS attributes
 # vo_key (required if use_voms_server = false):
 #     path to the key used to sign the proxy's VOMS attributes
-# bits (The strenght in bits of the generated proxy. default: 1024)
+# bits (The strenght in bits of the generated proxy. default: 2048)
 
 vo = osg
 # use_voms_server = false
 vo_cert = /etc/grid-security/voms/vomscert.pem
 vo_key = /etc/grid-security/voms/vomskey.pem
 # fqan = /osg/Role=NULL/Capability=NULL
-# bits = 1024
+# bits = 2048
 
 # Path to the output proxy
 # This should match the path specified in frontend.xml

--- a/frontend/gwms_renew_proxies.py
+++ b/frontend/gwms_renew_proxies.py
@@ -24,7 +24,7 @@ DEFAULTS = {'use_voms_server': 'false',
             'lifetime': '24',
             'path_length': '20',
             'rfc': 'true',
-            'bits': '1024',
+            'bits': '2048',
             'owner': 'frontend'}
 
 
@@ -37,7 +37,7 @@ class ConfigError(BaseException):
 class Proxy(object):
     """Class for holding information related to the proxy
     """
-    def __init__(self, cert, key, output, lifetime, uid=0, gid=0, rfc=True, pathlength='20', bits='1024'):
+    def __init__(self, cert, key, output, lifetime, uid=0, gid=0, rfc=True, pathlength='20', bits='2048'):
         self.cert = cert
         self.key = key
         self.tmp_output_fd = tempfile.NamedTemporaryFile(dir=os.path.dirname(output), delete=False)


### PR DESCRIPTION
Many places require bits > 1024 resulting in opaque errors that can be
hard to troubleshoot