### PR TITLE
Add dynamic creation of distribution, refactor and include documentation for on demand CVMFS feature 

### DIFF
--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -498,6 +498,8 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.post
 install -m 0644 %{SOURCE4} $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/glideinWMS.xml
 install -m 0644 %{SOURCE9} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/gwms-factory
+install -m 0644 creation/web-base/generate_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
+rm -f creation/web-base/generate_cvmfsexec_distros.sh
 
 # Install the web base
 cp -r creation/web_base/* $RPM_BUILD_ROOT%{web_base}/
@@ -873,6 +875,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.post
 %attr(-, gfactory, gfactory) %config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/gwms-factory/glideinWMS.xml
+%attr(-, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-factory
 
 %files vofrontend-core

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -498,8 +498,9 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.post
 install -m 0644 %{SOURCE4} $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/glideinWMS.xml
 install -m 0644 %{SOURCE9} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/gwms-factory
-install -m 0644 creation/web-base/generate_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
-rm -f creation/web-base/generate_cvmfsexec_distros.sh
+install -m 0755 creation/create_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/create_cvmfsexec_distros.sh
+# remove the file from python_sitelib as it is put elsewhere; similar to clone_glidein and info_glidein files
+rm -f $RPM_BUILD_ROOT%{python_sitelib}/glideinwms/creation/create_cvmfsexec_distros.sh
 
 # Install the web base
 cp -r creation/web_base/* $RPM_BUILD_ROOT%{web_base}/
@@ -875,7 +876,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.post
 %attr(-, gfactory, gfactory) %config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/gwms-factory/glideinWMS.xml
-%attr(-, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
+%attr(755, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/create_cvmfsexec_distros.sh
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-factory
 
 %files vofrontend-core

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -32,17 +32,18 @@ if [[ -d $cvmfsexec_temp ]]; then
         latest_ver=`$cvmfsexec_latest/cvmfsexec -v`
         if [[ $curr_ver != $latest_ver ]]; then
             # if current version and latest version are different, use the latest
+            echo "Current version of cvmfsexec: $curr_ver"
             echo "Found newer version of cvmfsexec..."
             rm -rf $cvmfsexec_base
             mv $cvmfsexec_latest $cvmfsexec_base
-            echo "Current version of cvmfsexec: $curr_ver"
             echo "Latest version of cvmfsexec: `$cvmfsexec_base/cvmfsexec -v`"
             echo "Using cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
         else
             # if current version and latest version are the same
-            echo "Current version and latest version are identical!"
+            echo "Current version and latest version of cvmfsexec are identical!"
             echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
             rm -rf $cvmfsexec_latest
+            exit 0
         fi
     else
         # $cvmfsexec_base does not exist
@@ -82,7 +83,6 @@ do
            $cvmfsexec_base/makedist -o $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
            if [[ -e $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} ]]; then
                echo " Success"
-               #echo ""
                tar -cvzf $cvmfsexec_tarballs/cvmfsexec_${cvmfs_src}_${os}_${arch}.tar.gz -C $cvmfsexec_distros cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
            fi
         else
@@ -92,9 +92,6 @@ do
         # delete the dist directory within cvmfsexec to download the cvmfs configuration
         # and repositories for another machine type
         rm -rf $cvmfsexec_base/dist
-        #echo ""
-        #echo ""
-        #echo ""
     done
 done
 

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -101,4 +101,4 @@ done
 end=`date +%s`
 
 runtime=$((end-start))
-echo "Took $runtime seconds (the two for-loops)"
+echo "Took $runtime seconds to create the cvmfsexec distributions"

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -17,11 +17,11 @@ CVMFS_SOURCES=osg:egi:default
 # egi for rhel8-x86_64 results in an error - egi does not yet have a centos8 build (as confirmed with Dave)
 # TODO: verify the logic when egi provides a centos8 build
 SUPPORTED_TYPES=rhel7-x86_64:rhel8-x86_64:suse15-x86_64
-cvmfsexec_temp=/tmp/cvmfsexec_pkg
+cvmfsexec_temp=$(mktemp -d -t cvmfsexec.XXX)
 cvmfsexec_base=$cvmfsexec_temp/cvmfsexec
 cvmfsexec_latest=$cvmfsexec_temp/latest
 cvmfsexec_distros=$cvmfsexec_temp/distros
-work_dir=/var/lib/gwms-factory/work-dir
+work_dir=$(grep -m 1 "submit" /etc/gwms-factory/glideinWMS.xml | awk -F"\"" '{print $6}')
 cvmfsexec_tarballs=$work_dir/cvmfsexec/tarballs
 
 if [[ -d $cvmfsexec_temp ]]; then

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+	echo "This script is used to generate cvmfsexec distributions for all"
+	echo "supported machine types (platform- and architecture-based)."
+	echo "The script takes one parameter {osg|egi|default} which specifies"
+	echo "the source to download the latest cvmfs configuration and repositories."
+}
+
+start=`date +%s`
+
+CVMFS_SOURCES=osg:egi:default
+# rhel6-x86_64 is not included; currently not supported due to EOL
+# egi for rhel8-x86_64 results in an error - egi does not yet have a centos8 build (as confirmed with Dave)
+# TODO: verify the logic when egi provides a centos8 build
+SUPPORTED_TYPES=rhel7-x86_64:rhel8-x86_64:suse15-x86_64
+cvmfsexec_temp=/tmp/cvmfsexec_pkg
+cvmfsexec_base=$cvmfsexec_temp/cvmfsexec
+cvmfsexec_latest=$cvmfsexec_temp/latest
+cvmfsexec_distros=$cvmfsexec_temp/distros
+work_dir=/var/lib/gwms-factory/work-dir
+cvmfsexec_tarballs=$work_dir/cvmfsexec/tarballs
+
+if [[ -d $cvmfsexec_temp ]]; then
+#    rm -rf $cvmfsexec_pkg
+    if [[ -d $cvmfsexec_base ]]; then
+        curr_ver=`$cvmfsexec_base/cvmfsexec -v`
+        git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_latest &> /dev/null
+        latest_ver=`$cvmfsexec_latest/cvmfsexec -v`
+        if [[ $curr_ver != $latest_ver ]]; then
+            # if current version and latest version are different, use the latest
+            echo "Found newer version of cvmfsexec..."
+            rm -rf $cvmfsexec_base
+            mv $cvmfsexec_latest $cvmfsexec_base
+            echo "Current version of cvmfsexec: $curr_ver"
+            echo "Latest version of cvmfsexec: `$cvmfsexec_base/cvmfsexec -v`"
+            echo "Using cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+        else
+            # if current version and latest version are the same
+            echo "Current version and latest version are identical!"
+            echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+            rm -rf $cvmfsexec_latest
+        fi
+    else
+        # $cvmfsexec_base does not exist
+        git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_base &> /dev/null
+        echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+    fi
+else
+    # $cvmfsexec_temp does not exist
+    git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_base &> /dev/null
+    echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+
+fi
+
+if [[ ! -d $cvmfsexec_distros ]]; then
+    mkdir -p $cvmfsexec_distros
+fi
+
+if [[ ! -d $cvmfsexec_tarballs ]]; then
+    mkdir -p $cvmfsexec_tarballs
+fi
+
+declare -a cvmfs_sources
+cvmfs_sources=($(echo $CVMFS_SOURCES | tr ":" "\n"))
+
+declare -a machine_types
+machine_types=($(echo $SUPPORTED_TYPES | tr ":" "\n"))
+
+for cvmfs_src in "${cvmfs_sources[@]}"
+do
+    for mach_type in "${machine_types[@]}"
+    do
+        echo -n "Making $cvmfs_src distribution for $mach_type machine..."
+        os=`echo $mach_type | awk -F'-' '{print $1}'`
+        arch=`echo $mach_type | awk -F'-' '{print $2}'`
+        $cvmfsexec_base/makedist -m $mach_type $cvmfs_src &> /dev/null
+        if [[ $? -eq 0 ]]; then
+           $cvmfsexec_base/makedist -o $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
+           if [[ -e $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} ]]; then
+               echo " Success"
+               #echo ""
+               tar -cvzf $cvmfsexec_tarballs/cvmfsexec_${cvmfs_src}_${os}_${arch}.tar.gz -C $cvmfsexec_distros cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
+           fi
+        else
+            echo " Failed! REASON: $cvmfs_src may not yet have a $mach_type build."
+        fi
+
+        # delete the dist directory within cvmfsexec to download the cvmfs configuration
+        # and repositories for another machine type
+        rm -rf $cvmfsexec_base/dist
+        #echo ""
+        #echo ""
+        #echo ""
+    done
+done
+
+# TODO: store version information in the $cvmfsexec_tarballs location for future reconfig/upgrade
+#echo "$curr_ver" > $cvmfsexec_tarballs/.version_info
+
+end=`date +%s`
+
+runtime=$((end-start))
+echo "Took $runtime seconds (the two for-loops)"

--- a/creation/lib/cgWConsts.py
+++ b/creation/lib/cgWConsts.py
@@ -27,6 +27,11 @@ CONDOR_ATTR = "CONDOR_DIR"
 
 CONDOR_STARTUP_FILE = "condor_startup.sh"
 
+# constants for cvmfsexec
+CVMFSEXEC_DISTRO_FILE = "cvmfsexec_dist_%s.tgz"
+CVMFSEXEC_DIR = "cvmfsexec"
+CVMFSEXEC_ATTR = "CVMFSEXEC_DIR"
+
 
 # these are in the submit dir, so they can be changed
 PARAMS_FILE = "params.cfg"

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -320,28 +320,32 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
         # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
-        for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
-            distro_info = distros[cvmfsexec_idx].split("_")
-            distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
-            # register the tarball, but make download conditional to cond_name
-            cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
+        if len(distros) == 0:
+            print("distributions for cvmfsexec not found... Skipping tarball creation.")
+        else:
+            for cvmfsexec_idx in range(len(distros)):
+                distro_info = distros[cvmfsexec_idx].split("_")
+                print(distro_info)
+                distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
+                # register the tarball, but make download conditional to cond_name
+                cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
 
-            platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
-            cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
-            cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
+                platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
+                cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
+                cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
 
-            self.dicts["file_list"].add_from_file(
-                cvmfsexec_platform_fname,
-                cWDictFile.FileDictFile.make_val_tuple(
-                    cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
-                ),
-                os.path.join(distros_loc, distros[cvmfsexec_idx]),
-            )
+                self.dicts["file_list"].add_from_file(
+                    cvmfsexec_platform_fname,
+                    cWDictFile.FileDictFile.make_val_tuple(
+                        cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
+                    ),
+                    os.path.join(distros_loc, distros[cvmfsexec_idx]),
+                )
 
-            self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
-            # Add cond_name in the config, so that it is known
-            # But leave it disabled by default
-            self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
+                self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
+                # Add cond_name in the config, so that it is known
+                # But leave it disabled by default
+                self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
         # end of "Add cvmfsexec" block
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -311,7 +311,9 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         dist_select_script = "cvmfsexec_platform_select.sh"
         self.dicts["file_list"].add_from_file(
             dist_select_script,
-            cWDictFile.FileDictFile.make_val_tuple(cWConsts.insert_timestr(dist_select_script), "exec"),
+            cWDictFile.FileDictFile.make_val_tuple(
+                cWConsts.insert_timestr(dist_select_script), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
+            ),
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )
 

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -317,7 +317,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         )
 
         # get the location of the tarballs created during reconfig/upgrade
-        distros_loc = os.path.abspath("/tmp/cvmfsexec_pkg/tarballs")
+        distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
+        # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
         for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
             distro_info = distros[cvmfsexec_idx].split("_")

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -297,15 +297,51 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["untar_cfg"].add(pychirp_tarball, "lib/python/htchirp")
 
         # Add cvmfsexec
-        cvmfsexec_tarball = "cvmfs_utils.tar.gz"
+        cvmfsexec_utils = "cvmfs_utils.tar.gz"
         self.dicts["file_list"].add_from_file(
-            cvmfsexec_tarball,
+            cvmfsexec_utils,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(cvmfsexec_tarball), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(cvmfsexec_utils), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
             ),
-            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_tarball),
+            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_utils),
         )
-        self.dicts["untar_cfg"].add(cvmfsexec_tarball, "cvmfs_utils")
+        self.dicts["untar_cfg"].add(cvmfsexec_utils, "cvmfs_utils")
+
+        # adding cvmfsexec distribution tarballs to the default list of uploads
+        # NOTE: the distribution tarballs are created during factory reconfig or upgrade
+        dist_select_script = "cvmfsexec_platform_select.sh"
+        self.dicts["file_list"].add_from_file(
+            dist_select_script,
+            cWDictFile.FileDictFile.make_val_tuple(cWConsts.insert_timestr(dist_select_script), "exec"),
+            os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
+        )
+
+        # get the location of the tarballs created during reconfig/upgrade
+        distros_loc = os.path.abspath("/tmp/cvmfsexec_pkg/tarballs")
+        distros = os.listdir(distros_loc)
+        for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
+            distro_info = distros[cvmfsexec_idx].split("_")
+            distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
+            # register the tarball, but make download conditional to cond_name
+            cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
+
+            platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
+            cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
+            cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
+
+            self.dicts["file_list"].add_from_file(
+                cvmfsexec_platform_fname,
+                cWDictFile.FileDictFile.make_val_tuple(
+                    cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
+                ),
+                os.path.join(distros_loc, distros[cvmfsexec_idx]),
+            )
+
+            self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
+            # Add cond_name in the config, so that it is known
+            # But leave it disabled by default
+            self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
+        # end of "Add cvmfsexec" block
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances
         # but must be loaded early, as it also works as a reporting script in case of error

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -297,18 +297,17 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["untar_cfg"].add(pychirp_tarball, "lib/python/htchirp")
 
         # Add cvmfsexec
-        cvmfsexec_utils = "cvmfs_utils.tar.gz"
+        # Add cvmfsexec helper script enabled by conditional download
+        cvmfs_helper = "cvmfs_helper_funcs.sh"
         self.dicts["file_list"].add_from_file(
-            cvmfsexec_utils,
+            cvmfs_helper,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(cvmfsexec_utils), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(cvmfs_helper), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
             ),
-            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_utils),
+            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfs_helper),
         )
-        self.dicts["untar_cfg"].add(cvmfsexec_utils, "cvmfs_utils")
 
-        # adding cvmfsexec distribution tarballs to the default list of uploads
-        # NOTE: the distribution tarballs are created during factory reconfig or upgrade
+        ### for dynamic selection of cvmfsexec distribution -- block start
         dist_select_script = "cvmfsexec_platform_select.sh"
         self.dicts["file_list"].add_from_file(
             dist_select_script,
@@ -316,16 +315,17 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )
 
+        # TODO: update the following line to use the temporary location of the tarballs
+        # TODO: currently uses the 'cvmfsexec' dir inside creation/web-base
+        # TODO: the 'cvmfsexec' dir has all the tarballs created as a result of running 'generate_cvmfsexec_distros.sh'
         # get the location of the tarballs created during reconfig/upgrade
         distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
-        # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
         if len(distros) == 0:
-            print("distributions for cvmfsexec not found... Skipping tarball creation.")
+            print("Distributions for cvmfsexec not found... Skipping tarball creation.")
         else:
-            for cvmfsexec_idx in range(len(distros)):
+            for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
                 distro_info = distros[cvmfsexec_idx].split("_")
-                print(distro_info)
                 distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
                 # register the tarball, but make download conditional to cond_name
                 cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
@@ -346,7 +346,7 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                 # Add cond_name in the config, so that it is known
                 # But leave it disabled by default
                 self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
-        # end of "Add cvmfsexec" block
+        ### for dynamic selection of cvmfsexec distribution -- block end
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances
         # but must be loaded early, as it also works as a reporting script in case of error

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -317,18 +317,29 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )
 
-        # TODO: update the following line to use the temporary location of the tarballs
-        # TODO: currently uses the 'cvmfsexec' dir inside creation/web-base
-        # TODO: the 'cvmfsexec' dir has all the tarballs created as a result of running 'generate_cvmfsexec_distros.sh'
         # get the location of the tarballs created during reconfig/upgrade
         distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
-        distros = os.listdir(distros_loc)
+        try:
+            distros = [
+                d for d in os.listdir(distros_loc) if d.startswith("cvmfsexec")
+            ]  # added protection with try-except here
+        except FileNotFoundError:
+            print(f"{distros_loc} does not exist.")
+        except NotADirectoryError:
+            print(f"{distros_loc} is not a directory.")
         if len(distros) == 0:
             print("Distributions for cvmfsexec not found... Skipping tarball creation.")
         else:
             for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
                 distro_info = distros[cvmfsexec_idx].split("_")
-                distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
+                try:
+                    distro_arch_temp = (
+                        distro_info[3] + "_" + distro_info[4]
+                    )  # added protection with try-except and continue if fail
+                except:
+                    print(f"Wrong subdirectory cvmfsexec/tarballs/{distro_info}")
+                    continue
+                distro_arch = distro_arch_temp.split(".")[0]
                 # register the tarball, but make download conditional to cond_name
                 cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
 

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -1,0 +1,548 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Project:
+#	GlideinWMS
+#
+#
+# Description:
+#	This script contains helper functions that support the mount/unmount of
+#	CVMFS on worker nodes.
+#
+#
+# Used by:
+#	cvmfs_setup.sh, cvmfs_unmount.sh
+#
+# Author:
+#	Namratha Urs
+#
+# Version:
+#	1.0
+#
+
+
+# to implement custom logging
+# https://stackoverflow.com/questions/42403558/how-do-i-manage-log-verbosity-inside-a-shell-script
+# WORKAROUND: redirect stdout and stderr to some file
+#LOGFILE="cvmfs_all.log"
+#exec &> $LOGFILE
+
+# fetch the error reporting helper script
+#error_gen=$(grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}')
+#echo "ERROR_GEN = $error_gen"
+
+# get the directory where cvmfsexec is unpacked
+#glidein_cvmfsexec_dir=$(grep '^CVMFSEXEC_DIR ' $glidein_config | awk '{print $2}')
+#echo "GLIDEIN_CVMFSEXEC_DIR = $glidein_cvmfsexec_dir"
+
+# get the CVMFS requirement setting passed as one of the factory attributes
+#glidein_cvmfs=$(grep '^GLIDEIN_CVMFS ' $glidein_config | awk '{print $2}')
+# make the attribute value case insensitive
+#glidein_cvmfs=${glidein_cvmfs,,}
+# Alt this will work on older bash (like on Mac:
+# glidein_cvmfs=$(echo ${glidein_cvmfs} | tr [A-Z] [a-z])
+#echo "GLIDEIN_CVMFS = $glidein_cvmfs"
+
+# get the CVMFS source information from the factory attributes
+#cvmfs_source=$(grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}')
+# make the attribute value case insensitive
+#cvmfs_source=${cvmfs_source,,}
+#echo "CVMFS_SOURCE = $cvmfs_source"
+
+
+variables_reset() {
+	# DESCRIPTION: This function lists and initializes the common variables
+	# to empty strings. These variables also become available to scripts
+	# that import functions defined in this script.
+	#
+	# INPUT(S): None
+	# RETURN(S): Variables initialized to empty strings
+
+	# indicates whether the perform_system_check function has been run
+	GWMS_SYSTEM_CHECK=
+
+	# following set of variables used to store operating system and kernel info
+	GWMS_OS_DISTRO=
+	GWMS_OS_VERSION=
+	GWMS_OS_KRNL_ARCH=
+	GWMS_OS_KRNL_NUM=
+	GWMS_OS_KRNL_VER=
+	GWMS_OS_KRNL_MAJOR_REV=
+	GWMS_OS_KRNL_MINOR_REV=
+	GWMS_OS_KRNL_PATCH_NUM=
+
+	# indicates whether CVMFS is locally mounted on the node
+	GWMS_IS_CVMFS_MNT=
+	# to indicate the status of mounting CVMFS by the glidein after evaluating the worker node
+	GWMS_IS_CVMFS=
+
+	# indicates if unpriv userns is available (or supported); not if it is enabled
+	GWMS_IS_UNPRIV_USERNS_SUPPORTED=
+	# indicates if unpriv userns is enabled (and available)
+	GWMS_IS_UNPRIV_USERNS_ENABLED=
+
+	# following variables store FUSE-related information
+	GWMS_IS_FUSE_INSTALLED=
+	GWMS_IS_FUSERMOUNT=
+	GWMS_IS_USR_IN_FUSE_GRP=
+}
+
+
+loginfo() {
+	# DESCRIPTION: This function prints informational messages to STDOUT
+	# along with hostname and date/time.
+	#
+	# INPUT(S): String containing the message
+	# RETURN(S): Prints message to STDOUT
+
+	echo -e "$(hostname -s) $(date +%m-%d-%Y\ %T\ %Z) \t INFO: $1" >&2
+}
+
+
+logwarn(){
+	# DESCRIPTION: This function prints warning messages to STDOUT along
+	# with hostname and date/time.
+	#
+	# INPUT(S): String containing the message
+	# RETURN(S): Prints message to STDOUT
+
+	echo -e "$(hostname -s) $(date +%m-%d-%Y\ %T\ %Z) \t WARNING: $1" >&2
+}
+
+
+logerror() {
+	# DESCRIPTION: This function prints error messages to STDOUT along with
+	# hostname and date/time.
+	#
+        # INPUT(S): String containing the message
+	# RETURN(S): Prints message to STDOUT
+
+	echo -e "$(hostname -s) $(date +%m-%d-%Y\ %T\ %Z) \t ERROR: $1" >&2
+}
+
+
+check_exit_status () {
+        # DESCRIPTION: This function prints an appropriate message to the
+        # console to indicate what the exit status means.
+        #
+        # INPUT(S): Number (exit status of a previously run command)
+        # RETURN(S): Prints "yes" or "no" to indicate the result of the command
+
+	[[ $1 -eq 0 ]] && echo yes || echo no
+}
+
+detect_local_cvmfs() {
+	CVMFS_ROOT="/cvmfs"
+	repo_name=oasis.opensciencegrid.org
+	# Second check...
+	if [[ -f $CVMFS_ROOT/$repo_name/.cvmfsdirtab || "$(ls -A $CVMFS_ROOT/$repo_name)" ]] &>/dev/null
+	then
+		loginfo "Validating CVMFS with ${repo_name}..."
+		true
+	else
+		logwarn "Validating CVMFS with ${repo_name}: directory empty or does not have .cvmfsdirtab"
+		false
+	fi
+
+	GWMS_IS_CVMFS_MNT=$?
+	loginfo "CVMFS locally installed: $(check_exit_status $GWMS_IS_CVMFS_MNT)"
+}
+
+perform_system_check() {
+        # DESCRIPTION: This functions performs required system checks (such as
+        # operating system and kernel info, unprivileged user namespaces, FUSE
+        # status) and stores the results in the common variables for later use.
+        #
+        # INPUT(S): None
+        # RETURN(S):
+	# 	-> common variables containing the exit status of the
+	# 	corresponding commands
+	# 	-> results from running the check_exit_status function
+	# 	for logging purposes (variables starting with res_)
+	# 	-> assigns "yes" to GWMS_SYSTEM_CHECK to indicate this function
+	# 	has been run.
+
+	if [ -f '/etc/redhat-release' ]; then
+		GWMS_OS_DISTRO=rhel
+	else
+		GWMS_OS_DISTRO=non-rhel
+	fi
+
+	GWMS_OS_VERSION=`lsb_release -r | awk -F'\t' '{print $2}'`
+	GWMS_OS_KRNL_ARCH=`arch`
+	GWMS_OS_KRNL_NUM=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " `
+	GWMS_OS_KRNL_VER=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $1}'`
+	GWMS_OS_KRNL_MAJOR_REV=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $2}'`
+	GWMS_OS_KRNL_MINOR_REV=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $3}'`
+	GWMS_OS_KRNL_PATCH_NUM=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 2 -d " "`
+
+	#df -h | grep /cvmfs &>/dev/null
+	#GWMS_IS_CVMFS_MNT=$?
+	# call function to detect local CVMFS only if the GWMS_IS_CVMFS_MNT variable is not set; if the variable is not empty, do nothing
+	[[ -z "${GWMS_IS_CVMFS_MNT}" ]] && detect_local_cvmfs || :
+
+	sysctl user.max_user_namespaces &>/dev/null
+	GWMS_IS_UNPRIV_USERNS_SUPPORTED=$?
+
+	unshare -U true &>/dev/null
+	GWMS_IS_UNPRIV_USERNS_ENABLED=$?
+
+	yum list installed *fuse* &>/dev/null
+	GWMS_IS_FUSE_INSTALLED=$?
+
+	fusermount -V &>/dev/null
+        GWMS_IS_FUSERMOUNT=$?
+
+	getent group fuse | grep $USER &>/dev/null
+	GWMS_IS_USR_IN_FUSE_GRP=$?
+
+	# set the variable indicating this function has been run
+	GWMS_SYSTEM_CHECK=yes
+
+}
+
+
+print_os_info () {
+        # DESCRIPTION: This functions prints operating system and kernel
+        # information to STDOUT.
+        #
+        # INPUT(S): None
+        # RETURN(S): Prints a message containing OS and kernel details
+
+        loginfo "Found $GWMS_OS_DISTRO${GWMS_OS_VERSION}-${GWMS_OS_KRNL_ARCH} with kernel $GWMS_OS_KRNL_NUM-$GWMS_OS_KRNL_PATCH_NUM"
+}
+
+
+log_all_system_info () {
+        # DESCRIPTION: This function prints all the necessary system information
+        # stored in common and result variables (see perform_system_check
+        # function) for easy debugging. This has been done as collecting
+        # information about the worker node can be useful for troubleshooting
+        # and gathering stats about what is out there.
+        #
+        # INPUT(S): None
+        # RETURN(S): Prints user-friendly messages to STDOUT
+
+	loginfo "..."
+	loginfo "Worker node details: "
+	loginfo "Operating system distro: $GWMS_OS_DISTRO"
+	loginfo "Operating System version: $GWMS_OS_VERSION"
+	loginfo "Kernel Architecture: $GWMS_OS_KRNL_ARCH"
+	loginfo "Kernel version: $GWMS_OS_KRNL_VER"
+	loginfo "Kernel major revision: $GWMS_OS_KRNL_MAJOR_REV"
+	loginfo "Kernel minor revision: $GWMS_OS_KRNL_MINOR_REV"
+	loginfo "Kernel patch number: $GWMS_OS_KRNL_PATCH_NUM"
+
+	loginfo "CVMFS locally installed: $(check_exit_status $GWMS_IS_CVMFS_MNT)"
+	loginfo "Unprivileged user namespaces supported: $(check_exit_status $GWMS_IS_UNPRIV_USERNS_SUPPORTED)"
+	loginfo "Unprivileged user namespaces enabled: $(check_exit_status $GWMS_IS_UNPRIV_USERNS_ENABLED)"
+	loginfo "FUSE installed: $(check_exit_status $GWMS_IS_FUSE_INSTALLED)"
+	loginfo "fusermount available: $(check_exit_status $GWMS_IS_FUSERMOUNT)"
+	loginfo "Is the user in 'fuse' group: $(check_exit_status $GWMS_IS_USR_IN_FUSE_GRP)"
+	loginfo "..."
+}
+
+
+mount_cvmfs_repos () {
+        # DESCRIPTION: This function mounts all the required and additional
+        # CVMFS repositories that would be needed for user jobs.
+        #
+        # INPUT(S): 1. CVMFS configuration repository (string); 2. Additional CVMFS
+        # repositories (colon-delimited string)
+        # RETURN(S): Mounts the defined repositories on the worker node filesystem
+
+	# QUESTION FOR MARCO
+	# see if the utilities are available (in the hidden directory) from the previous mount activity on the worker node
+	# this is not possible since this script is run once at the time of glidein creation on the worker node - is that right???
+	#if [[ ! -d $cvmfs_utils_dir/.cvmfsexec ]]; then
+	#	$cvmfs_utils_dir/mycvmfsexec -- echo "CVMFS utilities available" &> /dev/null
+	#	echo "executing inside"
+	#fi
+
+	#$cvmfs_utils_dir/mycvmfsexec $1 -- echo "setting up mount utilities..." &> /dev/null
+	#echo "glidein_cvmfsexec_dir set to $glidein_cvmfsexec_dir"
+	$glidein_cvmfsexec_dir/$dist_file $1 -- echo "setting up mount utilities..." &> /dev/null
+	if [[ $(df -h|grep /cvmfs|wc -l) -eq 1 ]]; then
+		loginfo "CVMFS config repo already mounted!"
+		continue
+	else
+		# mounting the configuration repo (pre-requisite)
+		loginfo "Mounting CVMFS config repo now..."
+		$glidein_cvmfsexec_dir/.cvmfsexec/mountrepo $1
+		#.cvmfsexec/mountrepo $1
+	fi
+
+	# using an array to unpack the names of additional CVMFS repositories
+	# from the colon-delimited string
+	declare -a cvmfs_repos
+	repos=($(echo $2 | tr ":" "\n"))
+	#echo ${repos[@]}
+
+	loginfo "Mounting additional CVMFS repositories..."
+	# mount every repository that was previously unpacked
+	for repo in "${repos[@]}"
+	do
+		$glidein_cvmfsexec_dir/.cvmfsexec/mountrepo $repo
+	#	.cvmfsexec/mountrepo $repo
+	done
+
+	# see if all the repositories got mounted
+	num_repos_mntd=`df -h | grep /cvmfs | wc -l`
+	total_num_repos=$(( ${#repos[@]} + 1 ))
+	if [ "$num_repos_mntd" -eq "$total_num_repos" ]; then
+	#if [ "$num_repos_mntd" -eq 2 ]; then
+		loginfo "All CVMFS repositories mounted successfully on the worker node"
+		true
+	else
+		logwarn "One or more CVMFS repositories might not be mounted on the worker node"
+		false
+	fi
+
+	GWMS_IS_CVMFS=$?
+}
+
+
+has_unpriv_userns() {
+        # DESCRIPTION: This function checks the status of unprivileged user
+        # namespaces being supported and enabled on the worker node. Depending
+        #
+        # INPUT(S): None
+        # RETURN(S):
+	#	-> true (0) if unpriv userns can be used (supported and enabled),
+	#	false otherwise
+	#	-> status of unpriv userns (unavailable, disabled, enabled,
+	#	error) to stdout
+
+	# make sure that perform_system_check has run
+	[[ -z "${GWMS_SYSTEM_CHECK}" ]] && perform_system_check
+
+	# determine whether unprivileged user namespaces are supported and/or enabled...
+	if [[ "${GWMS_IS_UNPRIV_USERNS_ENABLED}" -eq 0 ]]; then
+		# unprivileged user namespaces is enabled
+		if [[ "${GWMS_IS_UNPRIV_USERNS_SUPPORTED}" -eq 0 ]]; then
+			# unprivileged user namespaces is supported
+			loginfo "Unprivileged user namespaces supported and enabled"
+			echo enabled
+		else
+			# unprivileged user namespaces is not supported
+			logerror "Inconsistent system configuration: unprivileged userns is enabled but not supported"
+        		echo error
+		fi
+		true
+	else
+		# unprivileged user namespaces is disabled
+		if [[ "${GWMS_IS_UNPRIV_USERNS_SUPPORTED}" -eq 0 ]]; then
+			# unprivileged user namespaces is supported
+			logwarn "Unprivileged user namespaces disabled: can be enabled by the root user via sysctl"
+			echo disabled
+		else
+			# unprivileged user namespaces is not supported
+			logwarn "Unprivileged user namespaces disabled and unsupported: can be supported/enabled only after a system upgrade"
+			echo unavailable
+		fi
+		false
+	fi
+
+}
+
+
+has_fuse() {
+        # DESCRIPTION: This function checks FUSE-related configurations on the
+        # worker node. This is a pre-requisite before evaluating whether CVMFS
+        # is mounted on the filesystem.
+        #
+        # FUSE Documentation references:
+	# https://www.kernel.org/doc/html/latest/filesystems/fuse.html
+        # https://en.wikipedia.org/wiki/Filesystem_in_Userspace
+        #
+        # INPUT(S): None
+        # RETURN(S): string denoting fuse availability (yes, no, error)
+
+	# make sure that perform_system_check has run
+	[[ -n "${GWMS_SYSTEM_CHECK}" ]] && perform_system_check
+
+	#GWMS_IS_FUSERMOUNT=0
+	#res_is_fusermount=$(check_exit_status $GWMS_IS_FUSERMOUNT)
+	#loginfo "fusermount available: $res_is_fusermount"
+
+	# check what specific configuration of unprivileged user namespaces exists in the system (worker node)
+	unpriv_userns_config=$(has_unpriv_userns)
+
+	# exit from the script if unprivileged namespaces are not supported but enabled in the kernel
+	if [[ "${unpriv_userns_config}" == error ]]; then
+		"$error_gen" -error "`basename $0`" "WN_Resource" "Unprivileged user namespaces are not supported but enabled in the kernel! Check system configuration."
+		exit 1
+	# determine if mountrepo/umountrepo could be used by checking availability of fuse, fusermount and user being in fuse group...
+	elif [[ "${GWMS_IS_FUSE_INSTALLED}" -eq 0 ]]; then
+		# fuse is installed
+		if [[ $unpriv_userns_config == unavailable ]]; then
+			# unprivileged user namespaces unsupported, i.e. kernels 2.x (scenarios 5b,6b)
+			if [[ "${GWMS_IS_USR_IN_FUSE_GRP}" -eq 0 ]]; then
+				# user is in fuse group -> fusermount is available (scenario 6b)
+                                if [[ "${GWMS_IS_FUSERMOUNT}" -ne 0 ]]; then
+                                        logwarn "Inconsistent system configuration: fusermount is available with fuse installed and when user is in fuse group"
+                                        echo error
+                                else
+                                        loginfo "FUSE requirements met by the worker node"
+                                        echo yes
+                                fi
+                        else
+                                # user is not in fuse group -> fusermount is unavailable (scenario 5b)
+				if [[ "${GWMS_IS_FUSERMOUNT}" -eq 0 ]]; then
+                                        logwarn "Inconsistent system configuration: fusermount is available only when user is in fuse group and fuse is installed"
+                                        echo error
+                                else
+                                        loginfo "FUSE requirements not satisfied: user is not in fuse group"
+                                        echo no
+                                fi
+			fi
+		else
+			# unprivileged user namespaces is either enabled or disabled
+			if [[ "${GWMS_IS_FUSERMOUNT}" -eq 0 ]]; then
+				# fusermount is available (scenarios 7,8)
+				loginfo "FUSE requirements met by the worker node"
+				echo yes
+			else
+				# fusermount is not available (scenarios 5a,6a)
+				logwarn "Inconsistent system configuration: fusermount is available when fuse is installed "
+				echo error
+			fi
+		fi
+	else
+		# fuse is not installed
+		if [[ "${GWMS_IS_FUSERMOUNT}" -eq 0 ]]; then
+			# fusermount is somehow available and user is/is not in fuse group (scenarios 3,4)
+			logwarn "Inconsistent system configuration: fusermount is only available with fuse and/or when user belongs to the fuse group"
+			echo error
+		else
+			# fusermount is not available and user is/is not in fuse group (scenarios case 1,2)
+			loginfo "FUSE requirements not satisfied: fusermount is not available"
+			echo no
+		fi
+	fi
+
+}
+
+
+evaluate_worker_node_config () {
+        # DESCRIPTION: This function evaluates the worker using FUSE and
+        # unpriv. userns configurations to determine whether CVMFS can be
+        # mounted using mountrepo utility.
+        #
+        # INPUT(S): None
+        # RETURN(S): string message whether CVMFS can be mounted
+
+	# collect info about FUSE configuration on the worker node
+	fuse_config_status=$(has_fuse)
+
+	# check fuse related configurations in the system (worker node)
+	if [[ $fuse_config_status == yes ]]; then
+		# success;
+		loginfo "CVMFS can be mounted and unmounted on the worker node using mountrepo/umountrepo utility"
+		true
+	elif [[ $fuse_config_status == no ]]; then
+		# failure;
+		logerror "CVMFS cannot be mounted on the worker node using mountrepo utility"
+		false
+	elif [[ $fuse_config_status == error ]]; then
+		# inconsistent system configurations detected in the worker node
+		logerror "Detected inconsistent configurations on the worker node. mountrepo utility cannot be used!!"
+		false
+	fi
+
+}
+
+
+perform_cvmfs_mount () {
+        # reset all variables used in this script's namespace before executing the rest of the script
+        variables_reset
+
+        # perform checks on the worker node that will be used to assess whether CVMFS can be mounted or not
+        perform_system_check
+
+        #loginfo "Start log for mounting CVMFS"
+
+        # print/display all information pertaining to system checks performed previously (facilitates easy troubleshooting)
+        log_all_system_info
+
+        #cvmfs_source=osg
+        loginfo "CVMFS Source = $cvmfs_source"
+        # initializing CVMFS repositories to a variable for easy modification in the future
+        case $cvmfs_source in
+            osg)
+                GLIDEIN_CVMFS_CONFIG_REPO=config-osg.opensciencegrid.org
+                GLIDEIN_CVMFS_REPOS=singularity.opensciencegrid.org:cms.cern.ch
+                ;;
+            egi)
+                GLIDEIN_CVMFS_CONFIG_REPO=config-egi.egi.eu
+                GLIDEIN_CVMFS_REPOS=config-osg.opensciencegrid.org:singularity.opensciencegrid.org:cms.cern.ch
+                ;;
+            default)
+                GLIDEIN_CVMFS_CONFIG_REPO=cvmfs-config.cern.ch
+                GLIDEIN_CVMFS_REPOS=config-osg.opensciencegrid.org:singularity.opensciencegrid.org:cms.cern.ch
+                ;;
+            *)
+                "$error_gen" -error "`basename $0`" "WN_Resource" "Invalid factory attribute value specified for CVMFS source."
+                exit 1
+        esac
+        # (optional) set an environment variable that suggests additional repos to be mounted after config repos are mounted
+        loginfo "CVMFS Config Repo = $GLIDEIN_CVMFS_CONFIG_REPO"
+
+        # by this point, it would have been established that CVMFS is not locally available
+        # so, install CVMFS via mountrepo or cvmfsexec
+        loginfo "CVMFS is NOT locally mounted on the worker node! Mounting now..."
+        # check the operating system distribution
+        #if [[ $GWMS_OS_DISTRO = RHEL ]]; then
+            # evaluate the worker node's system configurations to decide whether CVMFS can be mounted or not
+            loginfo "Evaluating the worker node..."
+            # display operating system information
+            print_os_info
+
+        # assess the worker node based on its existing system configurations and perform next steps accordingly
+        if evaluate_worker_node_config ; then
+            # if evaluation was true, then proceed to mount CVMFS
+            if [[ $glidein_cvmfs = never ]]; then
+                # do nothing; test the node and print the results but do not even try to mount CVMFS
+                # just continue with glidein startup
+                echo $?
+                "$error_gen" -ok "`basename $0`" "msg" "Not trying to install CVMFS."
+            else
+                loginfo "Mounting CVMFS repositories..."
+                if mount_cvmfs_repos $GLIDEIN_CVMFS_CONFIG_REPO $GLIDEIN_CVMFS_REPOS ; then
+                    :
+                else
+                    if [[ $glidein_cvmfs = required ]]; then
+                        # if mount CVMFS is not successful, report an error and exit with failure exit code
+                        echo $?
+                        "$error_gen" -error "`basename $0`" "WN_Resource" "CVMFS is required but unable to mount CVMFS on the worker node."
+                        exit 1
+                    elif [[ $glidein_cvmfs = preferred || $glidein_cvmfs = optional ]]; then
+                        # if mount CVMFS is not successful, report a warning/error in the logs and continue with glidein startup
+                        # script status must be OK, otherwise the glidein will fail
+                        echo $?
+                        "$error_gen" -ok "`basename $0`" "WN_Resource" "Unable to mount required CVMFS on the worker node. Continuing without CVMFS."
+                    else
+                        "$error_gen" -error "`basename $0`" "WN_Resource" "Invalid factory attribute value specified for CVMFS requirement."
+                        exit 1
+                    fi
+                fi
+            fi
+        else
+            # if evaluation was false, then exit from this activity of mounting CVMFS
+            "$error_gen" -error "`basename $0`" "WN_Resource" "Worker node configuration did not pass the evaluation checks. CVMFS will not be mounted."
+            exit 1
+        fi
+        #else
+        # if operating system distribution is non-RHEL (any non-rhel OS)
+        # display operating system information and a user-friendly message
+        #print_os_info
+        #logwarn "This is a non-RHEL OS and is not covered in the implementation yet!"
+        # ----- Further Implementation: TBD (To Be Done) ----- #
+        #fi
+
+        #fi
+
+        #loginfo "End log for mounting CVMFS"
+}

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -29,29 +29,6 @@
 #LOGFILE="cvmfs_all.log"
 #exec &> $LOGFILE
 
-# fetch the error reporting helper script
-#error_gen=$(grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}')
-#echo "ERROR_GEN = $error_gen"
-
-# get the directory where cvmfsexec is unpacked
-#glidein_cvmfsexec_dir=$(grep '^CVMFSEXEC_DIR ' $glidein_config | awk '{print $2}')
-#echo "GLIDEIN_CVMFSEXEC_DIR = $glidein_cvmfsexec_dir"
-
-# get the CVMFS requirement setting passed as one of the factory attributes
-#glidein_cvmfs=$(grep '^GLIDEIN_CVMFS ' $glidein_config | awk '{print $2}')
-# make the attribute value case insensitive
-#glidein_cvmfs=${glidein_cvmfs,,}
-# Alt this will work on older bash (like on Mac:
-# glidein_cvmfs=$(echo ${glidein_cvmfs} | tr [A-Z] [a-z])
-#echo "GLIDEIN_CVMFS = $glidein_cvmfs"
-
-# get the CVMFS source information from the factory attributes
-#cvmfs_source=$(grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}')
-# make the attribute value case insensitive
-#cvmfs_source=${cvmfs_source,,}
-#echo "CVMFS_SOURCE = $cvmfs_source"
-
-
 variables_reset() {
 	# DESCRIPTION: This function lists and initializes the common variables
 	# to empty strings. These variables also become available to scripts
@@ -261,8 +238,6 @@ mount_cvmfs_repos () {
 	#	echo "executing inside"
 	#fi
 
-	#$cvmfs_utils_dir/mycvmfsexec $1 -- echo "setting up mount utilities..." &> /dev/null
-	#echo "glidein_cvmfsexec_dir set to $glidein_cvmfsexec_dir"
 	$glidein_cvmfsexec_dir/$dist_file $1 -- echo "setting up mount utilities..." &> /dev/null
 	if [[ $(df -h|grep /cvmfs|wc -l) -eq 1 ]]; then
 		loginfo "CVMFS config repo already mounted!"
@@ -271,7 +246,6 @@ mount_cvmfs_repos () {
 		# mounting the configuration repo (pre-requisite)
 		loginfo "Mounting CVMFS config repo now..."
 		$glidein_cvmfsexec_dir/.cvmfsexec/mountrepo $1
-		#.cvmfsexec/mountrepo $1
 	fi
 
 	# using an array to unpack the names of additional CVMFS repositories
@@ -285,14 +259,12 @@ mount_cvmfs_repos () {
 	for repo in "${repos[@]}"
 	do
 		$glidein_cvmfsexec_dir/.cvmfsexec/mountrepo $repo
-	#	.cvmfsexec/mountrepo $repo
 	done
 
 	# see if all the repositories got mounted
 	num_repos_mntd=`df -h | grep /cvmfs | wc -l`
 	total_num_repos=$(( ${#repos[@]} + 1 ))
 	if [ "$num_repos_mntd" -eq "$total_num_repos" ]; then
-	#if [ "$num_repos_mntd" -eq 2 ]; then
 		loginfo "All CVMFS repositories mounted successfully on the worker node"
 		true
 	else
@@ -467,7 +439,6 @@ perform_cvmfs_mount () {
         # print/display all information pertaining to system checks performed previously (facilitates easy troubleshooting)
         log_all_system_info
 
-        #cvmfs_source=osg
         loginfo "CVMFS Source = $cvmfs_source"
         # initializing CVMFS repositories to a variable for easy modification in the future
         case $cvmfs_source in

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -230,14 +230,6 @@ mount_cvmfs_repos () {
         # repositories (colon-delimited string)
         # RETURN(S): Mounts the defined repositories on the worker node filesystem
 
-	# QUESTION FOR MARCO
-	# see if the utilities are available (in the hidden directory) from the previous mount activity on the worker node
-	# this is not possible since this script is run once at the time of glidein creation on the worker node - is that right???
-	#if [[ ! -d $cvmfs_utils_dir/.cvmfsexec ]]; then
-	#	$cvmfs_utils_dir/mycvmfsexec -- echo "CVMFS utilities available" &> /dev/null
-	#	echo "executing inside"
-	#fi
-
 	$glidein_cvmfsexec_dir/$dist_file $1 -- echo "setting up mount utilities..." &> /dev/null
 	if [[ $(df -h|grep /cvmfs|wc -l) -eq 1 ]]; then
 		loginfo "CVMFS config repo already mounted!"
@@ -335,10 +327,6 @@ has_fuse() {
 	# make sure that perform_system_check has run
 	[[ -n "${GWMS_SYSTEM_CHECK}" ]] && perform_system_check
 
-	#GWMS_IS_FUSERMOUNT=0
-	#res_is_fusermount=$(check_exit_status $GWMS_IS_FUSERMOUNT)
-	#loginfo "fusermount available: $res_is_fusermount"
-
 	# check what specific configuration of unprivileged user namespaces exists in the system (worker node)
 	unpriv_userns_config=$(has_unpriv_userns)
 
@@ -433,8 +421,6 @@ perform_cvmfs_mount () {
 
         # perform checks on the worker node that will be used to assess whether CVMFS can be mounted or not
         perform_system_check
-
-        #loginfo "Start log for mounting CVMFS"
 
         # print/display all information pertaining to system checks performed previously (facilitates easy troubleshooting)
         log_all_system_info

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -77,7 +77,7 @@ fi
 # TODO: Verify the findmnt ... will always find the correct CVMFS mount
 mount_point=$(findmnt -t fuse -S /dev/fuse | tail -n 1 | cut -d ' ' -f 1 )
 if [[ -n "$mount_point" && "$mount_point" != TARGET* ]]; then
-    mount_point=$(basename "$mount_point")
+    mount_point=$(dirname "$mount_point")
     if [[ -n "$mount_point" && "$mount_point" != /cvmfs ]]; then
         CVMFS_MOUNT_DIR="$mount_point"
         export CVMFS_MOUNT_DIR

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -65,7 +65,6 @@ arch=$GWMS_OS_KRNL_ARCH
 dist_file=cvmfsexec-${cvmfs_source}-${os_like}${os_ver}-${arch}
 # the appropriate distribution file does not have to manually untarred as the glidein setup takes care of this automatically
 
-# TODO: Is this file somewhere in the source tree? use: # shellcheck source=./cvmfs_mount.sh
 perform_cvmfs_mount
 
 if [[ $GWMS_IS_CVMFS -ne 0 ]]; then

--- a/creation/web_base/cvmfs_umount.sh
+++ b/creation/web_base/cvmfs_umount.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#/bin/bash
 
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
@@ -37,7 +37,6 @@ add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '
 use_cvmfsexec=$(grep '^GLIDEIN_USE_CVMFSEXEC ' $glidein_config | awk '{print $2}')
 # TODO: int or string? if string, make the attribute value case insensitive
 #use_cvmfsexec=${use_cvmfsexec,,}
-echo "GLIDEIN_USE_CVMFSEXEC attribute set to $use_cvmfsexec"
 
 if [[ $use_cvmfsexec -ne 1 ]]; then
     "$error_gen" -ok "$(basename $0)" "umnt_msg1" "Not using cvmfsexec; skipping cleanup."
@@ -46,11 +45,15 @@ fi
 
 # get the glidein work directory location from glidein_config file
 work_dir=$(grep '^GLIDEIN_WORK_DIR ' $glidein_config | awk '{print $2}')
-cvmfs_utils_dir="$work_dir"/cvmfs_utils
+#cvmfs_utils_dir="$work_dir"/cvmfs_utils
 # $PWD=/tmp/glide_xxx and every path is referenced with respect to $PWD
 # source the helper script
 # TODO: Is this file somewhere in the source tree? use: # shellcheck source=./cvmfs_helper_funcs.sh
-. "$cvmfs_utils_dir"/utils/cvmfs_helper_funcs.sh
+#. "$cvmfs_utils_dir"/utils/cvmfs_helper_funcs.sh
+. $work_dir/cvmfs_helper_funcs.sh
+
+# get the cvmfsexec directory location
+glidein_cvmfsexec_dir=$(grep '^CVMFSEXEC_DIR ' $glidein_config | awk '{print $2}')
 
 ########################################################################################################
 # Start: main program
@@ -69,8 +72,8 @@ if [[ $GWMS_IS_CVMFS_MNT -eq 0 ]]; then
     exit 0
 fi
 
-loginfo "Unmounting CVMFS (that mounted by the glidein)..."
-"$cvmfs_utils_dir"/distros/.cvmfsexec/umountrepo -a
+loginfo "Unmounting CVMFS mounted by the glidein..."
+$glidein_cvmfsexec_dir/.cvmfsexec/umountrepo -a
 
 if [[ -n "$CVMFS_MOUNT_DIR" ]]; then
     CVMFS_MOUNT_DIR=

--- a/creation/web_base/cvmfs_umount.sh
+++ b/creation/web_base/cvmfs_umount.sh
@@ -45,11 +45,10 @@ fi
 
 # get the glidein work directory location from glidein_config file
 work_dir=$(grep '^GLIDEIN_WORK_DIR ' $glidein_config | awk '{print $2}')
-#cvmfs_utils_dir="$work_dir"/cvmfs_utils
 # $PWD=/tmp/glide_xxx and every path is referenced with respect to $PWD
+
 # source the helper script
 # TODO: Is this file somewhere in the source tree? use: # shellcheck source=./cvmfs_helper_funcs.sh
-#. "$cvmfs_utils_dir"/utils/cvmfs_helper_funcs.sh
 . $work_dir/cvmfs_helper_funcs.sh
 
 # get the cvmfsexec directory location

--- a/creation/web_base/cvmfs_umount.sh
+++ b/creation/web_base/cvmfs_umount.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/creation/web_base/cvmfs_utils.tar.gz
+++ b/creation/web_base/cvmfs_utils.tar.gz
@@ -1,1 +1,0 @@
-../../bigfiles/cvmfs_utils.tar.gz

--- a/creation/web_base/cvmfsexec_platform_select.sh
+++ b/creation/web_base/cvmfsexec_platform_select.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+	echo "This script is used to generate cvmfsexec distributions for all"
+	echo "supported machine types (platform- and architecture-based)."
+	echo "The script takes one parameter {osg|egi|default} which specifies"
+	echo "the source to download the latest cvmfs configuration and repositories."
+}
+
+glidein_config=$1
+
+error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+
+# parameter is 'osg', 'egi' or 'default' to download the latest cvmfs and configuration
+# rpm from one of these three sources (Ref. https://www.github.com/cvmfs/cvmfsexec)
+cvmfs_src=`grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}'`
+cvmfs_src=${cvmfs_src,,}
+
+# check if the value of cvmfs_src is valid
+if [[ ! $cvmfs_src =~ ^(osg|egi|default)$ ]]; then
+    echo "Invalid command line argument: Must be one of {osg, egi, default}"
+    "$error_gen" -error "`basename $0`" "fail_msg" "Invalid command line argument: Must be one of {osg, egi, default}"
+    exit 1
+fi
+
+# import add_config_line function
+add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+source $add_config_line_source
+
+# TODO: is it possible to reuse cvmfs_helper_funcs.sh by sourcing it during the execution of this file????
+if [ -f '/etc/redhat-release' ]; then
+    os_distro=rhel
+else
+    os_distro=non-rhel
+fi
+
+os_ver=`lsb_release -r | awk -F'\t' '{print $2}' | awk -F"." '{print $1}'`
+krnl_arch=`arch`
+mach_type=${os_distro}${os_ver}-${krnl_arch}
+
+cvmfsexec_platform="${cvmfs_src}-${mach_type}"
+cvmfsexec_platform_id="CVMFSEXEC_PLATFORM_$cvmfsexec_platform"
+
+# add the attribute to enable the appropriate distro file
+add_config_line "$cvmfsexec_platform_id" "1"
+
+# if everything goes well, report the good part too!
+"$error_gen" -ok "`basename $0`" "Cvmfsexec_platform" "${cvmfs_src}-${mach_type}"
+
+exit 0

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2533,6 +2533,84 @@ MAX_STARTD_LOG          I       10000000        +                               
           </tr>
         </table>
       </div>
+      
+      <div class="section">
+        <h3><a name="cvmfs_vars"></a>CVMFS Variables</h3>
+        <p>
+          This section describes the variables that can be configured for 
+          use with the glidein to allow CVMFS to be provisioned on-demand. 
+          These variables are configured at the glidein level so that it 
+          applies to all the entries that are configured in the factory's 
+          configuration file.
+        </p>
+        <table class="attributes">
+          <tr class="head">
+            <td>
+              <p><b>Name</b></p>
+            </td>
+            <td>
+              <p><b>Type</b></p>
+            </td>
+            <td>
+              <p><b>Default Value</b></p>
+            </td>
+            <td>
+              <p><b>Where</b></p>
+            </td>
+            <td>
+              <p><b>Description</b></p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>GLIDEIN_USE_CVMFSEXEC</b></td>
+            <td>Int</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls whether 
+                <i>cvmfsexec</i> utility is used to mount CVMFS. Possible 
+                values are 0 or 1. A value of 0 indicates that 
+                glidein will not use <i>cvmfsexec</i> to mount CVMFS on the 
+                worker noden. A value of 1 indicates <i>cvmfsexec</i> will 
+                be used to mount CVMFS on the worker node by the glidein.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>CVMFS_SRC</b></td>
+            <td>String</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls the origin (source)
+                from which to download the CVMFS configuration repository 
+                from. Possible values are: <br/>
+                osg - configuration for cvmfs-config-osg; <br/>
+                egi - configuration for cvmfs-config-egi; <br/>
+                default - configuration for cvmfs-config-default<br/>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>GLIDEIN_CVMFS</b></td>
+            <td>String</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls the 
+                error handling behavior of the glidein in case of failures 
+                during the mounting of CVMFS. Possible values are:<br/>
+                REQUIRED - if unable to mount, report an error and abort 
+                mounting);<br/>
+                PREFERRED - if unable to mount, notify and continue 
+                normally;<br/>
+                OPTIONAL - continue if unable to mount (similar to 
+                PREFERRED);<br/>
+                NEVER - only exit if mounting fails<br/>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </div>
 
       <div class="section">
         <h3><a name="glidein_vars"></a>Glidein Script Variables (dynamic)</h3>

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2610,6 +2610,51 @@ MAX_STARTD_LOG          I       10000000        +                               
             </td>
           </tr>
         </table>
+        <br/>
+        <h4>Dynamic creation and selection of cvmfsexec 
+          platform-specific distribution</h4>
+        <p>
+          GlideinWMS factory includes the capability to mount and unmount 
+          CVMFS on demand, i.e. for sites that do not have a local 
+          installation of CVMFS available. This is achieved via the scripts 
+          <b>cvmfs_setup.sh</b> and <b>cvmfs_umount.sh</b>. Two additional 
+          shell scripts <i>cvmfs_helper_funcs.sh</i> and <i>cvmfs_mount
+          .sh</i> are used as helper scripts during the mounting process. On 
+          demand mounting and unmounting is achieved via the <b><i>cvmfsexec
+          </i></b> utility. The helper scripts are enabled for conditional 
+          download based on the GLIDEIN_USE_CVMFSEXEC variable. When the 
+          GLIDEIN_USE_CVMFSEXEC variable is set (value of 1), the helper 
+          scripts are downloaded for facilitating the mounting of CVMFS. 
+        </p>
+        <p>
+          cvmfsexec can be packaged as self-contained distribution specific 
+          to an operating system and platform with required configuration and 
+          executables necessary to enable CVMFS in unprivileged mode. Doing 
+          so allows easy distribution to multiple machines. Worker 
+          node specifications vary from each other and can change over 
+          time so, shipping all possible variations of cvmfsexec 
+          distributions with the glidein helps address the challenge when it
+          comes to using the correct distribution for use by the worker 
+          node. However, rather than having a tarball containing multiple 
+          cvmfsexec distribution files corresponding to a (CVMFS source, 
+          system platform, architecture) combination, GlideinWMS dynamically 
+          creates and selects the appropriate cvmfsexec distribution from 
+          the list of distributions.
+        </p>
+        <p>
+          Specific to a CVMFS source, system platform and architecture, 
+          cvmfsexec distribution files are created automatically by the script 
+          named <b>create_cvmfsexec_distros.sh</b>. The script is placed in 
+          <i>hooks.reconfig.pre</i> directory for dynamic execution. Each of
+          these distributions are packaged as individual tarballs and are 
+          added to the default list of uploads at the time of factory 
+          reconfiguration and/or upgrade. Another script, <i>
+          cvmfsexec_platform_select.sh</i>, automatically selects the 
+          appropriate distribution tarball based on the specifics of the 
+          worker node and ships the distribution with the glidein. This script
+          is invoked during the customization of the worker node as part of 
+          the glidein setup.
+        </p>
       </div>
 
       <div class="section">

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2533,15 +2533,15 @@ MAX_STARTD_LOG          I       10000000        +                               
           </tr>
         </table>
       </div>
-      
+
       <div class="section">
         <h3><a name="cvmfs_vars"></a>CVMFS Variables</h3>
         <p>
-          This section describes the variables that can be configured for 
-          use with the glidein to allow CVMFS to be provisioned on-demand. 
-          These variables are configured at the glidein level so that it 
-          applies to all the entries that are configured in the factory's 
-          configuration file.
+          This section describes the variables that can be configured for use
+          with the glidein to allow CVMFS to be provisioned on-demand. These
+          variables are configured at the glidein level so that it applies to
+          all the entries that are configured in the factory's configuration
+          file.
         </p>
         <table class="attributes">
           <tr class="head">
@@ -2567,12 +2567,14 @@ MAX_STARTD_LOG          I       10000000        +                               
             <td></td>
             <td>Factory</td>
             <td>
-              <p>Not set by default. This variable controls whether 
-                <i>cvmfsexec</i> utility is used to mount CVMFS. Possible 
-                values are 0 or 1. A value of 0 indicates that 
-                glidein will not use <i>cvmfsexec</i> to mount CVMFS on the 
-                worker noden. A value of 1 indicates <i>cvmfsexec</i> will 
-                be used to mount CVMFS on the worker node by the glidein.</p>
+              <p>
+                Not set by default. This variable controls whether
+                <i>cvmfsexec</i> utility is used to mount CVMFS. Possible values
+                are 0 or 1. A value of 0 indicates that glidein will not use
+                <i>cvmfsexec</i> to mount CVMFS on the worker noden. A value of
+                1 indicates <i>cvmfsexec</i> will be used to mount CVMFS on the
+                worker node by the glidein.
+              </p>
             </td>
           </tr>
           <tr>
@@ -2581,12 +2583,13 @@ MAX_STARTD_LOG          I       10000000        +                               
             <td></td>
             <td>Factory</td>
             <td>
-              <p>Not set by default. This variable controls the origin (source)
-                from which to download the CVMFS configuration repository 
-                from. Possible values are: <br/>
-                osg - configuration for cvmfs-config-osg; <br/>
-                egi - configuration for cvmfs-config-egi; <br/>
-                default - configuration for cvmfs-config-default<br/>
+              <p>
+                Not set by default. This variable controls the origin (source)
+                from which to download the CVMFS configuration repository from.
+                Possible values are: <br />
+                osg - configuration for cvmfs-config-osg; <br />
+                egi - configuration for cvmfs-config-egi; <br />
+                default - configuration for cvmfs-config-default<br />
               </p>
             </td>
           </tr>
@@ -2596,64 +2599,64 @@ MAX_STARTD_LOG          I       10000000        +                               
             <td></td>
             <td>Factory</td>
             <td>
-              <p>Not set by default. This variable controls the 
-                error handling behavior of the glidein in case of failures 
-                during the mounting of CVMFS. Possible values are:<br/>
-                REQUIRED - if unable to mount, report an error and abort 
-                mounting);<br/>
-                PREFERRED - if unable to mount, notify and continue 
-                normally;<br/>
-                OPTIONAL - continue if unable to mount (similar to 
-                PREFERRED);<br/>
-                NEVER - only exit if mounting fails<br/>
+              <p>
+                Not set by default. This variable controls the error handling
+                behavior of the glidein in case of failures during the mounting
+                of CVMFS. Possible values are:<br />
+                REQUIRED - if unable to mount, report an error and abort
+                mounting);<br />
+                PREFERRED - if unable to mount, notify and continue normally;<br />
+                OPTIONAL - continue if unable to mount (similar to
+                PREFERRED);<br />
+                NEVER - only exit if mounting fails<br />
               </p>
             </td>
           </tr>
         </table>
-        <br/>
-        <h4>Dynamic creation and selection of cvmfsexec 
-          platform-specific distribution</h4>
+        <br />
+        <h4>
+          Dynamic creation and selection of cvmfsexec platform-specific
+          distribution
+        </h4>
         <p>
-          GlideinWMS factory includes the capability to mount and unmount 
-          CVMFS on demand, i.e. for sites that do not have a local 
-          installation of CVMFS available. This is achieved via the scripts 
-          <b>cvmfs_setup.sh</b> and <b>cvmfs_umount.sh</b>. Two additional 
-          shell scripts <i>cvmfs_helper_funcs.sh</i> and <i>cvmfs_mount
-          .sh</i> are used as helper scripts during the mounting process. On 
-          demand mounting and unmounting is achieved via the <b><i>cvmfsexec
-          </i></b> utility. The helper scripts are enabled for conditional 
-          download based on the GLIDEIN_USE_CVMFSEXEC variable. When the 
-          GLIDEIN_USE_CVMFSEXEC variable is set (value of 1), the helper 
-          scripts are downloaded for facilitating the mounting of CVMFS. 
+          GlideinWMS factory includes the capability to mount and unmount CVMFS
+          on demand, i.e. for sites that do not have a local installation of
+          CVMFS available. This is achieved via the scripts
+          <b>cvmfs_setup.sh</b> and <b>cvmfs_umount.sh</b>. Two additional shell
+          scripts <i>cvmfs_helper_funcs.sh</i> and <i>cvmfs_mount .sh</i> are
+          used as helper scripts during the mounting process. On demand mounting
+          and unmounting is achieved via the <b><i>cvmfsexec </i></b> utility.
+          The helper scripts are enabled for conditional download based on the
+          GLIDEIN_USE_CVMFSEXEC variable. When the GLIDEIN_USE_CVMFSEXEC
+          variable is set (value of 1), the helper scripts are downloaded for
+          facilitating the mounting of CVMFS.
         </p>
         <p>
-          cvmfsexec can be packaged as self-contained distribution specific 
-          to an operating system and platform with required configuration and 
-          executables necessary to enable CVMFS in unprivileged mode. Doing 
-          so allows easy distribution to multiple machines. Worker 
-          node specifications vary from each other and can change over 
-          time so, shipping all possible variations of cvmfsexec 
-          distributions with the glidein helps address the challenge when it
-          comes to using the correct distribution for use by the worker 
-          node. However, rather than having a tarball containing multiple 
-          cvmfsexec distribution files corresponding to a (CVMFS source, 
-          system platform, architecture) combination, GlideinWMS dynamically 
-          creates and selects the appropriate cvmfsexec distribution from 
-          the list of distributions.
+          cvmfsexec can be packaged as self-contained distribution specific to
+          an operating system and platform with required configuration and
+          executables necessary to enable CVMFS in unprivileged mode. Doing so
+          allows easy distribution to multiple machines. Worker node
+          specifications vary from each other and can change over time so,
+          shipping all possible variations of cvmfsexec distributions with the
+          glidein helps address the challenge when it comes to using the correct
+          distribution for use by the worker node. However, rather than having a
+          tarball containing multiple cvmfsexec distribution files corresponding
+          to a (CVMFS source, system platform, architecture) combination,
+          GlideinWMS dynamically creates and selects the appropriate cvmfsexec
+          distribution from the list of distributions.
         </p>
         <p>
-          Specific to a CVMFS source, system platform and architecture, 
-          cvmfsexec distribution files are created automatically by the script 
-          named <b>create_cvmfsexec_distros.sh</b>. The script is placed in 
+          Specific to a CVMFS source, system platform and architecture,
+          cvmfsexec distribution files are created automatically by the script
+          named <b>create_cvmfsexec_distros.sh</b>. The script is placed in
           <i>hooks.reconfig.pre</i> directory for dynamic execution. Each of
-          these distributions are packaged as individual tarballs and are 
-          added to the default list of uploads at the time of factory 
-          reconfiguration and/or upgrade. Another script, <i>
-          cvmfsexec_platform_select.sh</i>, automatically selects the 
-          appropriate distribution tarball based on the specifics of the 
-          worker node and ships the distribution with the glidein. This script
-          is invoked during the customization of the worker node as part of 
-          the glidein setup.
+          these distributions are packaged as individual tarballs and are added
+          to the default list of uploads at the time of factory reconfiguration
+          and/or upgrade. Another script, <i> cvmfsexec_platform_select.sh</i>,
+          automatically selects the appropriate distribution tarball based on
+          the specifics of the worker node and ships the distribution with the
+          glidein. This script is invoked during the customization of the worker
+          node as part of the glidein setup.
         </p>
       </div>
 

--- a/unittests/fixtures/factory/work-dir/cvmfsexec/tarballs/cvmfsexec_src_os_x86_64.txt
+++ b/unittests/fixtures/factory/work-dir/cvmfsexec/tarballs/cvmfsexec_src_os_x86_64.txt
@@ -1,0 +1,1 @@
+this is a mock placeholder for the cvmfsexec distribution that gets created during reconfig/upgrade


### PR DESCRIPTION
Consists of work on tickets [26713](https://cdcvs.fnal.gov/redmine/issues/26713), [26096](https://cdcvs.fnal.gov/redmine/issues/26096) and [26094](https://cdcvs.fnal.gov/redmine/issues/26094).

Includes code changes for:
(1) documenting the factory configuration settings, the dynamic creation and selection of cvmfsexec distribution as per the worker node specifications to achieve on demand provisioning of CVMFS
(2) reorganizing and refactoring the main scripts that handle the CVMFS mounting and unmounting via the mountrepo/umountrepo utilities
(3) shipping only one tarball with the cvmfsexec distribution upon evaluating the worker node to determine system information and dynamically create a cvmfsexec distribution to be shipped with the glidein