### PR TITLE
Fixing OSG_autoconf and x509Support unit tests with EL8 and Py39

### DIFF
--- a/creation/lib/cvWParamDict.py
+++ b/creation/lib/cvWParamDict.py
@@ -1295,6 +1295,17 @@ def populate_main_security(client_security, params):
 
 
 def populate_group_security(client_security, params, sub_params, group_name):
+    """Populate the DNs in client_security (factory_DNs, schedd_DNs, pilot_DNs)
+
+    There is no return. Only via side effects
+
+    Args:
+        client_security(dict): Frontend security info
+        params: parameters form the configuration
+        sub_params:
+        group_name(str): group name
+
+    """
     factory_dns = []
     for collectors in (params.match.factory.collectors, sub_params.match.factory.collectors):
         for el in collectors:

--- a/factory/tools/OSG_autoconf.py
+++ b/factory/tools/OSG_autoconf.py
@@ -9,8 +9,8 @@
 
 import argparse
 import copy
-import fractions
 import logging
+import math
 import os
 import sys
 
@@ -94,7 +94,7 @@ def get_bestfit_pilot(celem, resource):
             if cpus == None:
                 cpus = osg_catalog["CPUs"]
             else:
-                cpus = fractions.gcd(cpus, osg_catalog["CPUs"])
+                cpus = math.gcd(cpus, osg_catalog["CPUs"])
 
     return get_entry_dictionary(resource, vos, cpus, walltime, memory)
 

--- a/frontend/gwms_renew_proxies.py
+++ b/frontend/gwms_renew_proxies.py
@@ -130,6 +130,12 @@ def parse_vomses(vomses_contents):
 
     1. Case insensitive VO name to their canonical versions
     2. VO certificate DN to URI, i.e. HOSTNAME:PORT
+
+    Args:
+        vomses_contents(str): vomses file content
+
+    Returns:
+        dict, dict: lower case VO names to correct case, DN to "host:port"
     """
     vo_info = re.findall(r'"[\w\.]+"\s+"([^"]+)"\s+"(\d+)"\s+"([^"]+)"\s+"([\w\.]+)"', vomses_contents, re.IGNORECASE)
     # VO names are case-sensitive but we don't expect users to get the case right in proxies.ini

--- a/lib/defaults.py
+++ b/lib/defaults.py
@@ -42,3 +42,34 @@ def force_bytes(instr, encoding=BINARY_ENCODING_CRYPTO):
             )
         return instr.encode(encoding)
     return instr
+
+
+def force_str(inbytes, encoding=BINARY_ENCODING_CRYPTO):
+    """Forces the output to be str, decoding the input if it is a bytestring (bytes)
+
+    AnyStr is str or bytes types
+
+    Args:
+        inbytes (AnyStr): string to be converted
+        encoding (str): a valid encoding, utf8, ascii, latin-1
+
+    Returns:
+        str: instr as unicode string
+
+    Raises:
+        ValueError: if it detects an improper str conversion (b'' around the string) or
+            the input is neither string or bytes
+    """
+    if isinstance(inbytes, str):
+        # raise Exception("ALREADY str!")
+        if inbytes.startswith("b'"):
+            raise ValueError(
+                "Input was improperly converted into string (resulting in b'' characters added): %s" % inbytes
+            )
+        return inbytes
+    # if isinstance(inbytes, (bytes, bytearray)):
+    try:
+        return inbytes.decode(encoding)
+    except AttributeError:
+        # This is not bytes, bytearray (and was not str)
+        raise ValueError(f"Input is not str or bytes: {type(inbytes)} ({inbytes})")

--- a/lib/x509Support.py
+++ b/lib/x509Support.py
@@ -9,11 +9,19 @@ from . import defaults
 
 
 def extract_DN(fname):
-    """
-    Extract a Distinguished Name from an X.509 proxy.
+    """Extract a Distinguished Name from an X.509 proxy.
 
-    @type fname: string
-    @param fname: Filename containing the X.509 proxy
+    Get the proxy subject: the subject of the first certificate
+    starting form the bottom of the chain (PEM format)
+    that is not a CA.
+    This is necessary to skip the proxies at the beginning and
+    get the subject of the user/server certificate.
+
+    Args:
+        fname(str): Filename containing the X.509 proxy
+
+    Returns:
+        bytes: Proxy subject in oneline format
     """
 
     with open(fname) as fd:
@@ -28,6 +36,7 @@ def extract_DN(fname):
             print("%s not a valid certificate file" % fname)
             sys.exit(3)
 
+        # load certificate from AnyStr. Default format=FORMAT_PEM
         m = M2Crypto.X509.load_cert_string(data)
         if m.check_ca():
             # oops, this is the CA part
@@ -37,7 +46,12 @@ def extract_DN(fname):
             break  # ok, found it, end the loop
 
     # M2Crypto.X509.x509.get_subject() returns M2Crypto.X509.x509_Name, .__str__() returns bytes
-    # return str(m.get_subject()).decode(defaults.BINARY_ENCODING_CRYPTO)
-    # return m.get_subject().__str__().decode(defaults.BINARY_ENCODING_CRYPTO)
-    # leaving it as it was even if the str() method is returning bytes according to the documentation
-    return str(m.get_subject())
+    # the str() method is returning bytes according to the source code:
+    # https://github.com/mcepl/M2Crypto/blob/b8addc7ad9990d1ba3786830ebd74aa8c939849d/src/M2Crypto/X509.py#L343
+    #     def __str__(self):
+    #         """type here () -> bytes"""
+    #         assert m2.x509_name_type_check(self.x509_name), \
+    #             "'x509_name' type error"
+    #         return m2.x509_name_oneline(self.x509_name)
+    # Forcing to return str (unicode string)
+    return defaults.force_str(str(m.get_subject()))

--- a/unittests/test_lib_x509Support.py
+++ b/unittests/test_lib_x509Support.py
@@ -30,10 +30,19 @@ except ImportError as err:
 
 class TestExtractDN(unittest.TestCase):
     def test_extract_dn(self):
+        """Testing DN extraction. Need to adapt to change in behavior of openssl
+
+        On EL8: "openssl x509 -noout -subject -nameopt compat -in %s" returns the desired /DN=... string
+        and "openssl x509 -noout -subject -in %s" returns DN = org, DC =...
+        On El7 happens exactly the opposite
+        """
         fname = "fixtures/hostcert.pem"
-        cmd = "openssl x509 -in %s -noout -subject" % fname
-        out = glideinwms.lib.subprocessSupport.iexe_cmd(cmd)
-        expected = " ".join(out.split()[1:])
+        cmd = f"openssl x509 -noout -subject -in {fname}"
+        out = glideinwms.lib.subprocessSupport.iexe_cmd(f"{cmd} -nameopt compat")
+        expected = "=".join(out.split("=")[1:]).strip(" \n")
+        if not expected.startswith("/"):
+            out = glideinwms.lib.subprocessSupport.iexe_cmd(cmd)
+            expected = " ".join(out.split()[1:])
         self.assertEqual(expected, extract_DN(fname))
 
 


### PR DESCRIPTION
Fixing OSG_autoconf and x509Support unit tests with EL8 and Python 3.9, and fixed string handling in x509Support

Added function in defaults to make sure a string is returned

Added comments, type annotations, and a note for a TODO refactoring and unused code lines

This solves part of #177