### PR TITLE
Fixed default TRUST_DOMAIN to hostname of the first collector without port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ Changes since the last release
 ### New features / functionalities
 
 -   Added `GLIDEIN_PERIODIC_SCRIPT` env variable: when set custom scripts run periodically, started by HTCSS startd cron
+-   Added the possibility to set the Glidein HTCSS TRUST_DOMAIN as attribute in the Frontend configuration
 
 ### Changed defaults / behaviours
 
 -   Frontend configuration valid (reconfig/upgrade successful) even if some HTCSS schedds are not in DNS. Failing only if all schedds are unknown to DNS.
 -   Working and local tmp directories are removed during Glidein cleanup also when the start directory is missing. This result in a loss of Glidein final status information but avoids sandbox leaks on the Worker Node. (issue #189)
 -   HTCSS DC_DAEMON_LIST equal to DAEMON_LIST only in the Factory, in all other GlideinWMS components only selected HTCSS daemons are added explicitly to it (issue #205)
+-   Only the first collector in TRUST_DOMAIN is kept, following collectors are removed. This happens both in the Frontend token issuer and in the setting of the Glidein TRUST_DOMAIN (setup_x509.sh).
 
 ### Deprecated / removed options and commands
 
@@ -42,6 +44,7 @@ Changes since the last release
 -   Fixed gwms-renew-proxies service should check if local VOMS cert is expired (issue #21)
 -   Fixed python3 check return value in case of exception (PR #211)
 -   Fixed list_get_intersection in singularity_lib.sh that was requiring python2 (PR #212)
+-   Unset SEC_PASSWORD_DIRECTORY in the Glidein HTCSS configuration, was causing warnings for unknown files (PR #226).
 
 ### Testing / Development
 

--- a/creation/web_base/condor_config
+++ b/creation/web_base/condor_config
@@ -5,7 +5,7 @@
 ##
 ##  condor_config
 ##
-##  This is the global configuration file for condor.
+##  This is the (global) configuration file for condor in the Glideins
 ##
 ######################################################################
 
@@ -95,7 +95,8 @@ BenchmarkTimer = (CurrentTime - LastBenchmark)
 RunBenchmarks : (LastBenchmark == 0 ) || ($(BenchmarkTimer) >= (4 * $(HOUR)))
 
 GSI_DAEMON_DIRECTORY=$(LOCAL_DIR)
-SEC_PASSWORD_DIRECTORY=$(LOCAL_DIR)
+# Undefined, Glideins are only clients and do not use passwords (alt: $(LOCAL_DIR)/cred.d/passwords)
+SEC_PASSWORD_DIRECTORY=
 SEC_TOKEN_SYSTEM_DIRECTORY=$(LOCAL_DIR)/cred.d/idtokens
 SEC_TOKEN_DIRECTORY=$(SEC_TOKEN_SYSTEM_DIRECTORY)
 SEC_DEFAULT_AUTHENTICATION = REQUIRED

--- a/creation/web_base/condor_vars.lst
+++ b/creation/web_base/condor_vars.lst
@@ -110,7 +110,7 @@ SiteWMS_WN_Draining  C   False       +   N   Y   -
 SiteWMS_WN_Preempt  C   False       +   N   Y   -
 GLIDEIN_PROVIDES    S	-			+   N	Y	+
 GLIDEIN_CONDOR_TOKEN        S   -               +   N   Y   @
-TRUST_DOMAIN                S   -               +   N   Y   @
+TRUST_DOMAIN                C   -               +   N   Y   @
 
 # Entry specific User modifiable variables
 GLIDEIN_Site		S	$GLIDEIN_Entry_Name	+			N	Y	@

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -2262,7 +2262,7 @@ class GlideinTotals:
                     try:
                         self.frontend_limits[el_list[0]][max_glideinstatus_key] = int(el_list[1])
                     except:
-                        log.warn(
+                        log.warning(
                             "Invalid FrontendName:SecurityClassName combo '%s' encountered while finding '%s' from max_job_frontend"
                             % (el_list[0], max_glideinstatus_key)
                         )

--- a/frontend/glideinFrontend.py
+++ b/frontend/glideinFrontend.py
@@ -433,7 +433,7 @@ def shouldHibernate(frontendDescript, work_dir, ha, mode, groups):
                         factory_pool_node,
                         master_frontend_name,
                     )
-                    logSupport.log.warn(msg)
+                    logSupport.log.warning(msg)
                     msg = "Exception talking to the factory_pool {} to get the status of Master frontend {}: ".format(
                         factory_pool_node,
                         master_frontend_name,

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -1081,11 +1081,15 @@ class glideinFrontendElement:
         return None, None
 
     def refresh_entry_token(self, glidein_el):
-        """
-        create or update a condor token for an entry point
-        params:  glidein_el: a glidein element data structure
-        returns:  jwt encoded condor token on success
-                  None on failure
+        """Create or update a condor token for an entry point
+
+        Args:
+            glidein_el: a glidein element data structure
+
+        Returns:
+            jwt encoded condor token on success
+            None on failure
+
         """
         tkn_file = ""
         tkn_str = ""
@@ -1128,6 +1132,7 @@ class glideinFrontendElement:
                     logSupport.log.debug("scope= %s" % scope)
                     logSupport.log.debug("duration= %s" % duration)
                     logSupport.log.debug("identity= %s" % identity)
+                    # issuer (TRUST_DOMAIN) not passed, token generation will use the collector host name
                     tkn_str = token_util.create_and_sign_token(
                         pwd_file, scope=scope, duration=duration, identity=identity
                     )

--- a/lib/token_util.py
+++ b/lib/token_util.py
@@ -51,7 +51,7 @@ def token_file_expired(token_file):
     Check validity of token exp and nbf claim.
     Do not check signature, audience, or other claims
 
-    Arguments:
+    Args:
         token_file: (str) a filename containing a jwt
 
     Returns:
@@ -74,7 +74,7 @@ def token_str_expired(token_str):
     Check validity of token exp and nbf claim.
     Do not check signature, audience, or other claims
 
-    Arguments:
+    Args:
         token_str: (str) a string containing a jwt
 
     Returns:
@@ -95,13 +95,12 @@ def token_str_expired(token_str):
 
 
 def simple_scramble(data):
-    """
-    Undo the simple scramble of HTCondor - simply
-    XOR with 0xdeadbeef
+    """Undo the simple scramble of HTCondor
+    simply XOR with 0xdeadbeef
 
     Source: https://github.com/CoffeaTeam/jhub/blob/master/charts/coffea-casa-jhub/files/hub/auth.py#L196-L235
 
-    Arguments:
+    Args:
         data: binary string to be unscrambled
 
     Returns:
@@ -123,11 +122,11 @@ def simple_scramble(data):
 
 
 def derive_master_key(password):
-    """
-    derive an encryption/decryption key
+    """Derive an encryption/decryption key
+
     Source: https://github.com/CoffeaTeam/jhub/blob/master/charts/coffea-casa-jhub/files/hub/auth.py#L196-L235
 
-    Arguments:
+    Args:
         password: (str) an unscrambled HTCondor password
 
     Returns:
@@ -142,9 +141,9 @@ def derive_master_key(password):
 
 
 def sign_token(identity, issuer, kid, master_key, duration=None, scope=None):
-    """
-    Assemble and sign an idtoken
-    Arguments:
+    """Assemble and sign an idtoken
+
+    Args:
         identity: (str)  who the token was generated for
         issuer: (str) idtoken issuer, typically HTCondor Collector
         kid: (str) Key ID
@@ -175,10 +174,11 @@ def sign_token(identity, issuer, kid, master_key, duration=None, scope=None):
 
 
 def create_and_sign_token(pwd_file, issuer=None, identity=None, kid=None, duration=None, scope=None):
-    """
-    Create an HTCondor IDTOKEN
+    """Create an HTCSS IDTOKEN
 
-    Arguments:
+    This should be compatible with the HTCSS code to create tokens.
+
+    Args:
         pwd_file: (str) file containing an HTCondor password
         issuer: (str, optional) default is HTCondor TRUST_DOMAIN
         identity: (str, optional) identity claim, default is $USERNAME@$HOSTNAME
@@ -196,16 +196,34 @@ def create_and_sign_token(pwd_file, issuer=None, identity=None, kid=None, durati
     if not kid:
         kid = os.path.basename(pwd_file)
     if not issuer:
-        # split() has been added because condor is only considering the first part. Here is Brian B. comment:
-        # "any comma, space, or tab character in the trust domain is treated as a separator.  Hence, for purpose of finding the token,
+        # split() has been added because condor is only considering the first part. Here is
+        # As of Oct 2022
+        # TRUST_DOMAIN is an opaque string to be taken as it is (Brian B.), but for tokens only the first collector
+        # is considered in the TRUST_DOMAIN (TJ, generate_token HTCSS code):
+        # 	std::string issuer;
+        # 	if (!param(issuer, "TRUST_DOMAIN")) {
+        # 		if (err) err->push("PASSWD", 1, "Issuer namespace is not set");
+        # 		return false;
+        # 	}
+        # 	issuer = issuer.substr(0, issuer.find_first_of(", \t"));
+        # And Brian B. comment: "any comma, space, or tab character in the trust domain is treated as a separator.
+        # Hence, for purpose of finding the token,
         # TRUST_DOMAIN=vocms0803.cern.ch:9618,cmssrv623.fnal.gov:9618
         # TRUST_DOMAIN=vocms0803.cern.ch:9618
         # TRUST_DOMAIN=vocms0803.cern.ch:9618,Some Random Text
         # are all considered the same - vocms0803.cern.ch:9618."
-
         full_issuer = iexe_cmd("condor_config_val TRUST_DOMAIN").strip()
-        split_issuers = re.split(" |,|\t", full_issuer)
-        issuer = split_issuers[0]
+        if not full_issuer:
+            logSupport.log.warning(
+                "Unable to retrieve TRUST_DOMAIN and no issuer provided: token will have empty 'iss'"
+            )
+        else:
+            # to set the issuer TRUST_DOMAIN is split no matter whether coming from COLLECTOR_HOST or not
+            # Using the same splitting as creation/web_base/setup_x509.sh
+            # is_default_trust_domain = "# at: <Default>" in iexe_cmd("condor_config_val -v TRUST_DOMAIN")
+            split_issuers = re.split(" |,|\t", full_issuer)  # get only the first collector
+            # re.split(r":|\?", split_issuers[0]) would remove also synful string and port (to have the same tring for secondary collectors, but not needed)
+            issuer = split_issuers[0]
     if not identity:
         identity = f"{os.getlogin()}@{socket.gethostname()}"
 

--- a/test/bats/creation_web_base_setup_x509.bats
+++ b/test/bats/creation_web_base_setup_x509.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+load 'lib/bats-support/load'
+load 'lib/bats-assert/load'
+
+#load 'helper'
+
+
+[[ -z "$GWMS_SOURCEDIR" ]] && GWMS_SOURCEDIR=../..
+
+# mocking gconfig_get()
+gconfig_get_mock() {
+    if [[ "$1" = GLIDEIN_Collector ]]; then
+        echo "$collector_host"
+    elif [[ "$1" = CCB_ADDRESS ]]; then
+        echo "$ccb_address"
+    else
+        echo ""
+    fi
+}
+
+setup () {
+    source compat.bash
+    glidein_config=fixtures/glidein_config
+    # export GLIDEIN_QUIET=true
+    source "$GWMS_SOURCEDIR"/creation/web_base/add_config_line.source  # 2>&3
+    source "$GWMS_SOURCEDIR"/creation/web_base/setup_x509.sh  # 2>&3
+    load 'mock_gwms_logs'
+
+    # Mock gconfig_get intercepting some inputs
+    # used by get_trust_domain, and others
+    eval "$(echo "gconfig_get_orig()"; declare -f gconfig_get | tail -n +2 )"
+    # echo "Runnig setup" >&3
+    gconfig_get() { gconfig_get_mock "$@"; }
+}
+
+setup_nameprint() {
+    if [ "${BATS_TEST_NUMBER}" = 1 ];then
+        echo "# --- TEST NAME IS $(basename "${BATS_TEST_FILENAME}")" >&3
+    fi
+}
+
+token_util_splitting() {
+  # This is the trust_domain splitting in token_util.py (when it comes from the COLLECTOR_HOST)
+  python3 -c "import re; print(re.split(' |,|\t', '$1')[0])"
+}
+
+
+@test "Test get_trust_domain" {
+    # This trust_domain calculation must be compatible w/ the one used to create the IDTOKEN in the Frontand
+    # Resilient to multiple collectors, it uses only the first one
+    # Resilient to suggested port range or synful strings for secondary collectors (will limit to the host name)
+    # Should result in the hostname all the time ("mycollector.domain.edu")
+    collector_host='mycollector.domain.edu'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu:9618?sock=collector5'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu:9621'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu:9618-9628'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu:$RANDOM_INTEGER(9618,9628)'
+    [ "$(get_trust_domain)" = $(token_util_splitting "mycollector.domain.edu:RANDOM") ]
+    collector_host='mycollector.domain.edu:9618?sock=collector5,cecollector.domain.edu:9619'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu:9618?sock=collector5 , cecollector.domain.edu:9619'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu?sock=collector5,cecollector.domain.edu:9619'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu?sock=collector5,cecollector.domain.edu:9619'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host='mycollector.domain.edu,cecollector.domain.edu:9619'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    ccb_address='mycollector2.domain.edu:9640'
+    [ "$(get_trust_domain)" = $(token_util_splitting "$collector_host") ]
+    collector_host=''
+    [ "$(get_trust_domain)" = $(token_util_splitting "$ccb_address") ]
+}


### PR DESCRIPTION
Adding the possibility to set TRUST_DOMAIN via the attr TRUST_DOMAIN

By default TRUST_DOMAIN is GLIDEIN_Collector and if that is empty, CCB_ADDRESS.
Now if TRUST_DOMAIN is set it will be checked and used first.

And fixed TRUST_DOMAIN value: now it is the first collector (with port and synful string).

Considering only the first collector in the list (CE collectors could be added to the glidein). Secondary collectors could have a different port and synful string, but it is OK because the Glidein TRUST_DOMAIN does not have to be the same as the collector.
Both shell script and python code (the one to evaluate the issuer of the token) have been updated accordingly

Then fixed condor config vars: TRUST_DOMAIN is a condor expression, not a quoted string (suggested by TJ)

Added also unit tests for setup_x509.sh
And resed SEC_PASSWORD_DIRECTORY to an empty string (not needed in a client)

TODO: evaluate if the entry/credential trust domain from the Frontend configuration should be considered instead of the HTCSS one. Does it really matter what value is the TRUST_DOMAIN of the Glidein/startd? Will open an issue for it.

This includes and closes PR #223 