### PR TITLE
Adding a space after attribute name in gconfig_get to avoid partial name hits

### DIFF
--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -28,11 +28,14 @@ PSPID="$(command -v ps) -q"
 #  1: id (key) of the value to retrieve;
 #  2(opt): path of the config file ("$glidein_config" by default)
 # Counting on $glidein_config if $2 not provided
+# compatible w/: grep "^$1 " "$glidein_config" | cut -d ' ' -f 2-
+# different form previous: grep "^$1 " "$glidein_config" | awk '{print $2}' (was trimming and returning 1st word, not rest of line)
 gconfig_get() {
-    # compatible w/: grep "^$1 " "$glidein_config" | cut -d ' ' -f 2-
     local config_file=${2:-$glidein_config}
     [[ -z "${config_file}" ]] && { warn "Error: glidein_config not provided and not defined"; exit 1; }
-    $TAC "$config_file" | grep -m1 "^$1" | cut -d ' ' -f 2-
+    [[ -r "$config_file" ]] || { true; return; } 
+    # Leave the extra space in the grep, to parse correctly strings w/ the same beginning
+    $TAC "$config_file" | grep -m1 "^$1 " | cut -d ' ' -f 2-
 }
 
 gconfig_log_name() {

--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -33,7 +33,7 @@ PSPID="$(command -v ps) -q"
 gconfig_get() {
     local config_file=${2:-$glidein_config}
     [[ -z "${config_file}" ]] && { warn "Error: glidein_config not provided and not defined"; exit 1; }
-    [[ -r "$config_file" ]] || { true; return; } 
+    [[ -r "$config_file" ]] || { true; return; }
     # Leave the extra space in the grep, to parse correctly strings w/ the same beginning
     $TAC "$config_file" | grep -m1 "^$1 " | cut -d ' ' -f 2-
 }


### PR DESCRIPTION
Adding a space after attribute name in gconfig_get to avoid partial name hits
Added also unit tests for gconfig_get