### PR TITLE
Improved fe logging

### DIFF
--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -889,7 +889,7 @@ class glideinFrontendElement:
 
                 if os.path.exists(scitoken_fullpath):
                     try:
-                        logSupport.log.info("found scitoken %s" % scitoken_fullpath)
+                        logSupport.log.debug("found scitoken %s" % scitoken_fullpath)
                         with open(scitoken_fullpath) as fbuf:
                             for line in fbuf:
                                 stkn += line
@@ -904,7 +904,7 @@ class glideinFrontendElement:
                         logSupport.log.exception("failed to read scitoken: %s" % err)
 
                 # now advertise
-                logSupport.log.info("advertising tokens %s" % gp_encrypt.keys())
+                logSupport.log.debug("advertising tokens %s" % gp_encrypt.keys())
                 advertizer.add(
                     factory_pool_node,
                     request_name,
@@ -1051,7 +1051,7 @@ class glideinFrontendElement:
                     os.close(fd)
                     shutil.move(tmpnm, tkn_file)
                     chmod(tkn_file, 0o600)
-                    logSupport.log.info("created token %s" % tkn_file)
+                    logSupport.log.debug("created token %s" % tkn_file)
                 elif os.path.exists(tkn_file):
                     with open(tkn_file) as fbuf:
                         for line in fbuf:

--- a/frontend/glideinFrontendLib.py
+++ b/frontend/glideinFrontendLib.py
@@ -1203,8 +1203,13 @@ def getCondorQConstrained(schedd_names, type_constraint, constraint=None, format
             logSupport.log.exception("Condor Error. Failed to talk to schedd: ")
             # If schedd not found it is equivalent to no jobs in the queue
             continue
-        except RuntimeError:
-            logSupport.log.exception("Runtime Error. Failed to talk to schedd %s" % schedd)
+        except RuntimeError as e:
+            # schedd not found is common (for example, flocking host with 0 jobs)
+            # we do not need lots of stack traces in the logs for those
+            if "not found" in str(e):
+                logSupport.log.error("Failed to talk to schedd %s - not found" % schedd)
+            else:
+                logSupport.log.exception("Runtime Error. Failed to talk to schedd %s" % schedd)
             continue
         except Exception:
             logSupport.log.exception("Unknown Exception. Failed to talk to schedd %s" % schedd)


### PR DESCRIPTION
Token logging was moved from info to debug. When logging to info in that loop, it breaks the fe overview table. Also remove the stacktrace logging when a schedd is not found - this is very common when schedds are flocking to the pool and have 0 jobs in the queue, so cleaning this up saves a lot of noise in the logs.