### PR TITLE
Add line terminator to the end of decoded SciToken

### DIFF
--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -1278,7 +1278,6 @@ def unit_work_v3(
     scitoken_file = os.path.join(submit_credentials.cred_dir, scitoken)
     scitoken_data = decrypted_params.get("frontend_scitoken")
     if scitoken_data:
-        scitoken_data = scitoken_data.rstrip("\n ")
         if token_util.token_str_expired(scitoken_data):
             entry.log.warning(
                 "frontend_scitoken supplied by frontend, but expired. Renaming to %s.expired" % scitoken_file
@@ -1288,12 +1287,12 @@ def unit_work_v3(
             if "frontend_scitoken" in submit_credentials.identity_credentials:
                 del submit_credentials.identity_credentials["frontend_scitoken"]
         else:
-            (fd, tmpnm) = tempfile.mkstemp(dir=submit_credentials.cred_dir)
             try:
                 entry.log.info("frontend_scitoken supplied, writing to %s" % scitoken_file)
+                (fd, tmpnm) = tempfile.mkstemp(dir=submit_credentials.cred_dir)
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(f"{scitoken_data.strip()}\n")
                 chmod(tmpnm, 0o600)
-                os.write(fd, scitoken_data.encode("utf-8"))
-                os.close(fd)
                 util.file_tmp2final(scitoken_file, tmpnm)
             except Exception as err:
                 entry.log.exception("failed to create scitoken: %s" % err)

--- a/lib/token_util.py
+++ b/lib/token_util.py
@@ -85,7 +85,8 @@ def token_str_expired(token_str):
     expired = True
     try:
         decoded = jwt.decode(
-            token_str, options={"verify_signature": False, "verify_aud": False, "verify_exp": True, "verify_nbf": True}
+            token_str.strip(),
+            options={"verify_signature": False, "verify_aud": False, "verify_exp": True, "verify_nbf": True},
         )
         expired = False
     except Exception as e:


### PR DESCRIPTION
This PR fixes an issue causing SciTokens, transferred from the Frontend, to be written on the Factory without line terminators. This problem would cause the resulting SciToken to be impossible to decode.