### PR TITLE
Added Apptainer support

### DIFF
--- a/build/ci/do_bats.sh
+++ b/build/ci/do_bats.sh
@@ -128,8 +128,9 @@ do_count_failures() {
             # TAP format
             fail="$(echo "$tmp_out" | grep -c "^not ok")"
         else
-            lline="$(echo "$tmp_out" | tail -n1)"
-            if [[ "$lline" = *failures* ]]; then
+            # Summary line like: 24 tests, 1 failure, 1 skipped (failure or failures depending on number)
+            lline="$(echo "$tmp_out" | tail -n2 | grep failure)"
+            if [[ -n "$lline" ]]; then
                 fail=$(echo "$lline" | cut -f3 -d' ')
             fi
         fi

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1386,7 +1386,7 @@ singularity_locate_bin() {
     # 2. Look for 'singularity' and then 'apptainer' in the path suggested via $1 (SINGULARITY_BIN)
     #      (keywords: PATH -> go to step 3 - ie start w/ $PATH;
     #           OSG -> OSG location, and continue from step 3 if failed, this is the default)
-    # 3. Look in $PATH for 'singularity' and then 'apptainer'
+    # 3. Look in $PATH for 'apptainer' and then 'singularity'
     # 4. Invoke module singularitypro
     # 5. Invoke module singularity
     # 6. Look in the default OSG location
@@ -1462,13 +1462,13 @@ singularity_locate_bin() {
         fi
     fi
     if [[ "$HAS_SINGULARITY" != True ]]; then
-        # 3. Look in $PATH for singularity
-        # 4. Look in $PATH for apptainer
+        # 3. Look in $PATH for apptainer
+        # 4. Look in $PATH for singularity
         # 5. Invoke module singularitypro
         # 6. Invoke module singularity
         #    some sites requires us to do a module load first - not sure if we always want to do that
         # 7. Look in the default OSG location
-        for attempt in "PATH,singularity" "PATH,apptainer" "module,singularitypro" "module,singularity" "OSG,${osg_singularity_binary}"; do
+        for attempt in "PATH,apptainer" "PATH,singularity" "module,singularitypro" "module,singularity" "OSG,${osg_singularity_binary}"; do
             if test_out=$(singularity_test_bin "$attempt" "$s_image"); then
                 HAS_SINGULARITY=True
                 break

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2127,6 +2127,11 @@ MAX_STARTD_LOG          I       10000000        +                               
           coming from SINGULARITY_IMAGES_DICT or specified in the job. The debug
           options are used if GLIDEIN_DEBUG_OUTPUT is set.
         </p>
+        <p>
+          GlideinWMS is compatible also with Apptainer. Internal variables still
+          use the "singularity" name but will set the proper environment
+          variables for both programs and look for both executables.
+        </p>
         <pre>
  singularity [-d -vvv] exec --home "$PWD":/srv --pwd /srv --ipc --pid --contain \
     $GLIDEIN_SINGULARITY_OPTS --bind "$singularity_binds"} \
@@ -2521,13 +2526,19 @@ MAX_STARTD_LOG          I       10000000        +                               
                 clearall - clear all from the environment unless other sets are
                 listed (clearing evrything may cause problems also w/ some
                 Glidein functionalities);<br />
+                condorset - preserves HTCondor variables (env variables starting
+                with _CONDOR_ and variables defined in the job ClassAd
+                (Environment)<br />
                 osgset - preserve the set of OSG variables (originally from OSG
                 wrapper);<br />
                 gwmsset - preserve the set of GWMS utilities variables;<br />
-                clear - same as: clearall,gwmsset,osgset;<br />
+                clear - same as: clearall,gwmsset,osgset,condorset;<br />
                 clearpaths - clear only PATH,LD_LIBRARY_PATH,PYTHONPATH
                 (default);<br />
-                keepall - clear no variable, incompatible w/ any clear... option
+                keepall - clear no variable, incompatible w/ any clear...
+                option<br />
+                condorset and osgset both imply also gwmsset. osgset implies
+                also condorset.
               </p>
             </td>
           </tr>

--- a/test/bats/creation_web_base_singularity_lib.bats
+++ b/test/bats/creation_web_base_singularity_lib.bats
@@ -510,7 +510,7 @@ mock_singularity_test_bin() {
     run  singularity_locate_bin_wrapped "ppp" "/path/to/image"
     echo "part 3: $output" >&3
     #[ "$output" = "SLB: 0, True, mock_OSG, $OSG_SINGULARITY_BINARY_DEFAULT, 1" ]
-    [ "$output" = "SLB: 0, True, mock_PATH, singularity, 1" ]
+    [ "$output" = "SLB: 0, True, mock_PATH, apptainer, 1" ]
     OSG_SINGULARITY_BINARY=$tmp_singularity_bin
     # default
     run  singularity_locate_bin_wrapped "" "/path/to/image"
@@ -519,7 +519,7 @@ mock_singularity_test_bin() {
     # keyword PATH
     run  singularity_locate_bin_wrapped "PATH" "/path/to/image"
     echo "part 5: $output" >&3
-    [ "$output" = "SLB: 0, True, mock_PATH, singularity, 1" ]
+    [ "$output" = "SLB: 0, True, mock_PATH, apptainer, 1" ]
     # keyword OSG
     run  singularity_locate_bin_wrapped "OSG" "/path/to/image"
     echo "part 6: $output" >&3
@@ -532,7 +532,7 @@ mock_singularity_test_bin() {
     if [ -e "$OSG_SINGULARITY_BINARY_DEFAULT" ]; then
         [ "$output" = "SLB: 0, True, mock_s_bin_OSG, $OSG_SINGULARITY_BINARY_DEFAULT, 1" ]
     else
-        [ "$output" = "SLB: 0, True, mock_PATH, singularity, 1" ]
+        [ "$output" = "SLB: 0, True, mock_PATH, apptainer, 1" ]
     fi
     mock_singularity_test_bin_control=false  # all fail
     run  singularity_locate_bin_wrapped "" "/path/to/image"
@@ -546,7 +546,7 @@ mock_singularity_test_bin() {
     mock_singularity_test_bin_control=PATH  # only PATH successful
     run  singularity_locate_bin_wrapped "" "/path/to/image"
     echo "part 9: $output" >&3
-    [ "$output" = "SLB: 0, True, mock_PATH, singularity, 2" ]
+    [ "$output" = "SLB: 0, True, mock_PATH, apptainer, 2" ]
     mock_singularity_test_bin_control=module  # only module successful
     run  singularity_locate_bin_wrapped "" "/path/to/image"
     echo "part 10: $output" >&3

--- a/test/bats/creation_web_base_singularity_lib.bats
+++ b/test/bats/creation_web_base_singularity_lib.bats
@@ -165,7 +165,8 @@ dit() { echo "TEST:<$1><$2><$3>"; }
     [ "$(env_process_options $envoptions)" = "clearpath" ]  # Default is 'clearpath'
     [[ ",$(env_process_options clear)," = *",clearall,gwmsset,osgset,condorset,"* ]] || false  # clear substitution
     [[ ",$(env_process_options aaa,osgset)," = *",condorset,"* ]] || false  # osgset implies condorset
-    [ "$(env_process_options aaa,osgset,condorset)" = "aaa,osgset,condorset" ]  # should be the same
+    [[ ",$(env_process_options aaa,osgset)," = *",gwmsset,"* ]] || false  # osgset implies gwmsset
+    [ "$(env_process_options aaa,osgset,condorset)" = "aaa,osgset,condorset,gwmsset" ]  # should be the same
     echo "Should print a warning (clear+keepall):" >&3
     env_process_options clear,osgset,condorset,keepall
 }
@@ -215,6 +216,11 @@ preset_env() {
         #echo "UE unsetting: $i" >&3
         unset $i
     done
+    env_appt="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^APPTAINERENV_ || true)"
+    for i in $env_appt ; do
+        #echo "UE unsetting: $i" >&3
+        unset $i
+    done
     # on GNU:
     export $(grep -v "^#" fixtures/environment_singularity | xargs -d '\n' )
     # On BSD like Mac
@@ -233,43 +239,53 @@ preset_env() {
     for i in env_sing ; do
         unset $i
     done
+    env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^APPTAINERENV_ || true)"
+    for i in env_sing ; do
+        unset $i
+    done
     preset_env
     env_preserve
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
-    [ $count_env_sing -eq 10 ]  # default is clearpath, GWMS set is preserved
+    [ $count_env_sing -eq 13 ]  # default is clearpath, GWMS set is preserved
     preset_env
     env_preserve gwmsset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
-    echo "Count: $count_env_sing" >&3
-    [ $count_env_sing -eq 10 ]  # 10 variables in GWMS set
+    count_env_appt="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^APPTAINERENV_ | wc -l)"
+    echo "Count: $count_env_sing, $count_env_appt" >&3
+    [ $count_env_appt -eq $count_env_sing ]  # Singularity and Apptainer variables should match
+    [ $count_env_sing -eq 13 ]  # 13 variables in GWMS set
     preset_env
     env_preserve condorset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
-    echo "Count: $count_env_sing" >&3
-    [ $count_env_sing -eq 14 ]  # 4 variables in HTCondor set + Job classad
+    count_env_appt="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^APPTAINERENV_ | wc -l)"
+    echo "Count: $count_env_sing, $count_env_appt" >&3
+    [ $count_env_appt -eq $count_env_sing ]  # Singularity and Apptainer variables should match
+    [ $count_env_sing -eq 17 ]  # 4 variables in HTCondor set + Job classad (+GWMS set)
     preset_env
     env_preserve osgset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
-    echo "Count: $count_env_sing" >&3
-    [ $count_env_sing -eq 40 ]  # 34 variables in OSG set + HTCondor
+    count_env_appt="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^APPTAINERENV_ | wc -l)"
+    echo "Count: $count_env_sing, $count_env_appt" >&3
+    [ $count_env_appt -eq $count_env_sing ]  # Singularity and Apptainer variables should match
+    [ $count_env_sing -eq 44 ]  # 31 variables in OSG set (+13 in GWMS set, +4 in implied HTCondor set) (4 overlap)
     preset_env
     env_preserve clear
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
     echo "Count: $count_env_sing" >&3
-    [ $count_env_sing -eq 40 ]  # 40 variables in OSG set + HTCondor + GWMS (5 overlap)
+    [ $count_env_sing -eq 44 ]  # 44 variables in OSG set (31) + HTCondor (4) + GWMS (13) (4 overlap)
     preset_env
     unset STASHCACHE
     unset STASHCACHE_WRITABLE
     env_preserve gwmsset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
     echo "Count: $count_env_sing" >&3
-    [ $count_env_sing -eq 8 ]  # 10 variables in GWMS set, 2 unset
+    [ $count_env_sing -eq 11 ]  # 13 variables in GWMS set, 2 unset
     preset_env
     export SINGULARITYENV_STASHCACHE=val_notfromfile
     env_preserve gwmsset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
     echo "Count: $count_env_sing, SINGULARITYENV_STASHCACHE: $SINGULARITYENV_STASHCACHE" >&3
-    [ $count_env_sing -eq 10 ]  # 10 variables in GWMS set, 1 already_protected, still 10
+    [ $count_env_sing -eq 13 ]  # 13 variables in GWMS set, 1 already_protected, still 13
     [ "$(env | grep ^SINGULARITYENV_STASHCACHE= | cut -d'=' -f2 )" = val_notfromfile ]  # val_notfromfile preserved
     # Add a test also with a Job classad w/ a SINGULARITYENV_ in the environment to get a warning
 }
@@ -439,12 +455,13 @@ mock_singularity_test_bin() {
     local step="${1%%,*}"
     local sin_path="${1#*,}"
     local sin_version=3.6.4
+    local sin_version_full="singularity version 3.6.4"
     local sin_type=mock_$step
     if [[ -z "$sin_path" ]] && [[ "$step" = module || "$step" = PATH ]]; then
         sin_path=/path/to/singularity
     fi
     if [[ "$mock_singularity_test_bin_control" = "true" || "$mock_singularity_test_bin_control" = "$step" ]]; then
-        echo -e "_$step\n_$sin_type\n_$sin_version\n_$sin_path\n_@ $step($sin_path):TT"
+        echo -e "_$step\n_$sin_type\n_$sin_version\n_$sin_version_full\n_$sin_path\n_@ $step($sin_path):TT"
     else
         echo -e " $step($sin_path):"
         false
@@ -521,9 +538,9 @@ mock_singularity_test_bin() {
     run  singularity_locate_bin_wrapped "" "/path/to/image"
     echo "part 8: $output" >&3
     if [ -e "$OSG_SINGULARITY_BINARY_DEFAULT" ]; then
-        [ "$output" = "SLB: 1, False, , , 5" ]
+        [ "$output" = "SLB: 1, False, , , 6" ]
     else
-        [ "$output" = "SLB: 1, False, , , 4" ]
+        [ "$output" = "SLB: 1, False, , , 5" ]
     fi
     OSG_SINGULARITY_BINARY=$tmp_singularity_bin # To avoid having 2 versions for when /cvmfs is available and when not
     mock_singularity_test_bin_control=PATH  # only PATH successful
@@ -533,11 +550,11 @@ mock_singularity_test_bin() {
     mock_singularity_test_bin_control=module  # only module successful
     run  singularity_locate_bin_wrapped "" "/path/to/image"
     echo "part 10: $output" >&3
-    [ "$output" = "SLB: 0, True, mock_module, singularitypro, 3" ]
+    [ "$output" = "SLB: 0, True, mock_module, singularitypro, 4" ]
     mock_singularity_test_bin_control=OSG  # only OSG successful
     run  singularity_locate_bin_wrapped "" "/path/to/image"
     echo "part 11: $output" >&3
-    [ "$output" = "SLB: 0, True, mock_OSG, $tmp_singularity_bin, 5" ]
+    [ "$output" = "SLB: 0, True, mock_OSG, $tmp_singularity_bin, 6" ]
 
     [[ -n "${tmp_singularity_dir}" ]] && rm -rf "${tmp_singularity_dir}"
 }

--- a/test/bats/fixtures/environment_singularity
+++ b/test/bats/fixtures/environment_singularity
@@ -2,7 +2,7 @@
 # The numbers in the BATS file must be updated as well
 # General
 BATS_TEST_DIR=./
-# GWMS set, 10 variables
+# GWMS set, 13 variables
 GWMS_SINGULARITY_REEXEC=1
 GLIDEIN_Proxy_URL="http://my.proxy.net"
 MODULE_USE=1
@@ -13,14 +13,18 @@ STASHCACHE=1
 STASHCACHE_WRITABLE=0
 LoadModules=1
 GWMS_AUX_SUBDIR=.gwms
+GWMS_BASE_SUBDIR=
+GWMS_SUBDIR=
+GWMS_DIR=
 # HTCondor set, 4 variables
 _CONDOR_CONDOR_CONFIG=condor_config
 _CONDOR_HTCVAR1=val_htcvar1
 _CONDOR_HTCVAR2="val_htcvar2"
 _CONDOR_JOB_AD="$BATS_TEST_DIR"/fixtures/condor_job_ad
-# OSG set, 30 variables
+# OSG set, 31 variables (4 also in GWMS set)
 OSG_SINGULARITY_REEXEC=1
 _CHIRP_DELAYED_UPDATE_PREFIX=chde
+APPTAINER_WORKDIR=/srv
 CONDOR_PARENT_ID=1234
 GLIDEIN_ResourceName=TEST_ResourceName
 GLIDEIN_Site=TEST_Site


### PR DESCRIPTION
Internal variables are still named ...SINGULARITY... but reading and writing APPTAINER_ variables as well

GlideinWMS is not reading SINGULARITY_ environment variables. It is setting one
All singularity used vars:
   2 SINGULARITY_BINDPATH
Only in comments, GWMS is not checking or setting it
   1 SINGULARITY_HOME
Only in comments, GWMS is not checking or setting it
   4 SINGULARITY_NAME
Only in comments, GWMS is not checking or setting it
  11 SINGULARITY_WORKDIR
Only set, setting also APPTAINER_WORKDIR and updated BATS test

GlideinWMS is reading, clearing, or setting SINGULARITYENV_ variables. Treating the same also APPTAINERENV_

GlideinWMS is parsing and interpreting correctly also the apptainer version, a new variable GWMS_CONTAINERSW_FULL_VERSION, allows to distinguish between singularity and apptainer.

GlideinWMS is looking also for the "apptainer" binary (currently not needed since Apptainer is committed to providing a singularity symlink)

This PR fixes also a bug with the BATS test runner that was not detecting correctly some failures (separate commit).