### PR TITLE
Update issue-labeler.yaml for automatic labeling of issues workflow

### DIFF
--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: RegEx-based Issue Labeler
         uses: github/issue-labeler@v2.5
         with:
-          repo-token: "${{ secrets.REGEX_LABELER }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/issue-labeler-config-regexes.yaml
           # from the third-party documentation:
           # not-before attribute is optional and will result in any issues prior to this timestamp to be ignored.


### PR DESCRIPTION
The underlying GH action and the workflow relies on a secret to function as expected. Rather than creating a new secret specifically for the issue labeling workflow, a suggestion was made to use the GITHUB_TOKEN as the secret as it has already been configured and in use for other workflows. 

This PR updates the `repo-token` value to use `GITHUB_TOKEN` instead of the previous value, which was not supposed to be the case in the first place. 