### PR TITLE
Downgrade pyupgrade version on pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - "prettier"
           - "prettier-plugin-toml@0.3.1"
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: v2.31.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args:


### PR DESCRIPTION
Starting from version v2.31.1, `pyupgrade` requires Python 3.7, which breaks `pre-commit` for older python versions.