### PR TITLE
Timeout feature run_test bats

### DIFF
--- a/.github/actions/bats-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/bats-in-sl7-docker/entrypoint.sh
@@ -5,7 +5,8 @@
 
 export PYVER=${1:-"3.6"}
 GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-`pwd`}
-glideinwms/build/ci/runtest.sh -vi bats -a
+# 20 minutes timeout for each test
+glideinwms/build/ci/runtest.sh -vi bats -a -k 1200
 status=$?
 tar cvfj $GITHUB_WORKSPACE/logs.tar.bz2 output/*
 cat output/gwms.*.bats

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bigfiles/*
 # Scripts were moved. The following 2 are here for back compatibility, can be removed in the future
 !bigfiles/pull-bigfiles.sh
 !bigfiles/push-bigfiles.sh
+
+.idea/*

--- a/build/ci/do_bats.sh
+++ b/build/ci/do_bats.sh
@@ -20,9 +20,9 @@ Command options:
   -a        run on all unit tests (see above)
   -t        Test Anything Protocol (TAP) output format (the default is human readable)
   -c        generate a coverage report while running unit tests (requires kcov)
-  -k        set a timeout in seconds for the execution of singular tests.
-            A TERM signal is sent and if 20 seconds after the number of seconds specified the test
-            will not be terminated, a hard timeout will be triggered (KILL signal)
+  -k TOUT   set a timeout of TOUT seconds for the execution of each test (BATS file).
+            A TERM signal is sent if the test is still running after TOUT seconds and a
+            hard kill (KILL signal) is sent 20 seconds after that if the test did not end
 EOF
 }
 
@@ -105,11 +105,21 @@ do_count_failures_tap() {
     fail_files_list="$fail_files_list $file"
     if [[ $1 -eq 1 ]]; then
         fail="$(echo "$tmp_out" | grep -c "^not ok")"
-    fi
+    elif [[ $1 -gt 123 ]]; then
+            # timed out tests
+         fail=1
+         echo "-> Timeout of ${TIMEOUT}s triggered while executing test.."
+         if [[ $1 -eq 137 ]]; then
+             # hardly timed out tests
+             echo "-> Timeout signal wasn't able to stop the test.."
+             echo "-> Hard timeout triggered after ${HARD_TIMEOUT_DELAY}s.."
+         fi
+         timed_out_files=$((timed_out_files + 1))
+     fi
     fail_files=$((fail_files + 1))
     fail_all=$((fail_all + fail))
-    logerror "Test $file failed ($1): $fail failed tests"
-    return "$1"
+    logerror "Test $file failed ($1): $fail failed tests, $timed_out_files timed out tests."
+    return $1
 }
 
 do_count_failures() {
@@ -149,14 +159,12 @@ do_count_failures() {
             # hardly timed out tests
             echo "-> Timeout signal wasn't able to stop the test.."
             echo "-> Hard timeout triggered after ${HARD_TIMEOUT_DELAY}s.."
-            hardly_timed_out_files=$((hardly_timed_out_files + 1))
         fi
         timed_out_files=$((timed_out_files + 1))
     fi
-    #TODO: Should I add 1 to the failed tests also in the case of timed out files?
     fail_files=$((fail_files + 1))
     fail_all=$((fail_all + fail))
-    logerror "Test $file failed ($1): $fail failed tests"
+    logerror "Test $file failed ($1): $fail failed tests, $timed_out_files timed out tests."
     return $1
 }
 
@@ -198,7 +206,6 @@ do_process_branch() {
     local -i fail_files=0
     local -i fail_all=0
     local -i timed_out_files=0
-    local -i hardly_timed_out_files=0
     local fail_files_list=
     local tmp_out=
     local -i tmp_exit_code
@@ -207,14 +214,13 @@ do_process_branch() {
     mkdir -p "${test_outdir}"
     local timeout_cmd=
     # define the prefix to the command if the timout is set (prefix: 'timeout [--kill-after=HARD_DELAY] DELAY command')
-    if [[ ! -z ${TIMEOUT} ]]; then
+    if [[ -n ${TIMEOUT} ]]; then
         timeout_cmd="timeout --kill-after=${HARD_TIMEOUT_DELAY} ${TIMEOUT}  "
     fi
     for file in ${files_list} ; do
         loginfo "Testing: $file"
         out_file="${test_outdir}/$(basename "${test_outdir}").$(basename "${file%.*}").txt"
         [[ -e "$out_file" ]] && logwarn "duplicate file name, overwriting test results: $out_file"
-
 #            if [[ -n "$RUN_COVERAGE" ]]; then
 #                kcov --include-path="${SOURCES}" "$out_coverage"  ./"$file" ${BATSOPT} || log_nonzero_rc "$file" $?
 #            else
@@ -222,11 +228,10 @@ do_process_branch() {
 #            fi
         # The prefix will not be considered if the timeout was not set
         if [[ -n "$RUN_COVERAGE" ]]; then
-            tmp_out="$( ${timeout_cmd} kcov --include-path="${SOURCES}" "$out_coverage" "$file" -p ${BATSOPT})" || do_count_failures $?
+            tmp_out="$(${timeout_cmd} kcov --include-path="${SOURCES}" "$out_coverage" "$file" -p ${BATSOPT})" || do_count_failures $?
         else
-            tmp_out="$( ${timeout_cmd} ./"$file" -p ${BATSOPT})" || do_count_failures $?
+            tmp_out="$(${timeout_cmd} ./"$file" -p ${BATSOPT})" || do_count_failures $?
         fi
-        echo "$tmp_out"
         tmp_exit_code=$?
         [[ ${tmp_exit_code} -gt ${exit_code} ]] && exit_code=${tmp_exit_code}
         echo "$tmp_out" > "$out_file"
@@ -240,9 +245,7 @@ do_process_branch() {
     BATS_ERROR_COUNT=${fail_all}
     echo "BATS_ERROR_COUNT=${BATS_ERROR_COUNT}" >> "${outfile}"
     echo "BATS_ERROR_FILES_TIMED_OUT=${timed_out_files}" >> "${outfile}"
-    echo "BATS_ERROR_FILES_HARDLY_TIMED_OUT=${hardly_timed_out_files}" >> "${outfile}"
     echo "BATS_TIMEOUT=${TIMEOUT}" >> "${outfile}"
-    echo "BATS_HARD_TIMEOUT_DELAY=${HARD_TIMEOUT_DELAY}" >> "${outfile}"
     echo "$(get_commom_info "$branch")" >> "${outfile}"
     echo "BATS=$(do_get_status)" >> "${outfile}"
     echo "----------------"


### PR DESCRIPTION
Added the support to a timeout while executing 'run_test -i bats'.
Setting the option -k 'seconds' it will be possible to set a maximum amount of time after which the test will be considered failed. If after the number of seconds specified, the test will not be timed out, a forced timeout will occur.