### PR TITLE
Allow Frontend schedds not to be in DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
+-   Frontend configuration valid (reconfig/upgrade successful) even if some HTCSS schedds are not in DNS. Failing only if all schedds are unknown to DNS.
+
 ### Deprecated / removed options and commands
 
 -   To make `glidein_config` more robust and resistant to concurrent interactions the handling function to use in custom scripts have been updated:

--- a/creation/lib/cWDictFile.py
+++ b/creation/lib/cWDictFile.py
@@ -2238,17 +2238,23 @@ class MonitorFileDicts:
 # 'fermicloudui.fnal.gov:9618?key1=val1&sock=collector&key2=val2']
 
 
-def validate_node(nodestr, allow_range=False):
+def validate_node(nodestr, allow_range=False, check_dns=True):
     """Validate HTCondor endpoint (node) string
-    this can be a node, node:port, node:port-range
+
+    This can be a node, node:port, node:port-range
     or a shared port sinful string node[:port]?[var=val&]sock=collectorN1[-N2][&var=val]
     or a schedd schedd_name@node:port[?sock=collector&var=val]
     'sock' cannot appear more than once
     ranges can be either in ports or in 'sock', not in both at the same time
 
-    @param nodestr: endpoint (node) string
-    @param allow_range: True if a port range is allowed (e.g. for secondary collectors or CCBs)
-    @return: raise RuntimeError if the validation fails
+    Args:
+        nodestr (str): endpoint (node) string
+        allow_range (bool): True if a port range is allowed (e.g. for secondary collectors or CCBs)
+        check_dns (bool): False if the DNS check should raise only a RuntimeWarning (e.g. for schedds)
+
+    Raises:
+        RuntimeWarning if the DNS check fails and check_dns is False
+        RuntimeError if the validation fails in any other way
     """
     # check that ; and , are not in the node string
     if "," in nodestr or ";" in nodestr:
@@ -2318,6 +2324,9 @@ def validate_node(nodestr, allow_range=False):
     try:
         socket.getaddrinfo(nodename, None)
     except:
-        raise RuntimeError("Node name unknown to DNS: '%s'" % nodestr)
+        if check_dns:
+            raise RuntimeError("Node name unknown to DNS: '%s'" % nodestr)
+        else:
+            raise RuntimeWarning("Node name unknown to DNS: '%s'" % nodestr)
     # OK, all looks good
     return

--- a/unittests/test_creation_lib_cWDictFile_validate_node.py
+++ b/unittests/test_creation_lib_cWDictFile_validate_node.py
@@ -77,7 +77,7 @@ class Test_validate_node(unittest.TestCase):
             try:
                 validate_node(node, allow_range=True)
                 raise RuntimeError("node %s validated, it should not")
-            except RuntimeError as e:
+            except RuntimeError:
                 pass
 
     def test_range_not_allowed(self):
@@ -85,8 +85,17 @@ class Test_validate_node(unittest.TestCase):
             try:
                 validate_node(node, allow_range=False)
                 raise RuntimeError("node %s validated, it should not")
-            except RuntimeError as e:
+            except RuntimeError:
                 pass
+
+    def test_no_dns(self):
+        try:
+            validate_node("I.dont.exist:9618", check_dns=False)
+            raise RuntimeWarning("node %s validated, it should have raised a RuntimeWarning")
+        except RuntimeWarning:
+            pass
+        except RuntimeError as e:
+            raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Failing Frontend configuration validation (reconfig/upgrade) only if all HTCSS schedds are unknown to DNS

Especially in production, there may be many VO HTCSS schedds, some not regularly maintained (coming up and down also from DNS)
