### PR TITLE
Conditionally include --pid based on environment (SOFTWARE-5340)

### DIFF
--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1151,7 +1151,9 @@ singularity_exec() {
     local singularity_binds="$3"
     # Keeping --contain. Should not interfere w/ GPUs
     local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
-    [[ $DISABLE_SINGULARITY_PID_NAMESPACES = 1 ]] || singularity_opts+=" --pid"
+    # add --pid if not disabled in config
+    no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
+    [[ $no_pid_ns = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1150,7 +1150,8 @@ singularity_exec() {
     local singularity_image="$2"
     local singularity_binds="$3"
     # Keeping --contain. Should not interfere w/ GPUs
-    local singularity_opts="--ipc --pid --contain $4"  # extra options added at the end (still before binds)
+    local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
+    [[ $DISABLE_SINGULARITY_PID_NAMESPACES = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1145,6 +1145,8 @@ singularity_exec() {
     # Out:
     # Return:
     #  string w/ command options on stdout
+    # Uses:
+    #  SINGULARITY_DISABLE_PID_NAMESPACES
 
     local singularity_bin="$1"
     local singularity_image="$2"
@@ -1152,8 +1154,7 @@ singularity_exec() {
     # Keeping --contain. Should not interfere w/ GPUs
     local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
     # add --pid if not disabled in config
-    no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
-    [[ $no_pid_ns = 1 ]] || singularity_opts+=" --pid"
+    [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }


### PR DESCRIPTION
Attn @mambelli 

Per follow-up discussion from SOFTWARE-5340, we'd like to get this fix upstream (to avoid adding `--pid` to the singularity command line if `DISABLE_SINGULARITY_PID_NAMESPACES=1` is in the glidein config).