### PR TITLE
Substitution of deprecated grep command/add_config_line for reading from/writing to glidein_config

### DIFF
--- a/creation/web_base/cat_consts.sh
+++ b/creation/web_base/cat_consts.sh
@@ -21,19 +21,20 @@ function warn {
 
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 # import get_prefix function
-get_id_selectors_source=$(grep -m1 '^GET_ID_SELECTORS_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$get_id_selectors_source"
+get_id_selectors_source=$(gconfig_get GET_ID_SELECTORS_SOURCE "$glidein_config")
+. "$get_id_selectors_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
-id_prefix=`get_prefix $dir_id`
+id_prefix=$(get_prefix $dir_id)
 
 ###################################
 # Find file names
-consts_file=$(gconfig_get ${id_prefix}CONSTS_FILE "$glidein_config")
+consts_file=$(gconfig_get "${id_prefix}CONSTS_FILE" "$glidein_config")
 if [ -z "$consts_file" ]; then
     #warn "Cannot find ${id_prefix}CONSTS_FILE in $glidein_config!"
     STR="Cannot find ${id_prefix}CONSTS_FILE in $glidein_config!"

--- a/creation/web_base/cat_consts.sh
+++ b/creation/web_base/cat_consts.sh
@@ -20,20 +20,20 @@ function warn {
 }
 
 # import add_config_line function
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
 # import get_prefix function
-get_id_selectors_source="`grep '^GET_ID_SELECTORS_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+get_id_selectors_source=$(grep -m1 '^GET_ID_SELECTORS_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$get_id_selectors_source"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 id_prefix=`get_prefix $dir_id`
 
 ###################################
 # Find file names
-consts_file="`grep "^${id_prefix}CONSTS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
+consts_file=$(gconfig_get ${id_prefix}CONSTS_FILE "$glidein_config")
 if [ -z "$consts_file" ]; then
     #warn "Cannot find ${id_prefix}CONSTS_FILE in $glidein_config!"
     STR="Cannot find ${id_prefix}CONSTS_FILE in $glidein_config!"
@@ -55,7 +55,7 @@ if [ -n "$consts_file" ]; then
 	# var_name keeps lines w/ no separator
 	var_name="`echo "$line" | cut -f 1 | sed -e 's/[[:space:]]*$//'`"
 	var_value="`echo "$line" | cut -s -f 2- | sed -e 's/[[:space:]]*$//'`"
-        ( set -f; add_config_line $var_name "$var_value" )
+        ( set -f; gconfig_add $var_name "$var_value" )
         let ++nr_lines
     done < "$consts_file"
     echo "# --- End $dir_id constants       ---" >> "$glidein_config"

--- a/creation/web_base/check_blacklist.sh
+++ b/creation/web_base/check_blacklist.sh
@@ -57,15 +57,19 @@ function check_blacklist {
 config_file="$1"
 dir_id=$2
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$config_file" | cut -d ' ' -f 2-`"
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
+source "$add_config_line_source"
+
+error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 
 # import get_prefix function
-get_id_selectors_source="`grep '^GET_ID_SELECTORS_SOURCE ' "$config_file" | cut -d ' ' -f 2-`"
+get_id_selectors_source=$(grep -m1 '^GET_ID_SELECTORS_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
 source "$get_id_selectors_source"
 
 id_prefix=`get_prefix $dir_id`
 
-blacklist_file="`grep -i "^${id_prefix}BLACKLIST_FILE " "$config_file" | cut -d ' ' -f 2-`"
+blacklist_file=$(gconfig_get ${id_prefix}BLACKLIST_FILE "$config_file")
 if [ -n "$blacklist_file" ]; then
   check_blacklist
 fi

--- a/creation/web_base/check_blacklist.sh
+++ b/creation/web_base/check_blacklist.sh
@@ -59,17 +59,18 @@ dir_id=$2
 
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 
 # import get_prefix function
-get_id_selectors_source=$(grep -m1 '^GET_ID_SELECTORS_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
-source "$get_id_selectors_source"
+get_id_selectors_source=$(gconfig_get GET_ID_SELECTORS_SOURCE "$config_file")
+. "$get_id_selectors_source"
 
-id_prefix=`get_prefix $dir_id`
+id_prefix=$(get_prefix $dir_id)
 
-blacklist_file=$(gconfig_get ${id_prefix}BLACKLIST_FILE "$config_file")
+blacklist_file=$(gconfig_get "${id_prefix}"BLACKLIST_FILE "$config_file")
 if [ -n "$blacklist_file" ]; then
   check_blacklist
 fi

--- a/creation/web_base/check_proxy.sh
+++ b/creation/web_base/check_proxy.sh
@@ -13,7 +13,7 @@
 glidein_config="$1"
 
 # import add_config_line function
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/check_proxy.sh
+++ b/creation/web_base/check_proxy.sh
@@ -13,8 +13,9 @@
 glidein_config="$1"
 
 # import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 X509_CERT_DIR=$(gconfig_get X509_CERT_DIR "$glidein_config")

--- a/creation/web_base/collector_setup.sh
+++ b/creation/web_base/collector_setup.sh
@@ -120,7 +120,8 @@ done | sort -n | cut -c8- | tr -d "\n" | sed -r 's/,+/,/g'`"
 _main() {
     # import add_config_line function
     add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-    source "$add_config_line_source"
+    # shellcheck source=./add_config_line.source
+    . "$add_config_line_source"
 
     error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/collector_setup.sh
+++ b/creation/web_base/collector_setup.sh
@@ -68,7 +68,7 @@ parse_and_select_collectors() {
     # Used for both User collectors and CCBs
     local inattr="$1"
 
-    local inlist="$(gconfig_get $inattr "$glidein_config")"
+    local inlist=$(gconfig_get $inattr "$glidein_config")
     [ -z "$inlist" ] && return 0
 
     # Split the groups
@@ -119,12 +119,12 @@ done | sort -n | cut -c8- | tr -d "\n" | sed -r 's/,+/,/g'`"
 
 _main() {
     # import add_config_line function
-    add_config_line_source="$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
+    add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
     source "$add_config_line_source"
 
-    error_gen="$(gconfig_get ERROR_GEN_PATH "$glidein_config")"
+    error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
-    condor_vars_file="$(gconfig_get CONDOR_VARS_FILE "$glidein_config")"
+    condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
 
     collector_host="$(parse_and_select_collectors GLIDEIN_Collector)"
     if [ -z "$collector_host" ]; then

--- a/creation/web_base/collector_setup.sh
+++ b/creation/web_base/collector_setup.sh
@@ -68,7 +68,7 @@ parse_and_select_collectors() {
     # Used for both User collectors and CCBs
     local inattr="$1"
 
-    local inlist="$(grep "^$inattr " "$glidein_config" | cut -d ' ' -f 2-)"
+    local inlist="$(gconfig_get $inattr "$glidein_config")"
     [ -z "$inlist" ] && return 0
 
     # Split the groups
@@ -119,12 +119,12 @@ done | sort -n | cut -c8- | tr -d "\n" | sed -r 's/,+/,/g'`"
 
 _main() {
     # import add_config_line function
-    add_config_line_source="$(grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
+    add_config_line_source="$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
     source "$add_config_line_source"
 
-    error_gen="$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)"
+    error_gen="$(gconfig_get ERROR_GEN_PATH "$glidein_config")"
 
-    condor_vars_file="$(grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-)"
+    condor_vars_file="$(gconfig_get CONDOR_VARS_FILE "$glidein_config")"
 
     collector_host="$(parse_and_select_collectors GLIDEIN_Collector)"
     if [ -z "$collector_host" ]; then
@@ -133,12 +133,12 @@ _main() {
         "$error_gen" -error "collector_setup.sh" "Corruption" "$STR" "attribute" "GLIDEIN_Collector"
         exit 1
     fi
-    add_config_line GLIDEIN_Collector "$collector_host"
+    gconfig_add GLIDEIN_Collector "$collector_host"
 
     # If $CONDORCE_COLLECTOR_HOST is set in the glidein's environment, site
     # wants to have some visibility into the glidein. Add to COLLECTOR_HOST
     if [ -n "$CONDORCE_COLLECTOR_HOST" ]; then
-        add_config_line GLIDEIN_Site_Collector "$CONDORCE_COLLECTOR_HOST"
+        gconfig_add GLIDEIN_Site_Collector "$CONDORCE_COLLECTOR_HOST"
     fi
 
     ccb_host="$(parse_and_select_collectors GLIDEIN_CCB)"
@@ -151,7 +151,7 @@ _main() {
         # the CCB servers in ranmdom order until it gets a successful connection.
         # add a last shuffle to change the order between groups
         # add_config_line GLIDEIN_CCB "`csv_shuffle $ccb_host`"
-        add_config_line GLIDEIN_CCB "$ccb_host"
+        gconfig_add GLIDEIN_CCB "$ccb_host"
     fi
 
 
@@ -162,9 +162,9 @@ _main() {
     else
         # factory has a collector, add it to the master collector list
         master_collector_host="$collector_host,$factory_collector_host"
-        add_config_line GLIDEIN_Factory_Collector "$factory_collector_host"
+        gconfig_add GLIDEIN_Factory_Collector "$factory_collector_host"
     fi
-    add_config_line GLIDEIN_Master_Collector "$master_collector_host"
+    gconfig_add GLIDEIN_Master_Collector "$master_collector_host"
 
     "$error_gen" -ok "collector_setup.sh" "Collector" "$collector_host" "MasterCollector" "$master_collector_host"
 }

--- a/creation/web_base/collector_setup.sh
+++ b/creation/web_base/collector_setup.sh
@@ -68,7 +68,7 @@ parse_and_select_collectors() {
     # Used for both User collectors and CCBs
     local inattr="$1"
 
-    local inlist=$(gconfig_get $inattr "$glidein_config")
+    local inlist=$(gconfig_get "$inattr" "$glidein_config")
     [ -z "$inlist" ] && return 0
 
     # Split the groups

--- a/creation/web_base/condor_chirp
+++ b/creation/web_base/condor_chirp
@@ -9,7 +9,12 @@
 
 if [ -f "$1" ]; then
     glidein_config="$1"
-    error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | awk '{print $2}')
+
+    # import add_config_line function
+    add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+    source "$add_config_line_source"
+
+    error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 fi
 
 [ -n "$error_gen" ] && CONFIG=TRUE

--- a/creation/web_base/condor_chirp
+++ b/creation/web_base/condor_chirp
@@ -9,12 +9,8 @@
 
 if [ -f "$1" ]; then
     glidein_config="$1"
-
-    # import add_config_line function
-    add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-    source "$add_config_line_source"
-
-    error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+    # retained grep here since (1) it is being used to get the value of EEROR_GEN_PATH only, i.e. single occurrence, and (2) the variable is safe meaning not modified by the scripts
+    error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | awk '{print $2}')
 fi
 
 [ -n "$error_gen" ] && CONFIG=TRUE

--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -20,7 +20,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -18,15 +18,15 @@
 glidein_config="$1"
 tmp_fname="${glidein_config}.$$.tmp"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
-
-condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
-
-# import add_config_line and add_condor_vars_line functions
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
-condor_os="`grep '^CONDOR_OS ' "$glidein_config" | cut -d ' ' -f 2-`"
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
+
+condor_os=$(gconfig_get CONDOR_OS "$glidein_config")
 if [ -z "$condor_os" ]; then
     condor_os="default"
 fi
@@ -152,7 +152,7 @@ if [[ "$condor_os" == "auto" ]]; then
     echo "###END RELEASE INFORMATION###"
 fi
 
-condor_arch="`grep '^CONDOR_ARCH ' "$glidein_config" | cut -d ' ' -f 2-`"
+condor_arch=$(gconfig_get CONDOR_ARCH "$glidein_config")
 if [ -z "$condor_arch" ]; then
     condor_arch="default"
 fi
@@ -177,7 +177,7 @@ if [[ "$condor_arch" == "auto" ]]; then
     fi
 fi
 
-condor_version="`grep '^CONDOR_VERSION ' "$glidein_config" | cut -d ' ' -f 2-`"
+condor_version=$(gconfig_get CONDOR_VERSION "$glidein_config")
 if [ -z "$condor_version" ]; then
     condor_version="default"
 fi
@@ -196,7 +196,7 @@ for version_el in $(echo "$condor_version" | tr ',' ' '); do
             condor_platform="${version_el}-${os_el}-${arch_el}"
             condor_platform_id="CONDOR_PLATFORM_$condor_platform"
 
-            condor_platform_check=`grep "^$condor_platform_id " "$glidein_config" | awk '{print $2}'`
+            condor_platform_check=$(gconfig_get $condor_platform_id "$glidein_config")
           fi
         done
       fi
@@ -217,7 +217,7 @@ if [ -z "$condor_platform_check" ]; then
 fi
 
 # this will enable this particular Condor version to be downloaded and unpacked
-add_config_line "$condor_platform_id" "1"
+gconfig_add "$condor_platform_id" "1"
 
 "$error_gen" -ok "condor_platform_select.sh" "Condor_platform" "${version_el}-${os_el}-${arch_el}"
 

--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -197,7 +197,7 @@ for version_el in $(echo "$condor_version" | tr ',' ' '); do
             condor_platform="${version_el}-${os_el}-${arch_el}"
             condor_platform_id="CONDOR_PLATFORM_$condor_platform"
 
-            condor_platform_check=$(gconfig_get $condor_platform_id "$glidein_config")
+            condor_platform_check=$(gconfig_get "$condor_platform_id" "$glidein_config")
           fi
         done
       fi

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -66,7 +66,7 @@ config_file="$1"
 
 # Aux scripts: import gconfig functions and define error_gen
 # most grep here are case insensitive (grep -i ... )
-add_config_line_source="$(grep '^ADD_CONFIG_LINE_SOURCE ' "$config_file" | cut -d ' ' -f 2-)"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
 # shellcheck source=add_config_line.source
 . "$add_config_line_source"
 error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")

--- a/creation/web_base/create_mapfile.sh
+++ b/creation/web_base/create_mapfile.sh
@@ -10,7 +10,7 @@
 glidein_config="$1"  # Must define $glidein_config to use gconfig_add()
 
 # Aux scripts: import gconfig functions and define error_gen
-add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 # shellcheck source=add_config_line.source
 . "$add_config_line_source"
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
@@ -210,8 +210,8 @@ if ! create_condormapfile; then
     exit 1
 fi
 
-gconfig_add X509_CONDORMAP           "$X509_CONDORMAP"
-gconfig_add X509_GRIDMAP_DNS         "$X509_GRIDMAP_DNS"
+gconfig_add X509_CONDORMAP "$X509_CONDORMAP"
+gconfig_add X509_GRIDMAP_DNS "$X509_GRIDMAP_DNS"
 gconfig_add X509_GRIDMAP_TRUSTED_DNS "$X509_GRIDMAP_DNS"
 
 "$error_gen" -ok "create_mapfile.sh" "DNs" "$X509_GRIDMAP_DNS" "TrustedDNs" "$X509_GRIDMAP_DNS"

--- a/creation/web_base/create_temp_mapfile.sh
+++ b/creation/web_base/create_temp_mapfile.sh
@@ -16,7 +16,8 @@ glidein_config="$1"
 
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/create_temp_mapfile.sh
+++ b/creation/web_base/create_temp_mapfile.sh
@@ -15,10 +15,10 @@
 glidein_config="$1"
 
 # import add_config_line function
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 # create a condor_mapfile starting from a grid-mapfile
 function create_condormapfile {
@@ -52,11 +52,11 @@ X509_CONDORMAP="$PWD/condor_mapfile"
 
 create_condormapfile
 
-add_config_line X509_CONDORMAP "$X509_CONDORMAP"
+gconfig_add X509_CONDORMAP "$X509_CONDORMAP"
 
 # this is required by the condor_startup script
 # A star will allow everyone, which is OK for condor_advertize of the error classad
-add_config_line X509_GRIDMAP_TRUSTED_DNS "*"
+gconfig_add X509_GRIDMAP_TRUSTED_DNS "*"
 
 "$error_gen" -ok "create_temp_mapfile.sh"
 

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -9,7 +9,7 @@ glidein_config=$1
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
 # shellcheck source=./add_config_line.source
-source $add_config_line_source
+. "$add_config_line_source"
 
 # fetch the error reporting helper script
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -6,16 +6,16 @@
 # first parameter passed to this script will always be the glidein configuration file (glidein_config)
 glidein_config=$1
 
-# fetch the error reporting helper script
-error_gen=$(grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}')
-
 # import add_config_line function
-add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
 # shellcheck source=./add_config_line.source
-. $add_config_line_source
+source $add_config_line_source
+
+# fetch the error reporting helper script
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 # get the cvmfsexec attribute switch value from the config file
-use_cvmfsexec=$(grep '^GLIDEIN_USE_CVMFSEXEC ' $glidein_config | awk '{print $2}')
+use_cvmfsexec=$(gconfig_get GLIDEIN_USE_CVMFSEXEC "$glidein_config")
 # TODO: int or string?? if string, make the attribute value case insensitive
 #use_cvmfsexec=${use_cvmfsexec,,}
 
@@ -27,7 +27,7 @@ fi
 # if GLIDEIN_USE_CVMFSEXEC is set to 1 - check if CVMFS is locally available in the node
 # validate CVMFS by examining the directories within CVMFS... checking just one directory should be sufficient?
 # get the glidein work directory location from glidein_config file
-work_dir=$(grep '^GLIDEIN_WORK_DIR ' $glidein_config | awk '{print $2}')
+work_dir=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
 # $PWD=/tmp/glide_xxx and every path is referenced with respect to $PWD
 
 # source the helper script
@@ -47,13 +47,13 @@ fi
 
 # if CVMFS is not found locally...
 # get the CVMFS source information from <attr> in the glidein configuration
-cvmfs_source=$(grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}')
+cvmfs_source=$(gconfig_get CVMFS_SRC "$glidein_config")
 
 # get the directory where cvmfsexec is unpacked
-glidein_cvmfsexec_dir=$(grep '^CVMFSEXEC_DIR ' $glidein_config | awk '{print $2}')
+glidein_cvmfsexec_dir=$(gconfig_get CVMFSEXEC_DIR "$glidein_config")
 
 # get the CVMFS requirement setting passed as one of the factory attributes
-glidein_cvmfs=$(grep '^GLIDEIN_CVMFS ' $glidein_config | awk '{print $2}')
+glidein_cvmfs=$(gconfig_get GLIDEIN_CVMFS "$glidein_config")
 
 perform_system_check
 
@@ -81,7 +81,7 @@ if [[ -n "$mount_point" && "$mount_point" != TARGET* ]]; then
     if [[ -n "$mount_point" && "$mount_point" != /cvmfs ]]; then
         CVMFS_MOUNT_DIR="$mount_point"
         export CVMFS_MOUNT_DIR
-        add_config_line CVMFS_MOUNT_DIR "$mount_point"
+        gconfig_add CVMFS_MOUNT_DIR "$mount_point"
     fi
 fi
 

--- a/creation/web_base/cvmfs_umount.sh
+++ b/creation/web_base/cvmfs_umount.sh
@@ -28,9 +28,9 @@ echo "Unmounting CVMFS as part of glidein cleanup..."
 glidein_config=$1
 
 # import add_config_line to use gconfig_ utilities
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
 # shellcheck source=./add_config_line.source
-. $add_config_line_source
+. "$add_config_line_source"
 
 # import error_gen
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/cvmfs_umount.sh
+++ b/creation/web_base/cvmfs_umount.sh
@@ -27,14 +27,16 @@ echo "Unmounting CVMFS as part of glidein cleanup..."
 
 glidein_config=$1
 
-# Set and import error_gen and add_config_line
-error_gen=$(grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}')
-add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+# import add_config_line to use gconfig_ utilities
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
 # shellcheck source=./add_config_line.source
 . $add_config_line_source
 
+# import error_gen
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
 # get the cvmfsexec attribute switch value from the config file
-use_cvmfsexec=$(grep '^GLIDEIN_USE_CVMFSEXEC ' $glidein_config | awk '{print $2}')
+use_cvmfsexec=$(gconfig_get GLIDEIN_USE_CVMFSEXEC "$glidein_config")
 # TODO: int or string? if string, make the attribute value case insensitive
 #use_cvmfsexec=${use_cvmfsexec,,}
 
@@ -44,7 +46,7 @@ if [[ $use_cvmfsexec -ne 1 ]]; then
 fi
 
 # get the glidein work directory location from glidein_config file
-work_dir=$(grep '^GLIDEIN_WORK_DIR ' $glidein_config | awk '{print $2}')
+work_dir=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
 # $PWD=/tmp/glide_xxx and every path is referenced with respect to $PWD
 
 # source the helper script
@@ -52,7 +54,7 @@ work_dir=$(grep '^GLIDEIN_WORK_DIR ' $glidein_config | awk '{print $2}')
 . $work_dir/cvmfs_helper_funcs.sh
 
 # get the cvmfsexec directory location
-glidein_cvmfsexec_dir=$(grep '^CVMFSEXEC_DIR ' $glidein_config | awk '{print $2}')
+glidein_cvmfsexec_dir=$(gconfig_get CVMFSEXEC_DIR "$glidein_config")
 
 ########################################################################################################
 # Start: main program
@@ -77,7 +79,7 @@ $glidein_cvmfsexec_dir/.cvmfsexec/umountrepo -a
 if [[ -n "$CVMFS_MOUNT_DIR" ]]; then
     CVMFS_MOUNT_DIR=
     export CVMFS_MOUNT_DIR
-    add_config_line CVMFS_MOUNT_DIR ""
+    gconfig_add CVMFS_MOUNT_DIR ""
 fi
 
 # check again to ensure all CVMFS repositories were unmounted by umountrepo

--- a/creation/web_base/cvmfsexec_platform_select.sh
+++ b/creation/web_base/cvmfsexec_platform_select.sh
@@ -12,11 +12,15 @@ usage() {
 
 glidein_config=$1
 
-error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+source $add_config_line_source
+
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 # parameter is 'osg', 'egi' or 'default' to download the latest cvmfs and configuration
 # rpm from one of these three sources (Ref. https://www.github.com/cvmfs/cvmfsexec)
-cvmfs_src=`grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}'`
+cvmfs_src=$(gconfig_get CVMFS_SRC "$glidein_config")
 cvmfs_src=${cvmfs_src,,}
 
 # check if the value of cvmfs_src is valid
@@ -25,10 +29,6 @@ if [[ ! $cvmfs_src =~ ^(osg|egi|default)$ ]]; then
     "$error_gen" -error "`basename $0`" "fail_msg" "Invalid command line argument: Must be one of {osg, egi, default}"
     exit 1
 fi
-
-# import add_config_line function
-add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
-source $add_config_line_source
 
 # TODO: is it possible to reuse cvmfs_helper_funcs.sh by sourcing it during the execution of this file????
 if [ -f '/etc/redhat-release' ]; then
@@ -45,7 +45,7 @@ cvmfsexec_platform="${cvmfs_src}-${mach_type}"
 cvmfsexec_platform_id="CVMFSEXEC_PLATFORM_$cvmfsexec_platform"
 
 # add the attribute to enable the appropriate distro file
-add_config_line "$cvmfsexec_platform_id" "1"
+gconfig_add "$cvmfsexec_platform_id" "1"
 
 # if everything goes well, report the good part too!
 "$error_gen" -ok "`basename $0`" "Cvmfsexec_platform" "${cvmfs_src}-${mach_type}"

--- a/creation/web_base/cvmfsexec_platform_select.sh
+++ b/creation/web_base/cvmfsexec_platform_select.sh
@@ -13,8 +13,9 @@ usage() {
 glidein_config=$1
 
 # import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
-source $add_config_line_source
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/frontend/singularity_script_example.sh
+++ b/creation/web_base/frontend/singularity_script_example.sh
@@ -60,7 +60,7 @@ add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" |
 . "$add_config_line_source"
 
 # error_gen defined in singularity_lib.sh
-[[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+[[ -e "$glidein_config" ]] && error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
 
 
 # Source utility files, outside and inside Singularity

--- a/creation/web_base/frontend/singularity_script_example.sh
+++ b/creation/web_base/frontend/singularity_script_example.sh
@@ -54,11 +54,6 @@ warn_raw() {
 [[ -z "$glidein_config" ]] && [[ -e "$GWMS_THIS_SCRIPT_DIR/../glidein_config" ]] &&
     glidein_config="$GWMS_THIS_SCRIPT_DIR/../glidein_config"
 
-# import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
-# shellcheck source=./add_config_line.source
-. "$add_config_line_source"
-
 # error_gen defined in singularity_lib.sh
 [[ -e "$glidein_config" ]] && error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
 

--- a/creation/web_base/frontend/singularity_script_example.sh
+++ b/creation/web_base/frontend/singularity_script_example.sh
@@ -55,8 +55,9 @@ warn_raw() {
     glidein_config="$GWMS_THIS_SCRIPT_DIR/../glidein_config"
 
 # import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
-source $add_config_line_source
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 # error_gen defined in singularity_lib.sh
 [[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/frontend/singularity_script_example.sh
+++ b/creation/web_base/frontend/singularity_script_example.sh
@@ -54,8 +54,12 @@ warn_raw() {
 [[ -z "$glidein_config" ]] && [[ -e "$GWMS_THIS_SCRIPT_DIR/../glidein_config" ]] &&
     glidein_config="$GWMS_THIS_SCRIPT_DIR/../glidein_config"
 
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+source $add_config_line_source
+
 # error_gen defined in singularity_lib.sh
-[[ -e "$glidein_config" ]] && error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
+[[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 
 # Source utility files, outside and inside Singularity

--- a/creation/web_base/get_id_selectors.source
+++ b/creation/web_base/get_id_selectors.source
@@ -3,22 +3,24 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# NOTE: any script that imports this script to use the functions defined must also import add_config_line.source
+
 ############################################
 # Get entry/client/group work dir
 # Arg: type (main/entry/client/client_group)
 get_work_dir() {
     case "$1" in
         main)
-            grep "^GLIDEIN_WORK_DIR " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDEIN_WORK_DIR "${glidein_config}"
             return $?;;
         entry)
-            grep "^GLIDEIN_ENTRY_WORK_DIR " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDEIN_ENTRY_WORK_DIR "${glidein_config}"
             return $?;;
         client)
-            grep "^GLIDECLIENT_WORK_DIR " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_WORK_DIR "${glidein_config}"
             return $?;;
         client_group)
-            grep "^GLIDECLIENT_GROUP_WORK_DIR " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_GROUP_WORK_DIR "${glidein_config}"
             return $?;;
         *)
             echo "[get_work_dir] Invalid id: $1" 1>&2
@@ -32,16 +34,16 @@ get_work_dir() {
 get_descript_file() {
     case "$1" in
         main)
-            grep "^DESCRIPTION_FILE " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get DESCRIPTION_FILE "${glidein_config}"
             return $?;;
         entry)
-            grep "^DESCRIPTION_ENTRY_FILE " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get DESCRIPTION_ENTRY_FILE "${glidein_config}"
             return $?;;
         client)
-            grep "^GLIDECLIENT_DESCRIPTION_FILE " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_DESCRIPTION_FILE "${glidein_config}"
             return $?;;
         client_group)
-            grep "^GLIDECLIENT_DESCRIPTION_GROUP_FILE " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_DESCRIPTION_GROUP_FILE "${glidein_config}"
             return $?;;
         *)
             echo "[get_descript_file] Invalid id: $1" 1>&2
@@ -55,16 +57,16 @@ get_descript_file() {
 get_signature() {
     case "$1" in
         main)
-            grep "^GLIDEIN_Signature " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDEIN_Signature "${glidein_config}"
             return $?;;
         entry)
-            grep "^GLIDEIN_Entry_Signature " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDEIN_Entry_Signature "${glidein_config}"
             return $?;;
         client)
-            grep "^GLIDECLIENT_Signature " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_Signature "${glidein_config}"
             return $?;;
         client_group)
-            grep "^GLIDECLIENT_Group_Signature " "${glidein_config}" | cut -d ' ' -f 2-
+            gconfig_get GLIDECLIENT_Group_Signature "${glidein_config}"
             return $?;;
         *)
             echo "[get_signature] Invalid id: $1" 1>&2

--- a/creation/web_base/glidein_cpus_setup.sh
+++ b/creation/web_base/glidein_cpus_setup.sh
@@ -18,16 +18,16 @@ glidein_config="$1"
 # is tmp_fname used? to remove?
 tmp_fname="${glidein_config}.$$.tmp"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
-
-condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
-
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
+
 # Use GLIDEIN_CPUS if configured by the factory
-GLIDEIN_CPUS=`grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-`
+GLIDEIN_CPUS=$(gconfig_get GLIDEIN_CPUS "$glidein_config")
 
 # 3.2.16 Meaning of "auto" chenged from "node" to "slot"
 # node and 0 mean the same thing - detect the hardware resources
@@ -194,7 +194,7 @@ fi
 # export the GLIDEIN_CPUS
 echo "`date` Setting GLIDEIN_CPUS=$GLIDEIN_CPUS $glidein_cpus_how"
 
-add_config_line GLIDEIN_CPUS "${GLIDEIN_CPUS}"
+gconfig_add GLIDEIN_CPUS "${GLIDEIN_CPUS}"
 add_condor_vars_line GLIDEIN_CPUS "C" "-" "+" "N" "N" "-"
 
 "$error_gen" -ok "glidein_cpu_setup.sh" "GLIDEIN_CPUS" "${GLIDEIN_CPUS}"

--- a/creation/web_base/glidein_cpus_setup.sh
+++ b/creation/web_base/glidein_cpus_setup.sh
@@ -20,7 +20,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/glidein_memory_setup.sh
+++ b/creation/web_base/glidein_memory_setup.sh
@@ -18,7 +18,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/glidein_memory_setup.sh
+++ b/creation/web_base/glidein_memory_setup.sh
@@ -16,22 +16,22 @@
 glidein_config="$1"
 tmp_fname="${glidein_config}.$$.tmp"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
-
-condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
-
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
+
 # Use GLIDEIN_MaxMemMBs if configured by the factory
-GLIDEIN_MaxMemMBs=`grep -i "^GLIDEIN_MaxMemMBs " "$glidein_config" | cut -d ' ' -f 2-`
+GLIDEIN_MaxMemMBs=$(gconfig_get GLIDEIN_MaxMemMBs "$glidein_config")
 
 if [ "${GLIDEIN_MaxMemMBs}" = "" ]; then
     echo "`date` GLIDEIN_MaxMemMBs not set in $glidein_config."
 
     # Calculate Mem/CPU if the VO prefers an approx value
-    estimate=`grep -i "^GLIDEIN_MaxMemMBs_Estimate " $glidein_config | awk '{print $2}' | tr [:lower:] [:upper:]`
+    estimate=$(gconfig_get GLIDEIN_MaxMemMBs_Estimate "$glidein_config" | tr [:lower:] [:upper:])
 
     if [ "$estimate" = "TRUE" ]; then
         echo "`date` Estimating Max memory based on the CPUs and total memory."
@@ -39,7 +39,7 @@ if [ "${GLIDEIN_MaxMemMBs}" = "" ]; then
         # Figure out how much free memory is available
         mem=`free -m | grep "^Mem:" | awk '{print $2}'`
 
-        glidein_cpus=`grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-`
+        glidein_cpus=$(gconfig_get GLIDEIN_CPUS "$glidein_config")
 
         if [ "$glidein_cpus" != "" ]; then
             # GLIDEIN_CPUS is set. Set Max to all the free. Let HTCondor handle the memory.
@@ -76,7 +76,7 @@ fi
 # Export the GLIDEIN_MaxMemMBs
 echo "`date` Setting GLIDEIN_MaxMemMBs=$GLIDEIN_MaxMemMBs"
 
-add_config_line MEMORY "${GLIDEIN_MaxMemMBs}"
+gconfig_add MEMORY "${GLIDEIN_MaxMemMBs}"
 add_condor_vars_line MEMORY "C" "-" "+" "N" "N" "-"
 
 "$error_gen" -ok "glidein_memory_setup.sh" "MaxMemMBs" "${GLIDEIN_MaxMemMBs}"

--- a/creation/web_base/glidein_paths.source
+++ b/creation/web_base/glidein_paths.source
@@ -11,7 +11,6 @@ GWMS_SUBDIR_EXEC_PREJOB="exec/prejob"
 GWMS_SUBDIR_EXEC_POSTJOB="exec/postjob"
 GWMS_SUBDIR_EXEC_CLEANUP="exec/cleanup"
 
-
 robust_realpath() {
     # Echo to stdout the real path even if realpath is not installed
     # 1. file path to find the real path of
@@ -26,7 +25,6 @@ robust_realpath() {
         echo "${first}${last}"
     fi
 }
-
 
 gwms_process_scripts() {
     # Process all the scripts in the directory, in lexicographic order
@@ -71,6 +69,9 @@ gwms_from_config() {
     # 1. - parameter to parse from glidein_config
     # 2. - default
     # 3. - function to validate or process (get_prop_bool or same interface)
+    # NOTE: If grep-based reading of glidein_config needs to be replaced with
+    # gconfig_xxx functions, make sure that the script that calls this function has
+    # imported add_config_line.source file
     if [[ -n "$glidein_config" ]]; then
         ret=$(grep "^$1 " "$glidein_config" | cut -d ' ' -f 2-)
     fi

--- a/creation/web_base/glidein_sitewms_setup.sh
+++ b/creation/web_base/glidein_sitewms_setup.sh
@@ -18,7 +18,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")

--- a/creation/web_base/glidein_sitewms_setup.sh
+++ b/creation/web_base/glidein_sitewms_setup.sh
@@ -15,11 +15,13 @@
 
 glidein_config="$1"
 tmp_fname="${glidein_config}.$$.tmp"
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
-condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
+
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
+
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
 
 UNKNOWN="Unknown"
 
@@ -81,10 +83,10 @@ case $sitewms in
 esac
 
 
-add_config_line GLIDEIN_SiteWMS "${sitewms}"
-add_config_line GLIDEIN_SiteWMS_Slot "${sitewms_slot}"
-add_config_line GLIDEIN_SiteWMS_JobId "${sitewms_jobid}"
-add_config_line GLIDEIN_SiteWMS_Queue "${sitewms_queue}"
+gconfig_add GLIDEIN_SiteWMS "${sitewms}"
+gconfig_add GLIDEIN_SiteWMS_Slot "${sitewms_slot}"
+gconfig_add GLIDEIN_SiteWMS_JobId "${sitewms_jobid}"
+gconfig_add GLIDEIN_SiteWMS_Queue "${sitewms_queue}"
 
 add_condor_vars_line GLIDEIN_SiteWMS "S" "$UNKNOWN" "+" "N" "Y" "-"
 add_condor_vars_line GLIDEIN_SiteWMS_Slot "S" "$UNKNOWN" "+" "N" "Y" "-"

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -10,29 +10,6 @@
 # File Version:
 #
 
-# default IFS, to protect against unusual environment, better than "unset IFS" because works with restoring old one
-IFS=$' \t\n'
-
-global_args="$*"
-# GWMS_STARTUP_SCRIPT=$0
-GWMS_STARTUP_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
-GWMS_PATH=""
-# Relative to the work directory (GWMS_DIR, gwms_lib_dir, gwms_bin_dir and gwms_exec_dir will be the absolute paths)
-# bin (utilities), lib (libraries), exec (aux scripts to be executed/sourced, e.g. pre-job)
-GWMS_SUBDIR=".gwms.d"
-
-export LANG=C
-
-# General options
-GWMS_MULTIUSER_GLIDEIN=
-# Set GWMS_MULTIUSER_GLIDEIN if the Glidein may spawn processes (for jobs) as a different user.
-# This will prepare the glidein, e.g. setting to 777 the permission of TEMP directories
-# This should never happen only when using GlExec. Not in Singularity, not w/o sudo mechanisms.
-# Comment the following line if GlExec or similar will not be used
-#GWMS_MULTIUSER_GLIDEIN=true
-# Default GWMS log server
-GWMS_LOGSERVER_ADDRESS='https://fermicloud152.fnal.gov/log'
-
 ##############################
 # Utility functions to allow the script to source functions and retrieve data stored as tarball at the end of the script itself
 
@@ -90,7 +67,6 @@ on_die() {
     kill -s "$1" %1
 }
 
-GWMS_MULTIGLIDEIN_CHILDS=
 on_die_multi() {
     echo "Multi-Glidein received signal... shutting down child glideins (forwarding $1 signal to ${GWMS_MULTIGLIDEIN_CHILDS})" 1>&2
     ON_DIE=1
@@ -195,211 +171,156 @@ usage() {
     exit 1
 }
 
-
-# params will contain the full list of parameters
-# -param_XXX YYY will become "XXX YYY"
-# TODO: can use an array instead?
-params=""
-
-while [ $# -gt 0 ]
-do case "$1" in
-    -factory)    glidein_factory="$2";;
-    -name)       glidein_name="$2";;
-    -entry)      glidein_entry="$2";;
-    -clientname) client_name="$2";;
-    -clientgroup) client_group="$2";;
-    -web)        repository_url="$2";;
-    -proxy)      proxy_url="$2";;
-    -dir)        work_dir="$2";;
-    -sign)       sign_id="$2";;
-    -signtype)   sign_type="$2";;
-    -signentry)  sign_entry_id="$2";;
-    -cluster)    condorg_cluster="$2";;
-    -subcluster) condorg_subcluster="$2";;
-    -submitcredid) glidein_cred_id="$2";;
-    -schedd)     condorg_schedd="$2";;
-    -descript)   descript_file="$2";;
-    -descriptentry)   descript_entry_file="$2";;
-    -clientweb)             client_repository_url="$2";;
-    -clientwebgroup)        client_repository_group_url="$2";;
-    -clientsign)            client_sign_id="$2";;
-    -clientsigntype)        client_sign_type="$2";;
-    -clientsigngroup)       client_sign_group_id="$2";;
-    -clientdescript)        client_descript_file="$2";;
-    -clientdescriptgroup)   client_descript_group_file="$2";;
-    -slotslayout)           slots_layout="$2";;
-    -v)          operation_mode="$2";;
-    -multiglidein)  multi_glidein="$2";;
-    -multirestart)  multi_glidein_restart="$2";;
-    -param_*)    params="$params $(echo "$1" | awk '{print substr($0,8)}') $2";;
-    *)  (warn "Unknown option $1"; usage) 1>&2; exit 1
-esac
-shift 2
-done
-
-# make sure we have a valid slots_layout
-if (echo "x${slots_layout}" | grep -i fixed) >/dev/null 2>&1 ; then
-    slots_layout="fixed"
-else
-    slots_layout="partitionable"
-fi
-
 construct_xml() {
   result="$1"
 
   glidein_end_time="$(date +%s)"
 
   echo "<?xml version=\"1.0\"?>
-<OSGTestResult id=\"glidein_startup.sh\" version=\"4.3.1\">
-  <operatingenvironment>
-    <env name=\"cwd\">${start_dir}</env>
-  </operatingenvironment>
-  <test>
-    <cmd>$0 ${global_args}</cmd>
-    <tStart>$(date --date=@"${startup_time}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
-    <tEnd>$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
-  </test>
-${result}
-</OSGTestResult>"
+        <OSGTestResult id=\"glidein_startup.sh\" version=\"4.3.1\">
+        <operatingenvironment>
+        <env name=\"cwd\">${start_dir}</env>
+        </operatingenvironment>
+        <test>
+        <cmd>$0 ${global_args}</cmd>
+        <tStart>$(date --date=@"${startup_time}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
+        <tEnd>$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
+        </test>
+        ${result}
+        </OSGTestResult>"
 }
 
-
 extract_parent_fname() {
-  exitcode=$1
+    exitcode=$1
 
-  if [ -s otrx_output.xml ]; then
-      # file exists and is not 0 size
-      last_result=$(cat otrx_output.xml)
+    if [ -s otrx_output.xml ]; then
+        # file exists and is not 0 size
+        last_result=$(cat otrx_output.xml)
 
-      if [ "${exitcode}" -eq 0 ]; then
-          echo "SUCCESS"
-      else
-          last_script_name=$(echo "${last_result}" |awk '/<OSGTestResult /{split($0,a,"id=\""); split(a[2],b,"\""); print b[1];}')
-          echo "${last_script_name}"
-      fi
-  else
-      echo "Unknown"
-  fi
+        if [ "${exitcode}" -eq 0 ]; then
+            echo "SUCCESS"
+        else
+            last_script_name=$(echo "${last_result}" |awk '/<OSGTestResult /{split($0,a,"id=\""); split(a[2],b,"\""); print b[1];}')
+            echo "${last_script_name}"
+        fi
+    else
+        echo "Unknown"
+    fi
 }
 
 extract_parent_xml_detail() {
-  exitcode=$1
-  glidein_end_time="$(date +%s)"
+    exitcode=$1
+    glidein_end_time="$(date +%s)"
 
-  if [ -s otrx_output.xml ]; then
-      # file exists and is not 0 size
-      last_result="$(cat otrx_output.xml)"
+    if [ -s otrx_output.xml ]; then
+        # file exists and is not 0 size
+        last_result="$(cat otrx_output.xml)"
 
-      if [ "${exitcode}" -eq 0 ]; then
-          echo "  <result>"
-          echo "    <status>OK</status>"
-          # propagate metrics as well
-          echo "${last_result}" | grep '<metric '
-          echo "  </result>"
-      else
-          last_script_name=$(echo "${last_result}" |awk '/<OSGTestResult /{split($0,a,"id=\""); split(a[2],b,"\""); print b[1];}')
+        if [ "${exitcode}" -eq 0 ]; then
+            echo "  <result>"
+            echo "    <status>OK</status>"
+            # propagate metrics as well
+            echo "${last_result}" | grep '<metric '
+            echo "  </result>"
+        else
+            last_script_name=$(echo "${last_result}" |awk '/<OSGTestResult /{split($0,a,"id=\""); split(a[2],b,"\""); print b[1];}')
 
-          last_script_reason=$(echo "${last_result}" | awk 'BEGIN{fr=0;}/<[/]detail>/{fr=0;}{if (fr==1) print $0}/<detail>/{fr=1;}')
-          my_reason="     Validation failed in ${last_script_name}.
+            last_script_reason=$(echo "${last_result}" | awk 'BEGIN{fr=0;}/<[/]detail>/{fr=0;}{if (fr==1) print $0}/<detail>/{fr=1;}')
+            my_reason="     Validation failed in ${last_script_name}.
 
-${last_script_reason}"
+            ${last_script_reason}"
 
-          echo "  <result>"
-          echo "    <status>ERROR</status>
-    <metric name=\"TestID\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${last_script_name}</metric>"
-          # propagate metrics as well (will include the failure metric)
-          echo "${last_result}" | grep '<metric '
-          echo "  </result>"
-          echo "  <detail>
-${my_reason}
-  </detail>"
-      fi
-  else
-      # create a minimal XML file, else
-      echo "  <result>"
-      if [ "${exitcode}" -eq 0 ]; then
-          echo "    <status>OK</status>"
-      else
-          echo "    <status>ERROR</status>"
-          echo "    <metric name=\"failure\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Unknown</metric>"
-      fi
-      echo "  </result>
-  <detail>
+            echo "  <result>"
+            echo "    <status>ERROR</status>
+            <metric name=\"TestID\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${last_script_name}</metric>"
+            # propagate metrics as well (will include the failure metric)
+            echo "${last_result}" | grep '<metric '
+            echo "  </result>"
+            echo "  <detail>
+            ${my_reason}
+            </detail>"
+        fi
+    else
+        # create a minimal XML file, else
+        echo "  <result>"
+        if [ "${exitcode}" -eq 0 ]; then
+            echo "    <status>OK</status>"
+        else
+            echo "    <status>ERROR</status>"
+            echo "    <metric name=\"failure\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Unknown</metric>"
+        fi
+    echo "  </result>
+    <detail>
     No detail. Could not find source XML file.
-  </detail>"
-  fi
+    </detail>"
+    fi
 }
 
 basexml2simplexml() {
-  final_result="$1"
+    final_result="$1"
 
-  # augment with node info
-  echo "${final_result}" | awk 'BEGIN{fr=1;}{if (fr==1) print $0}/<operatingenvironment>/{fr=0;}'
+    # augment with node info
+    echo "${final_result}" | awk 'BEGIN{fr=1;}{if (fr==1) print $0}/<operatingenvironment>/{fr=0;}'
 
-  echo "    <env name=\"client_name\">${client_name}</env>"
-  echo "    <env name=\"client_group\">${client_group}</env>"
+    echo "    <env name=\"client_name\">${client_name}</env>"
+    echo "    <env name=\"client_group\">${client_group}</env>"
 
-  echo "    <env name=\"user\">$(id -un)</env>"
-  echo "    <env name=\"arch\">$(uname -m)</env>"
-  if [ -e '/etc/redhat-release' ]; then
-      echo "    <env name=\"os\">$(cat /etc/redhat-release)</env>"
-  fi
-  echo "    <env name=\"hostname\">$(uname -n)</env>"
+    echo "    <env name=\"user\">$(id -un)</env>"
+    echo "    <env name=\"arch\">$(uname -m)</env>"
+    if [ -e '/etc/redhat-release' ]; then
+        echo "    <env name=\"os\">$(cat /etc/redhat-release)</env>"
+    fi
+    echo "    <env name=\"hostname\">$(uname -n)</env>"
 
-  echo "${final_result}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<operatingenvironment>/{fr=1;}'
+    echo "${final_result}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<operatingenvironment>/{fr=1;}'
 }
 
 simplexml2longxml() {
-  final_result_simple="$1"
-  global_result="$2"
+    final_result_simple="$1"
+    global_result="$2"
 
-  echo "${final_result_simple}" | awk 'BEGIN{fr=1;}{if (fr==1) print $0}/<OSGTestResult /{fr=0;}'
+    echo "${final_result_simple}" | awk 'BEGIN{fr=1;}{if (fr==1) print $0}/<OSGTestResult /{fr=0;}'
 
-  if [ "${global_result}" != "" ]; then
-      # subtests first, so it is more readable, when tailing
-      echo '  <subtestlist>'
-      echo '    <OSGTestResults>'
-      echo "${global_result}" | awk '{print "      " $0}'
-      echo '    </OSGTestResults>'
-      echo '  </subtestlist>'
-  fi
+    if [ "${global_result}" != "" ]; then
+        # subtests first, so it is more readable, when tailing
+        echo '  <subtestlist>'
+        echo '    <OSGTestResults>'
+        echo "${global_result}" | awk '{print "      " $0}'
+        echo '    </OSGTestResults>'
+        echo '  </subtestlist>'
+    fi
 
-  echo "${final_result_simple}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<OSGTestResult /{fr=1;}/<operatingenvironment>/{fr=0;}'
+    echo "${final_result_simple}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<OSGTestResult /{fr=1;}/<operatingenvironment>/{fr=0;}'
 
-  echo "    <env name=\"glidein_factory\">${glidein_factory}</env>"
-  echo "    <env name=\"glidein_name\">${glidein_name}</env>"
-  echo "    <env name=\"glidein_entry\">${glidein_entry}</env>"
-  echo "    <env name=\"condorg_cluster\">${condorg_cluster}</env>"
-  echo "    <env name=\"condorg_subcluster\">${condorg_subcluster}</env>"
-  echo "    <env name=\"glidein_credential_id\">${glidein_cred_id}</env>"
-  echo "    <env name=\"condorg_schedd\">${condorg_schedd}</env>"
+    echo "    <env name=\"glidein_factory\">${glidein_factory}</env>"
+    echo "    <env name=\"glidein_name\">${glidein_name}</env>"
+    echo "    <env name=\"glidein_entry\">${glidein_entry}</env>"
+    echo "    <env name=\"condorg_cluster\">${condorg_cluster}</env>"
+    echo "    <env name=\"condorg_subcluster\">${condorg_subcluster}</env>"
+    echo "    <env name=\"glidein_credential_id\">${glidein_cred_id}</env>"
+    echo "    <env name=\"condorg_schedd\">${condorg_schedd}</env>"
 
-  echo "${final_result_simple}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<operatingenvironment>/{fr=1;}'
+    echo "${final_result_simple}" | awk 'BEGIN{fr=0;}{if (fr==1) print $0}/<operatingenvironment>/{fr=1;}'
 }
 
 print_tail() {
-  exit_code=$1
-  final_result_simple="$2"
-  final_result_long="$3"
+    exit_code=$1
+    final_result_simple="$2"
+    final_result_long="$3"
 
-  glidein_end_time=$(date +%s)
-  let total_time=${glidein_end_time}-${startup_time}
-  echo "=== Glidein ending $(date) (${glidein_end_time}) with code ${exit_code} after ${total_time} ==="
-  echo ""
-  echo "=== XML description of glidein activity ==="
-  echo  "${final_result_simple}" | grep -v "<cmd>"
-  echo "=== End XML description of glidein activity ==="
+    glidein_end_time=$(date +%s)
+    let total_time=${glidein_end_time}-${startup_time}
+    echo "=== Glidein ending $(date) (${glidein_end_time}) with code ${exit_code} after ${total_time} ==="
+    echo ""
+    echo "=== XML description of glidein activity ==="
+    echo  "${final_result_simple}" | grep -v "<cmd>"
+    echo "=== End XML description of glidein activity ==="
 
-  echo "" 1>&2
-  echo "=== Encoded XML description of glidein activity ===" 1>&2
-  echo "${final_result_long}" | gzip --stdout - | b64uuencode 1>&2
-  echo "=== End encoded XML description of glidein activity ===" 1>&2
+    echo "" 1>&2
+    echo "=== Encoded XML description of glidein activity ===" 1>&2
+    echo "${final_result_long}" | gzip --stdout - | b64uuencode 1>&2
+    echo "=== End encoded XML description of glidein activity ===" 1>&2
 }
-
-####################################
-# Cleaup, print out message and exit
-work_dir_created=0
-glide_local_tmp_dir_created=0
 
 # Remove Glidein directories (work_dir, glide_local_tmp_dir)
 # 1 - exit code
@@ -429,169 +350,167 @@ glidien_cleanup() {
 # use this for early failures, when we cannot assume we can write to disk at all
 # too bad we end up with some repeated code, but difficult to do better
 early_glidein_failure() {
-  error_msg="$1"
+    error_msg="$1"
 
-  warn "${error_msg}"
+    warn "${error_msg}"
 
-  sleep "${sleep_time}"
-  # wait a bit in case of error, to reduce lost glideins
+    sleep "${sleep_time}"
+    # wait a bit in case of error, to reduce lost glideins
 
-  glidein_end_time="$(date +%s)"
-  result="    <metric name=\"failure\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">WN_RESOURCE</metric>
+    glidein_end_time="$(date +%s)"
+    result="    <metric name=\"failure\" ts=\"$(date --date=@"${glidein_end_time}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">WN_RESOURCE</metric>
     <status>ERROR</status>
     <detail>
-     ${error_msg}
+    ${error_msg}
     </detail>"
 
-  final_result="$(construct_xml "${result}")"
-  final_result_simple="$(basexml2simplexml "${final_result}")"
-  # have no global section
-  final_result_long="$(simplexml2longxml "${final_result_simple}" "")"
+    final_result="$(construct_xml "${result}")"
+    final_result_simple="$(basexml2simplexml "${final_result}")"
+    # have no global section
+    final_result_long="$(simplexml2longxml "${final_result_simple}" "")"
 
-  glidien_cleanup
+    glidien_cleanup
 
-  print_tail 1 "${final_result_simple}" "${final_result_long}"
+    print_tail 1 "${final_result_simple}" "${final_result_long}"
 
-  exit 1
+    exit 1
 }
-
 
 # use this one once the most basic ops have been done
 glidein_exit() {
-  # Removed lines about $lock_file (lock file for whole machine) not present elsewhere
+    # Removed lines about $lock_file (lock file for whole machine) not present elsewhere
 
-  gwms_process_scripts "$GWMS_DIR" cleanup "${glidein_config}"
+    gwms_process_scripts "$GWMS_DIR" cleanup "${glidein_config}"
 
-  global_result=""
-  if [ -f otr_outlist.list ]; then
-      global_result=$(cat otr_outlist.list)
-      chmod u+w otr_outlist.list
-  fi
+    global_result=""
+    if [ -f otr_outlist.list ]; then
+        global_result=$(cat otr_outlist.list)
+        chmod u+w otr_outlist.list
+    fi
 
-  ge_last_script_name=$(extract_parent_fname "$1")
-  result=$(extract_parent_xml_detail "$1")
-  final_result=$(construct_xml "${result}")
+    ge_last_script_name=$(extract_parent_fname "$1")
+    result=$(extract_parent_xml_detail "$1")
+    final_result=$(construct_xml "${result}")
 
-  # augment with node info
-  final_result_simple=$(basexml2simplexml "${final_result}")
+    # augment with node info
+    final_result_simple=$(basexml2simplexml "${final_result}")
 
-  # Create a richer version, too
-  final_result_long=$(simplexml2longxml "${final_result_simple}" "${global_result}")
+    # Create a richer version, too
+    final_result_long=$(simplexml2longxml "${final_result_simple}" "${global_result}")
 
-  if [ "$1" -ne 0 ]; then
-      report_failed=$(grep -i "^GLIDEIN_Report_Failed " "${glidein_config}" | cut -d ' ' -f 2-)
+    if [ "$1" -ne 0 ]; then
+        report_failed=$(gconfig_get GLIDEIN_Report_Failed "${glidein_config}")
 
-      if [ -z "${report_failed}" ]; then
-          report_failed="NEVER"
-      fi
+        if [ -z "${report_failed}" ]; then
+            report_failed="NEVER"
+        fi
 
-      factory_report_failed=$(grep -i "^GLIDEIN_Factory_Report_Failed " "${glidein_config}" | cut -d ' ' -f 2-)
+        factory_report_failed=$(gconfig_get GLIDEIN_Factory_Report_Failed "${glidein_config}")
 
-      if [ -z "${factory_report_failed}" ]; then
-          factory_collector=$(grep -i "^GLIDEIN_Factory_Collector " "${glidein_config}" | cut -d ' ' -f 2-)
-          if [ -z "${factory_collector}" ]; then
-              # no point in enabling it if there are no collectors
-              factory_report_failed="NEVER"
-          else
-              factory_report_failed="ALIVEONLY"
-          fi
-      fi
+        if [ -z "${factory_report_failed}" ]; then
+            factory_collector=$(gconfig_get GLIDEIN_Factory_Collector "${glidein_config}")
+            if [ -z "${factory_collector}" ]; then
+                # no point in enabling it if there are no collectors
+                factory_report_failed="NEVER"
+            else
+                factory_report_failed="ALIVEONLY"
+            fi
+        fi
 
-      do_report=0
-      if [ "${report_failed}" != "NEVER" ] || [ "${factory_report_failed}" != "NEVER" ]; then
-          do_report=1
-      fi
+        do_report=0
+        if [ "${report_failed}" != "NEVER" ] || [ "${factory_report_failed}" != "NEVER" ]; then
+            do_report=1
+        fi
 
+        # wait a bit in case of error, to reduce lost glideins
+        let "dl=$(date +%s) + ${sleep_time}"
+        dlf=$(date --date="@${dl}")
+        gconfig_add "GLIDEIN_ADVERTISE_ONLY" "1"
+        gconfig_add "GLIDEIN_Failed" "True"
+        gconfig_add "GLIDEIN_EXIT_CODE" "$1"
+        gconfig_add "GLIDEIN_ToDie" "${dl}"
+        gconfig_add "GLIDEIN_Expire" "${dl}"
+        gconfig_add "GLIDEIN_LAST_SCRIPT" "${ge_last_script_name}"
+        gconfig_add "GLIDEIN_ADVERTISE_TYPE" "Retiring"
 
-      # wait a bit in case of error, to reduce lost glideins
-      let "dl=$(date +%s) + ${sleep_time}"
-      dlf=$(date --date="@${dl}")
-      add_config_line "GLIDEIN_ADVERTISE_ONLY" "1"
-      add_config_line "GLIDEIN_Failed" "True"
-      add_config_line "GLIDEIN_EXIT_CODE" "$1"
-      add_config_line "GLIDEIN_ToDie" "${dl}"
-      add_config_line "GLIDEIN_Expire" "${dl}"
-      add_config_line "GLIDEIN_LAST_SCRIPT" "${ge_last_script_name}"
-      add_config_line "GLIDEIN_ADVERTISE_TYPE" "Retiring"
+        gconfig_add "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Keeping node busy until ${dl} (${dlf})."
 
-      add_config_line "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Keeping node busy until ${dl} (${dlf})."
+        condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "${glidein_config}")
+        if [ -n "${condor_vars_file}" ]; then
+            # if we are to advertise, this should be available... else, it does not matter anyhow
+            add_condor_vars_line "GLIDEIN_ADVERTISE_ONLY" "C" "True" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_Failed" "C" "True" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_EXIT_CODE" "I" "-" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_ToDie" "I" "-" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_Expire" "I" "-" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_LAST_SCRIPT" "S" "-" "+" "Y" "Y" "-"
+            add_condor_vars_line "GLIDEIN_FAILURE_REASON" "S" "-" "+" "Y" "Y" "-"
+        fi
+        main_work_dir="$(get_work_dir main)"
 
-      condor_vars_file="$(grep -i "^CONDOR_VARS_FILE " "${glidein_config}" | cut -d ' ' -f 2-)"
-      if [ -n "${condor_vars_file}" ]; then
-         # if we are to advertise, this should be available... else, it does not matter anyhow
-         add_condor_vars_line "GLIDEIN_ADVERTISE_ONLY" "C" "True" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_Failed" "C" "True" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_EXIT_CODE" "I" "-" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_ToDie" "I" "-" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_Expire" "I" "-" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_LAST_SCRIPT" "S" "-" "+" "Y" "Y" "-"
-         add_condor_vars_line "GLIDEIN_FAILURE_REASON" "S" "-" "+" "Y" "Y" "-"
-      fi
-      main_work_dir="$(get_work_dir main)"
+        for ((t=$(date +%s); t < dl; t=$(date +%s)))
+        do
+            if [ -e "${main_work_dir}/${last_script}" ] && [ "${do_report}" = "1" ] ; then
+                # if the file exists, we should be able to talk to the collectors
+                # notify that things went badly and we are waiting
+                if [ "${factory_report_failed}" != "NEVER" ]; then
+                    gconfig_add "GLIDEIN_ADVERTISE_DESTINATION" "Factory"
+                    warn "Notifying Factory of error"
+                    "${main_work_dir}/${last_script}" glidein_config
+                fi
+                if [ "${report_failed}" != "NEVER" ]; then
+                    gconfig_add "GLIDEIN_ADVERTISE_DESTINATION" "VO"
+                    warn "Notifying VO of error"
+                    "${main_work_dir}/${last_script}" glidein_config
+                fi
+            fi
 
-      for ((t=$(date +%s); t < dl; t=$(date +%s)))
-      do
-        if [ -e "${main_work_dir}/${last_script}" ] && [ "${do_report}" = "1" ] ; then
-            # if the file exists, we should be able to talk to the collectors
-            # notify that things went badly and we are waiting
+            # sleep for about 5 mins... but randomize a bit
+            let "ds=250+${RANDOM}%100"
+            let "as=$(date +%s) + ${ds}"
+            if [ ${as} -gt ${dl} ]; then
+                # too long, shorten to the deadline
+                let "ds=${dl} - $(date +%s)"
+            fi
+            warn "Sleeping ${ds}"
+            sleep ${ds}
+        done
+
+        if [ -e "${main_work_dir}/${last_script}" ] && [ "${do_report}" = "1" ]; then
+            # notify that things went badly and we are going away
             if [ "${factory_report_failed}" != "NEVER" ]; then
-                add_config_line "GLIDEIN_ADVERTISE_DESTINATION" "Factory"
-                warn "Notifying Factory of error"
+                gconfig_add "GLIDEIN_ADVERTISE_DESTINATION" "Factory"
+                if [ "${factory_report_failed}" = "ALIVEONLY" ]; then
+                    gconfig_add "GLIDEIN_ADVERTISE_TYPE" "INVALIDATE"
+                else
+                    gconfig_add "GLIDEIN_ADVERTISE_TYPE" "Killing"
+                    gconfig_add "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Terminating now. (${dl}) (${dlf})"
+                fi
                 "${main_work_dir}/${last_script}" glidein_config
+                warn "Last notification sent to Factory"
             fi
             if [ "${report_failed}" != "NEVER" ]; then
-                add_config_line "GLIDEIN_ADVERTISE_DESTINATION" "VO"
-                warn "Notifying VO of error"
+                gconfig_add "GLIDEIN_ADVERTISE_DESTINATION" "VO"
+                if [ "${report_failed}" = "ALIVEONLY" ]; then
+                    gconfig_add "GLIDEIN_ADVERTISE_TYPE" "INVALIDATE"
+                else
+                    gconfig_add "GLIDEIN_ADVERTISE_TYPE" "Killing"
+                    gconfig_add "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Terminating now. (${dl}) (${dlf})"
+                fi
                 "${main_work_dir}/${last_script}" glidein_config
+                warn "Last notification sent to VO"
             fi
         fi
+    fi
 
-        # sleep for about 5 mins... but randomize a bit
-        let "ds=250+${RANDOM}%100"
-        let "as=$(date +%s) + ${ds}"
-        if [ ${as} -gt ${dl} ]; then
-            # too long, shorten to the deadline
-            let "ds=${dl} - $(date +%s)"
-        fi
-        warn "Sleeping ${ds}"
-        sleep ${ds}
-      done
+    log_write "glidein_startup.sh" "text" "glidein is about to exit with retcode $1" "info"
+    send_logs_to_remote
 
-      if [ -e "${main_work_dir}/${last_script}" ] && [ "${do_report}" = "1" ]; then
-          # notify that things went badly and we are going away
-          if [ "${factory_report_failed}" != "NEVER" ]; then
-              add_config_line "GLIDEIN_ADVERTISE_DESTINATION" "Factory"
-              if [ "${factory_report_failed}" = "ALIVEONLY" ]; then
-                  add_config_line "GLIDEIN_ADVERTISE_TYPE" "INVALIDATE"
-              else
-                  add_config_line "GLIDEIN_ADVERTISE_TYPE" "Killing"
-                  add_config_line "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Terminating now. (${dl}) (${dlf})"
-              fi
-              "${main_work_dir}/${last_script}" glidein_config
-              warn "Last notification sent to Factory"
-          fi
-          if [ "${report_failed}" != "NEVER" ]; then
-              add_config_line "GLIDEIN_ADVERTISE_DESTINATION" "VO"
-              if [ "${report_failed}" = "ALIVEONLY" ]; then
-                  add_config_line "GLIDEIN_ADVERTISE_TYPE" "INVALIDATE"
-              else
-                  add_config_line "GLIDEIN_ADVERTISE_TYPE" "Killing"
-                  add_config_line "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Terminating now. (${dl}) (${dlf})"
-              fi
-              "${main_work_dir}/${last_script}" glidein_config
-              warn "Last notification sent to VO"
-          fi
-      fi
-  fi
+    glidien_cleanup
 
-  log_write "glidein_startup.sh" "text" "glidein is about to exit with retcode $1" "info"
-  send_logs_to_remote
+    print_tail "$1" "${final_result_simple}" "${final_result_long}"
 
-  glidien_cleanup
-
-  print_tail "$1" "${final_result_simple}" "${final_result_long}"
-
-  exit "$1"
+    exit "$1"
 }
 
 ####################################################
@@ -652,34 +571,34 @@ params_get_simple() {
 
 params_decode() {
     echo "$1" | sed \
- -e 's/\.nbsp,/ /g' \
- -e 's/\.semicolon,/;/g' \
- -e 's/\.colon,/:/g' \
- -e 's/\.tilde,/~/g' \
- -e 's/\.not,/!/g' \
- -e 's/\.question,/?/g' \
- -e 's/\.star,/*/g' \
- -e 's/\.dollar,/$/g' \
- -e 's/\.comment,/#/g' \
- -e 's/\.sclose,/]/g' \
- -e 's/\.sopen,/[/g' \
- -e 's/\.gclose,/}/g' \
- -e 's/\.gopen,/{/g' \
- -e 's/\.close,/)/g' \
- -e 's/\.open,/(/g' \
- -e 's/\.gt,/>/g' \
- -e 's/\.lt,/</g' \
- -e 's/\.minus,/-/g' \
- -e 's/\.plus,/+/g' \
- -e 's/\.eq,/=/g' \
- -e "s/\.singquot,/'/g" \
- -e 's/\.quot,/"/g' \
- -e 's/\.fork,/\`/g' \
- -e 's/\.pipe,/|/g' \
- -e 's/\.backslash,/\\/g' \
- -e 's/\.amp,/\&/g' \
- -e 's/\.comma,/,/g' \
- -e 's/\.dot,/./g'
+    -e 's/\.nbsp,/ /g' \
+    -e 's/\.semicolon,/;/g' \
+    -e 's/\.colon,/:/g' \
+    -e 's/\.tilde,/~/g' \
+    -e 's/\.not,/!/g' \
+    -e 's/\.question,/?/g' \
+    -e 's/\.star,/*/g' \
+    -e 's/\.dollar,/$/g' \
+    -e 's/\.comment,/#/g' \
+    -e 's/\.sclose,/]/g' \
+    -e 's/\.sopen,/[/g' \
+    -e 's/\.gclose,/}/g' \
+    -e 's/\.gopen,/{/g' \
+    -e 's/\.close,/)/g' \
+    -e 's/\.open,/(/g' \
+    -e 's/\.gt,/>/g' \
+    -e 's/\.lt,/</g' \
+    -e 's/\.minus,/-/g' \
+    -e 's/\.plus,/+/g' \
+    -e 's/\.eq,/=/g' \
+    -e "s/\.singquot,/'/g" \
+    -e 's/\.quot,/"/g' \
+    -e 's/\.fork,/\`/g' \
+    -e 's/\.pipe,/|/g' \
+    -e 's/\.backslash,/\\/g' \
+    -e 's/\.amp,/\&/g' \
+    -e 's/\.comma,/,/g' \
+    -e 's/\.dot,/./g'
 }
 
 # Put parameters into the config file
@@ -691,35 +610,35 @@ params2file() {
         # TODO: Use params_decode. For 3.4.8, not to introduce many changes now. Use params_converter
         # Note: using $() we escape blackslash with \\ like above. Using backticks would require \\\
         pfval=$(echo "$2" | sed \
- -e 's/\.nbsp,/ /g' \
- -e 's/\.semicolon,/;/g' \
- -e 's/\.colon,/:/g' \
- -e 's/\.tilde,/~/g' \
- -e 's/\.not,/!/g' \
- -e 's/\.question,/?/g' \
- -e 's/\.star,/*/g' \
- -e 's/\.dollar,/$/g' \
- -e 's/\.comment,/#/g' \
- -e 's/\.sclose,/]/g' \
- -e 's/\.sopen,/[/g' \
- -e 's/\.gclose,/}/g' \
- -e 's/\.gopen,/{/g' \
- -e 's/\.close,/)/g' \
- -e 's/\.open,/(/g' \
- -e 's/\.gt,/>/g' \
- -e 's/\.lt,/</g' \
- -e 's/\.minus,/-/g' \
- -e 's/\.plus,/+/g' \
- -e 's/\.eq,/=/g' \
- -e "s/\.singquot,/'/g" \
- -e 's/\.quot,/"/g' \
- -e 's/\.fork,/\`/g' \
- -e 's/\.pipe,/|/g' \
- -e 's/\.backslash,/\\/g' \
- -e 's/\.amp,/\&/g' \
- -e 's/\.comma,/,/g' \
- -e 's/\.dot,/./g')
-        if ! add_config_line "$1 ${pfval}"; then
+        -e 's/\.nbsp,/ /g' \
+        -e 's/\.semicolon,/;/g' \
+        -e 's/\.colon,/:/g' \
+        -e 's/\.tilde,/~/g' \
+        -e 's/\.not,/!/g' \
+        -e 's/\.question,/?/g' \
+        -e 's/\.star,/*/g' \
+        -e 's/\.dollar,/$/g' \
+        -e 's/\.comment,/#/g' \
+        -e 's/\.sclose,/]/g' \
+        -e 's/\.sopen,/[/g' \
+        -e 's/\.gclose,/}/g' \
+        -e 's/\.gopen,/{/g' \
+        -e 's/\.close,/)/g' \
+        -e 's/\.open,/(/g' \
+        -e 's/\.gt,/>/g' \
+        -e 's/\.lt,/</g' \
+        -e 's/\.minus,/-/g' \
+        -e 's/\.plus,/+/g' \
+        -e 's/\.eq,/=/g' \
+        -e "s/\.singquot,/'/g" \
+        -e 's/\.quot,/"/g' \
+        -e 's/\.fork,/\`/g' \
+        -e 's/\.pipe,/|/g' \
+        -e 's/\.backslash,/\\/g' \
+        -e 's/\.amp,/\&/g' \
+        -e 's/\.comma,/,/g' \
+        -e 's/\.dot,/./g')
+        if ! gconfig_add "$1 ${pfval}"; then
             glidein_exit 1
         fi
         if [ -z "${param_list}" ]; then
@@ -732,6 +651,734 @@ params2file() {
     echo "PARAM_LIST ${param_list}"
     return 0
 }
+
+md5wrapper() {
+    # $1 - file name
+    # $2 - option (quiet)
+    # Result returned on stdout
+    local ERROR_RESULT="???"
+    local ONLY_SUM
+    if [ "x$2" = "xquiet" ]; then
+        ONLY_SUM=yes
+    fi
+    local executable=md5sum
+    if which ${executable} 1>/dev/null 2>&1; then
+        [ -n "${ONLY_SUM}" ] && executable="md5sum \"$1\" | cut -d ' ' -f 1" ||  executable="md5sum \"$1\""
+    else
+        executable=md5
+        if ! which ${executable} 1>/dev/null 2>&1; then
+            echo "${ERROR_RESULT}"
+            warn "md5wrapper error: can't neither find md5sum nor md5"
+            return 1
+        fi
+        [ -n "${ONLY_SUM}" ] && executable="md5 -q \"$1\"" || executable="md5 \"$1\""
+    fi
+    local res
+    # Flagged by some checkers but OK
+    if ! res="$(eval "${executable}" 2>/dev/null)"; then
+        echo "${ERROR_RESULT}"
+        warn "md5wrapper error: can't calculate md5sum using ${executable}"
+        return 1
+    fi
+    echo "${res}"
+}
+
+# Generate directory ID
+dir_id() {
+    # create an id to distinguish the directories when preserved
+    [[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,nocleanup,* ]] && return
+    local dir_id=""
+    local tmp="${repository_url%%.*}"
+    tmp="${tmp#*//}"
+    dir_id="${tmp: -4}"
+    tmp="${client_repository_url%%.*}"
+    tmp="${tmp#*//}"
+    dir_id="${dir_id}${tmp: -4}"
+    [[ -z "${dir_id}" ]] && dir_id='debug'
+    echo "${dir_id}_"
+}
+
+set_proxy_fullpath() {
+    # Set the X509_USER_PROXY path to full path to the file
+    if fullpath="$(readlink -f "${X509_USER_PROXY}")"; then
+        echo "Setting X509_USER_PROXY ${X509_USER_PROXY} to canonical path ${fullpath}" 1>&2
+        export X509_USER_PROXY="${fullpath}"
+    else
+        echo "Unable to get canonical path for X509_USER_PROXY, using ${X509_USER_PROXY}" 1>&2
+    fi
+}
+
+############################################
+# get the proper descript file based on id
+# Arg: type (main/entry/client/client_group)
+get_repository_url() {
+    case "$1" in
+        main) echo "${repository_url}";;
+        entry) echo "${repository_entry_url}";;
+        client) echo "${client_repository_url}";;
+        client_group) echo "${client_repository_group_url}";;
+        *) echo "[get_repository_url] Invalid id: $1" 1>&2
+           return 1
+           ;;
+    esac
+}
+
+#####################
+# Check signature
+check_file_signature() {
+    cfs_id="$1"
+    cfs_fname="$2"
+
+    cfs_work_dir="$(get_work_dir "${cfs_id}")"
+
+    cfs_desc_fname="${cfs_work_dir}/${cfs_fname}"
+    cfs_signature="${cfs_work_dir}/signature.sha1"
+
+    if [ "${check_signature}" -gt 0 ]; then # check_signature is global for simplicity
+        tmp_signname="${cfs_signature}_$$_$(date +%s)_${RANDOM}"
+        if ! grep " ${cfs_fname}$" "${cfs_signature}" > "${tmp_signname}"; then
+            rm -f "${tmp_signname}"
+            echo "No signature for ${cfs_desc_fname}." 1>&2
+        else
+            (cd "${cfs_work_dir}" && sha1sum -c "${tmp_signname}") 1>&2
+            cfs_rc=$?
+            if [ ${cfs_rc} -ne 0 ]; then
+                "${main_dir}"/error_augment.sh -init
+                "${main_dir}"/error_gen.sh -error "check_file_signature" "Corruption" "File $cfs_desc_fname is corrupted." "file" "${cfs_desc_fname}" "source_type" "${cfs_id}"
+                "${main_dir}"/error_augment.sh  -process ${cfs_rc} "check_file_signature" "${PWD}" "sha1sum -c ${tmp_signname}" "$(date +%s)" "(date +%s)"
+                "${main_dir}"/error_augment.sh -concat
+                warn "File ${cfs_desc_fname} is corrupted."
+                rm -f "${tmp_signname}"
+                return 1
+            fi
+            rm -f "${tmp_signname}"
+            echo "Signature OK for ${cfs_id}:${cfs_fname}." 1>&2
+        fi
+    fi
+    return 0
+}
+
+#####################
+# Untar support func
+
+get_untar_subdir() {
+    gus_id="$1"
+    gus_fname="$2"
+
+    gus_prefix="$(get_prefix "${gus_id}")"
+    gus_config_cfg="${gus_prefix}UNTAR_CFG_FILE"
+
+    gus_config_file=$(gconfig_get "${gus_config_cfg}" "${glidein_config}")
+    if [ -z "${gus_config_file}" ]; then
+        warn "Error, cannot find '${gus_config_cfg}' in glidein_config."
+        glidein_exit 1
+    fi
+
+    gus_dir="$(grep -i "^${gus_fname} " "${gus_config_file}" | cut -s -f 2-)"
+    if [ -z "${gus_dir}" ]; then
+        warn "Error, untar dir for '${gus_fname}' cannot be empty."
+        glidein_exit 1
+    fi
+
+    echo "${gus_dir}"
+    return 0
+}
+
+#####################
+# periodic execution support function
+add_periodic_script() {
+    # schedules a script for periodic execution using startd_cron
+    # parameters: wrapper full path, period, cwd, executable path (from cwd),
+    # config file path (from cwd), ID
+    # global variable: add_startd_cron_counter
+    #TODO: should it allow for variable number of parameters?
+    local include_fname=condor_config_startd_cron_include
+    local s_wrapper="$1"
+    local s_period_sec="${2}s"
+    local s_cwd="$3"
+    local s_fname="$4"
+    local s_config="$5"
+    local s_ffb_id="$6"
+    local s_cc_prefix="$7"
+    if [ "${add_startd_cron_counter}" -eq 0 ]; then
+        # Make sure that no undesired file is there when called for first cron
+        rm -f ${include_fname}
+    fi
+
+    let add_startd_cron_counter=add_startd_cron_counter+1
+    local name_prefix=GLIDEIN_PS_
+    local s_name="${name_prefix}${add_startd_cron_counter}"
+
+    # Append the following to the startd configuration
+    # Instead of Periodic and Kill wait for completion:
+    # STARTD_CRON_DATE_MODE = WaitForExit
+    cat >> ${include_fname} << EOF
+    STARTD_CRON_JOBLIST = \$(STARTD_CRON_JOBLIST) ${s_name}
+    STARTD_CRON_${s_name}_MODE = Periodic
+    STARTD_CRON_${s_name}_KILL = True
+    STARTD_CRON_${s_name}_PERIOD = ${s_period_sec}
+    STARTD_CRON_${s_name}_EXECUTABLE = ${s_wrapper}
+    STARTD_CRON_${s_name}_ARGS = ${s_config} ${s_ffb_id} ${s_name} ${s_fname} ${s_cc_prefix}
+    STARTD_CRON_${s_name}_CWD = ${s_cwd}
+    STARTD_CRON_${s_name}_SLOTS = 1
+    STARTD_CRON_${s_name}_JOB_LOAD = 0.01
+EOF
+    # NOPREFIX is a keyword for not setting the prefix for all condor attributes
+    [ "xNOPREFIX" != "x${s_cc_prefix}" ] && echo "STARTD_CRON_${s_name}_PREFIX = ${s_cc_prefix}" >> ${include_fname}
+    gconfig_add "GLIDEIN_condor_config_startd_cron_include" "${include_fname}"
+    gconfig_add "# --- Lines starting with ${s_cc_prefix} are from periodic scripts ---"
+}
+
+#####################
+# Fetch a single file
+#
+# Check cWDictFile/FileDictFile for the number and type of parameters (has to be consistent)
+fetch_file_regular() {
+    fetch_file "$1" "$2" "$2" "regular" 0 "GLIDEIN_PS_" "TRUE" "FALSE"
+}
+
+fetch_file() {
+    # custom_scripts parameters format is set in the GWMS configuration (creation/lib)
+    # 1. ID
+    # 2. target fname
+    # 3. real fname
+    # 4. file type (regular, exec, exec:s, untar, nocache)
+    # 5. period (0 if not a periodic file)
+    # 6. periodic scripts prefix
+    # 7. config check TRUE,FALSE
+    # 8. config out TRUE,FALSE
+    # The above is the most recent list, below some adaptations for different versions
+    if [ $# -gt 8 ]; then
+        # For compatibility w/ future versions (add new parameters at the end)
+        echo "More then 8 arguments, considering the first 8 ($#/${ifs_str}): $*" 1>&2
+    elif [ $# -ne 8 ]; then
+        if [ $# -eq 7 ]; then
+            #TODO: remove in version 3.3
+            # For compatibility with past versions (old file list formats)
+            # 3.2.13 and older: prefix (par 6) added in #12705, 3.2.14?
+            # 3.2.10 and older: period (par 5) added:  fetch_file_try "$1" "$2" "$3" "$4" 0 "GLIDEIN_PS_" "$5" "$6"
+            if ! fetch_file_try "$1" "$2" "$3" "$4" "$5" "GLIDEIN_PS_" "$6" "$7"; then
+                glidein_exit 1
+            fi
+            return 0
+        fi
+        if [ $# -eq 6 ]; then
+            # added to maintain compatibility with older (3.2.10) file list format
+            #TODO: remove in version 3.3
+            if ! fetch_file_try "$1" "$2" "$3" "$4" 0 "GLIDEIN_PS_" "$5" "$6"; then
+                glidein_exit 1
+            fi
+            return 0
+        fi
+        local ifs_str
+        printf -v ifs_str '%q' "${IFS}"
+        warn "Not enough arguments in fetch_file, 8 expected ($#/${ifs_str}): $*"
+        glidein_exit 1
+    fi
+
+    if ! fetch_file_try "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8"; then
+        glidein_exit 1
+    fi
+    return 0
+}
+
+fetch_file_try() {
+    # Verifies if the file should be downloaded and acted upon (extracted, executed, ...) or not
+    # There are 2 mechanisms to control the download
+    # 1. tar files have the attribute "cond_attr" that is a name of a variable in glidein_config.
+    #    if the named variable has value 1, then the file is downloaded. TRUE (default) means always download
+    #    even if the mechanism is generic, there is no way to specify "cond_attr" for regular files in the configuration
+    # 2. if the file name starts with "gconditional_AAA_", the file is downloaded only if a variable GLIDEIN_USE_AAA
+    #    exists in glidein_config and the value is not empty
+    # Both conditions are checked. If either one fails the file is not downloaded
+    fft_id="$1"
+    fft_target_fname="$2"
+    fft_real_fname="$3"
+    fft_file_type="$4"
+    fft_period="$5"
+    fft_cc_prefix="$6"
+    fft_config_check="$7"
+    fft_config_out="$8"
+
+    if [[ "${fft_config_check}" != "TRUE" ]]; then
+        # TRUE is a special case, always downloaded and processed
+        local fft_get_ss
+        fft_get_ss=$(grep -i "^${fft_config_check} " glidein_config | cut -d ' ' -f 2-)
+        # Stop download and processing if the cond_attr variable is not defined or has a value different from 1
+        [[ "${fft_get_ss}" != "1" ]] && return 0
+        # TODO: what if fft_get_ss is not 1? nothing, still skip the file?
+    fi
+
+    local fft_base_name fft_condition_attr fft_condition_attr_val
+    fft_base_name=$(basename "${fft_real_fname}")
+    if [[ "${fft_base_name}" = gconditional_* ]]; then
+        fft_condition_attr="${fft_base_name#gconditional_}"
+        fft_condition_attr="GLIDEIN_USE_${fft_condition_attr%%_*}"
+        fft_condition_attr_val=$(grep -i "^${fft_condition_attr} " glidein_config | cut -d ' ' -f 2-)
+        # if the variable fft_condition_attr is not defined or empty, do not download
+        [[ -z "${fft_condition_attr_val}" ]] && return 0
+    fi
+
+    fetch_file_base "${fft_id}" "${fft_target_fname}" "${fft_real_fname}" "${fft_file_type}" "${fft_config_out}" "${fft_period}" "${fft_cc_prefix}"
+    # returning the exit code of fetch_file_base
+}
+
+perform_wget() {
+    wget_args=("$@")
+    arg_len="${#wget_args[@]}"
+    ffb_url="${wget_args[0]}"
+    ffb_repository=$(dirname "${ffb_url}")
+    ffb_real_fname=$(basename "${ffb_url}")
+    proxy_url="None"
+    for ((i=0; i<arg_len; i++));
+    do
+        if [ "${wget_args[${i}]}" = "--output-document" ]; then
+            ffb_tmp_outname=${wget_args[${i}+1]}
+        fi
+        if [ "${wget_args[${i}]}" = "--proxy" ]; then
+            proxy_url=${wget_args[${i}+1]}
+        fi
+    done
+    START=$(date +%s)
+    if [ "${proxy_url}" != "None" ]; then
+        wget_args=(${wget_args[@]:0:${arg_len}-2})
+        wget_cmd=$(echo "env http_proxy=${proxy_url} wget" "${wget_args[@]}"| sed 's/"/\\\"/g')
+        wget_resp=$(env http_proxy="${proxy_url}" wget "${wget_args[@]}" 2>&1)
+        wget_retval=$?
+    else
+        wget_cmd=$(echo "wget" "${wget_args[@]}"| sed 's/"/\\\"/g')
+        wget_resp=$(wget "${wget_args[@]}" 2>&1)
+        wget_retval=$?
+    fi
+
+    if [ ${wget_retval} -ne 0 ]; then
+        wget_version=$(wget --version 2>&1 | head -1)
+        warn "${wget_cmd} failed. version:${wget_version}  exit code ${wget_retval} stderr: ${wget_resp}"
+        # cannot use error_*.sh helper functions
+        # may not have been loaded yet, and wget fails often
+        echo "<OSGTestResult id=\"perform_wget\" version=\"4.3.1\">
+        <operatingenvironment>
+        <env name=\"cwd\">${PWD}</env>
+        <env name=\"uname\">$(uname -a)</env>
+        <env name=\"release\">$(cat /etc/system-release)</env>
+        <env name=\"wget_version\">${wget_version}</env>
+        </operatingenvironment>
+        <test>
+        <cmd>${wget_cmd}</cmd>
+        <tStart>$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
+        <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
+        </test>
+        <result>
+        <status>ERROR</status>
+        <metric name=\"failure\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Network</metric>
+        <metric name=\"URL\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_url}</metric>
+        <metric name=\"http_proxy\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${proxy_url}</metric>
+        <metric name=\"source_type\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
+        </result>
+        <detail>
+        Failed to load file '${ffb_real_fname}' from '${ffb_repository}' using proxy '${proxy_url}'.  ${wget_resp}
+        </detail>
+        </OSGTestResult>" > otrb_output.xml
+        warn "Failed to load file '${ffb_real_fname}' from '${ffb_repository}'."
+
+        if [ -f otr_outlist.list ]; then
+            chmod u+w otr_outlist.list
+        else
+            touch otr_outlist.list
+        fi
+        cat otrb_output.xml >> otr_outlist.list
+        echo "<?xml version=\"1.0\"?>" > otrx_output.xml
+        cat otrb_output.xml >> otrx_output.xml
+        rm -f otrb_output.xml
+        chmod a-w otr_outlist.list
+    fi
+    return ${wget_retval}
+}
+
+perform_curl() {
+    curl_args=("$@")
+    arg_len="${#curl_args[@]}"
+    ffb_url="${curl_args[0]}"
+    ffb_repository="$(dirname "${ffb_url}")"
+    ffb_real_fname="$(basename "${ffb_url}")"
+    for ((i=0; i<arg_len; i++));
+    do
+        if [ "${curl_args[${i}]}" = "--output" ]; then
+            ffb_tmp_outname="${curl_args[${i}+1]}"
+        fi
+        if [ "${curl_args[${i}]}" = "--proxy" ]; then
+            proxy_url="${curl_args[${i}+1]}"
+        fi
+    done
+
+    START="$(date +%s)"
+    curl_cmd="$(echo "curl" "${curl_args[@]}" | sed 's/"/\\\"/g')"
+    curl_resp="$(curl "${curl_args[@]}" 2>&1)"
+    curl_retval=$?
+    if [ ${curl_retval} -eq 0 ] && [ ! -e "${ffb_tmp_outname}" ] ; then
+        touch "${ffb_tmp_outname}"
+    fi
+
+
+    if [ "${curl_retval}" -ne 0 ]; then
+        curl_version="$(curl --version 2>&1 | head -1)"
+        warn "${curl_cmd} failed. version:${curl_version}  exit code ${curl_retval} stderr: ${curl_resp} "
+        # cannot use error_*.sh helper functions
+        # may not have been loaded yet, and wget fails often
+        echo "<OSGTestResult id=\"perform_curl\" version=\"4.3.1\">
+        <operatingenvironment>
+        <env name=\"cwd\">${PWD}</env>
+        <env name=\"uname\">$(uname -a)</env>
+        <env name=\"release\">$(cat /etc/system-release)</env>
+        <env name=\"curl_version\">${curl_version}</env>
+        </operatingenvironment>
+        <test>
+        <cmd>${curl_cmd}</cmd>
+        <tStart>$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
+        <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
+        </test>
+        <result>
+        <status>ERROR</status>
+        <metric name=\"failure\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Network</metric>
+        <metric name=\"URL\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_url}</metric>
+        <metric name=\"http_proxy\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${proxy_url}</metric>
+        <metric name=\"source_type\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
+        </result>
+        <detail>
+        Failed to load file '${ffb_real_fname}' from '${ffb_repository}' using proxy '${proxy_url}'.  ${curl_resp}
+        </detail>
+        </OSGTestResult>" > otrb_output.xml
+        warn "Failed to load file '${ffb_real_fname}' from '${ffb_repository}'."
+
+        if [ -f otr_outlist.list ]; then
+            chmod u+w otr_outlist.list
+        else
+            touch otr_outlist.list
+        fi
+        cat otrb_output.xml >> otr_outlist.list
+        echo "<?xml version=\"1.0\"?>" > otrx_output.xml
+        cat otrb_output.xml >> otrx_output.xml
+        rm -f otrb_output.xml
+        chmod a-w otr_outlist.list
+    fi
+    return ${curl_retval}
+}
+
+fetch_file_base() {
+    # Perform the file download and corresponding action (untar, execute, ...)
+    ffb_id="$1"
+    ffb_target_fname="$2"
+    ffb_real_fname="$3"
+    ffb_file_type="$4"
+    ffb_config_out="$5"
+    ffb_period=$6
+    # condor cron prefix, used only for periodic executables
+    ffb_cc_prefix="$7"
+
+    ffb_work_dir="$(get_work_dir "${ffb_id}")"
+
+    ffb_repository="$(get_repository_url "${ffb_id}")"
+
+    ffb_tmp_outname="${ffb_work_dir}/${ffb_real_fname}"
+    ffb_outname="${ffb_work_dir}/${ffb_target_fname}"
+
+    # Create a dummy default in case something goes wrong
+    # cannot use error_*.sh helper functions
+    # may not have been loaded yet
+    have_dummy_otrx=1
+    echo "<?xml version=\"1.0\"?>
+    <OSGTestResult id=\"fetch_file_base\" version=\"4.3.1\">
+    <operatingenvironment>
+    <env name=\"cwd\">${PWD}</env>
+    </operatingenvironment>
+    <test>
+    <cmd>Unknown</cmd>
+    <tStart>$(date +%Y-%m-%dT%H:%M:%S%:z)</tStart>
+    <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
+    </test>
+    <result>
+    <status>ERROR</status>
+    <metric name=\"failure\" ts=\"$(date +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Unknown</metric>
+    <metric name=\"source_type\" ts=\"$(date +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
+    </result>
+    <detail>
+    An unknown error occurred.
+    </detail>
+    </OSGTestResult>" > otrx_output.xml
+    user_agent="glidein/${glidein_entry}/${condorg_schedd}/${condorg_cluster}.${condorg_subcluster}/${client_name}"
+    ffb_url="${ffb_repository}/${ffb_real_fname}"
+    curl_version=$(curl --version | head -1 )
+    wget_version=$(wget --version | head -1 )
+    #old wget command:
+    #wget --user-agent="wget/glidein/$glidein_entry/$condorg_schedd/$condorg_cluster.$condorg_subcluster/$client_name" "$ffb_nocache_str" -q  -O "$ffb_tmp_outname" "$ffb_repository/$ffb_real_fname"
+    #equivalent to:
+    #wget ${ffb_url} --user-agent=${user_agent} -q  -O "${ffb_tmp_outname}" "${ffb_nocache_str}"
+    #with env http_proxy=$proxy_url set if proxy_url != "None"
+    #
+    #construct curl equivalent so we can try either
+
+    wget_args=("${ffb_url}" "--user-agent" "wget/${user_agent}"  "--quiet"  "--output-document" "${ffb_tmp_outname}" )
+    curl_args=("${ffb_url}" "--user-agent" "curl/${user_agent}" "--silent"  "--show-error" "--output" "${ffb_tmp_outname}")
+
+    if [ "${ffb_file_type}" = "nocache" ]; then
+        if [ "${curl_version}" != "" ]; then
+            curl_args+=("--header")
+            curl_args+=("'Cache-Control: no-cache'")
+        fi
+        if [ "${wget_version}" != "" ]; then
+            if wget --help | grep -q "\-\-no-cache "; then
+                wget_args+=("--no-cache")
+            elif wget --help |grep -q "\-\-cache="; then
+                wget_args+=("--cache=off")
+            else
+                warn "wget ${wget_version} cannot disable caching"
+            fi
+         fi
+    fi
+
+    if [ "${proxy_url}" != "None" ];then
+        if [ "${curl_version}" != "" ]; then
+            curl_args+=("--proxy")
+            curl_args+=("${proxy_url}")
+        fi
+        if [ "${wget_version}" != "" ]; then
+            #these two arguments have to be last as coded, put any future
+            #wget args earlier in wget_args array
+            wget_args+=("--proxy")
+            wget_args+=("${proxy_url}")
+        fi
+    fi
+
+    fetch_completed=1
+    if [ ${fetch_completed} -ne 0 ] && [ "${wget_version}" != "" ]; then
+        perform_wget "${wget_args[@]}"
+        fetch_completed=$?
+    fi
+    if [ ${fetch_completed} -ne 0 ] && [ "${curl_version}" != "" ]; then
+        perform_curl "${curl_args[@]}"
+        fetch_completed=$?
+    fi
+
+    if [ ${fetch_completed} -ne 0 ]; then
+        return ${fetch_completed}
+    fi
+
+    # check signature
+    if ! check_file_signature "${ffb_id}" "${ffb_real_fname}"; then
+        # error already displayed inside the function
+        return 1
+    fi
+
+    # rename it to the correct final name, if needed
+    if [ "${ffb_tmp_outname}" != "${ffb_outname}" ]; then
+        if ! mv "${ffb_tmp_outname}" "${ffb_outname}"; then
+            warn "Failed to rename ${ffb_tmp_outname} into ${ffb_outname}"
+            return 1
+        fi
+    fi
+
+    # if executable, execute
+    if [[ "${ffb_file_type}" = "exec" || "${ffb_file_type}" = "exec:"* ]]; then
+        if ! chmod u+x "${ffb_outname}"; then
+            warn "Error making '${ffb_outname}' executable"
+            return 1
+        fi
+        if [ "${ffb_id}" = "main" ] && [ "${ffb_target_fname}" = "${last_script}" ]; then  # last_script global for simplicity
+            echo "Skipping last script ${last_script}" 1>&2
+        elif [[ "${ffb_target_fname}" = "cvmfs_umount.sh" ]] || [[ -n "${cleanup_script}" && "${ffb_target_fname}" = "${cleanup_script}" ]]; then  # cleanup_script global for simplicity
+            # TODO: temporary OR checking for cvmfs_umount.sh; to be removed after Bruno's ticket on cleanup [#25073]
+            echo "Skipping cleanup script ${ffb_outname} (${cleanup_script})" 1>&2
+            cp "${ffb_outname}" "$gwms_exec_dir/cleanup/${ffb_target_fname}"
+            chmod a+x "${gwms_exec_dir}/cleanup/${ffb_target_fname}"
+        else
+            echo "Executing (flags:${ffb_file_type#exec}) ${ffb_outname}"
+            # have to do it here, as this will be run before any other script
+            chmod u+rx "${main_dir}"/error_augment.sh
+
+            # the XML file will be overwritten now, and hopefully not an error situation
+            have_dummy_otrx=0
+            "${main_dir}"/error_augment.sh -init
+            START=$(date +%s)
+            if [[ "${ffb_file_type}" = "exec:s" ]]; then
+                "${main_dir}/singularity_wrapper.sh" "${ffb_outname}" glidein_config "${ffb_id}"
+            else
+                "${ffb_outname}" glidein_config "${ffb_id}"
+            fi
+            ret=$?
+            END=$(date +%s)
+            "${main_dir}"/error_augment.sh -process ${ret} "${ffb_id}/${ffb_target_fname}" "${PWD}" "${ffb_outname} glidein_config" "${START}" "${END}" #generating test result document
+            "${main_dir}"/error_augment.sh -concat
+            if [ ${ret} -ne 0 ]; then
+                echo "=== Validation error in ${ffb_outname} ===" 1>&2
+                warn "Error running '${ffb_outname}'"
+                < otrx_output.xml awk 'BEGIN{fr=0;}/<[/]detail>/{fr=0;}{if (fr==1) print $0}/<detail>/{fr=1;}' 1>&2
+                return 1
+            else
+                # If ran successfully and periodic, schedule to execute with schedd_cron
+                echo "=== validation OK in ${ffb_outname} (${ffb_period}) ===" 1>&2
+                if [ "${ffb_period}" -gt 0 ]; then
+                    add_periodic_script "${main_dir}/script_wrapper.sh" "${ffb_period}" "${work_dir}" "${ffb_outname}" glidein_config "${ffb_id}" "${ffb_cc_prefix}"
+                fi
+            fi
+        fi
+    elif [ "${ffb_file_type}" = "wrapper" ]; then
+        echo "${ffb_outname}" >> "${wrapper_list}"
+    elif [ "${ffb_file_type}" = "untar" ]; then
+        ffb_short_untar_dir="$(get_untar_subdir "${ffb_id}" "${ffb_target_fname}")"
+        ffb_untar_dir="${ffb_work_dir}/${ffb_short_untar_dir}"
+        START=$(date +%s)
+        (mkdir "${ffb_untar_dir}" && cd "${ffb_untar_dir}" && tar -xmzf "${ffb_outname}") 1>&2
+        ret=$?
+        if [ ${ret} -ne 0 ]; then
+            "${main_dir}"/error_augment.sh -init
+            "${main_dir}"/error_gen.sh -error "tar" "Corruption" "Error untarring '${ffb_outname}'" "file" "${ffb_outname}" "source_type" "${cfs_id}"
+            "${main_dir}"/error_augment.sh  -process ${cfs_rc} "tar" "${PWD}" "mkdir ${ffb_untar_dir} && cd ${ffb_untar_dir} && tar -xmzf ${ffb_outname}" "${START}" "$(date +%s)"
+            "${main_dir}"/error_augment.sh -concat
+            warn "Error untarring '${ffb_outname}'"
+            return 1
+        fi
+    fi
+
+    if [ "${ffb_config_out}" != "FALSE" ]; then
+        ffb_prefix="$(get_prefix "${ffb_id}")"
+        if [ "${ffb_file_type}" = "untar" ]; then
+            # when untaring the original file is less interesting than the untar dir
+            if ! gconfig_add "${ffb_prefix}${ffb_config_out}" "${ffb_untar_dir}"; then
+                glidein_exit 1
+            fi
+        else
+            if ! gconfig_add "${ffb_prefix}${ffb_config_out}" "${ffb_outname}"; then
+                glidein_exit 1
+            fi
+        fi
+    fi
+
+    if [ "${have_dummy_otrx}" -eq 1 ]; then
+        # no one should really look at this file, but just to avoid confusion
+        echo "<?xml version=\"1.0\"?>
+        <OSGTestResult id=\"fetch_file_base\" version=\"4.3.1\">
+        <operatingenvironment>
+        <env name=\"cwd\">${PWD}</env>
+        </operatingenvironment>
+        <test>
+        <cmd>Unknown</cmd>
+        <tStart>$(date +%Y-%m-%dT%H:%M:%S%:z)</tStart>
+        <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
+        </test>
+        <result>
+        <status>OK</status>
+        </result>
+        </OSGTestResult>" > otrx_output.xml
+    fi
+
+   return 0
+}
+
+# Adds $1 to GWMS_PATH and update PATH
+add_to_path() {
+    logdebug "Adding to GWMS_PATH: $1"
+    local old_path=":${PATH%:}:"
+    old_path="${old_path//:$GWMS_PATH:/}"
+    local old_gwms_path=":${GWMS_PATH%:}:"
+    old_gwms_path="${old_gwms_path//:$1:/}"
+    old_gwms_path="${1%:}:${old_gwms_path#:}"
+    export GWMS_PATH="${old_gwms_path%:}"
+    old_path="${GWMS_PATH}:${old_path#:}"
+    export PATH="${old_path%:}"
+}
+
+fixup_condor_dir() {
+    # All files in the native condor tarballs have a directory like condor-9.0.11-1-x86_64_CentOS7-stripped
+    # However the (not used anymore) gwms create_condor_tarball removes that dir
+    # Here we remove that dir as well to allow factory ops to use native condor tarballs
+
+    # Check if the condor dir has only one subdir, the one like "condor-9.0.11-1-x86_64_CentOS7-stripped"
+    # See https://stackoverflow.com/questions/32429333/how-to-test-if-a-linux-directory-contain-only-one-subdirectory-and-no-other-file
+    if [ $(find "${gs_id_work_dir}/condor" -maxdepth 1 -type d -printf 1 | wc -m) -eq 2 ]; then
+        echo "Fixing directory structure of condor tarball"
+        mv "${gs_id_work_dir}"/condor/condor*/* "${gs_id_work_dir}"/condor > /dev/null
+    else
+        echo "Condor tarball does not need to be fixed"
+    fi
+}
+
+# default IFS, to protect against unusual environment, better than "unset IFS" because works with restoring old one
+IFS=$' \t\n'
+
+global_args="$*"
+# GWMS_STARTUP_SCRIPT=$0
+GWMS_STARTUP_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+GWMS_PATH=""
+# Relative to the work directory (GWMS_DIR, gwms_lib_dir, gwms_bin_dir and gwms_exec_dir will be the absolute paths)
+# bin (utilities), lib (libraries), exec (aux scripts to be executed/sourced, e.g. pre-job)
+GWMS_SUBDIR=".gwms.d"
+
+export LANG=C
+
+# General options
+GWMS_MULTIUSER_GLIDEIN=
+# Set GWMS_MULTIUSER_GLIDEIN if the Glidein may spawn processes (for jobs) as a different user.
+# This will prepare the glidein, e.g. setting to 777 the permission of TEMP directories
+# This should never happen only when using GlExec. Not in Singularity, not w/o sudo mechanisms.
+# Comment the following line if GlExec or similar will not be used
+#GWMS_MULTIUSER_GLIDEIN=true
+# Default GWMS log server
+GWMS_LOGSERVER_ADDRESS='https://fermicloud152.fnal.gov/log'
+
+GWMS_MULTIGLIDEIN_CHILDS=
+
+# params will contain the full list of parameters
+# -param_XXX YYY will become "XXX YYY"
+# TODO: can use an array instead?
+params=""
+
+while [ $# -gt 0 ]
+do case "$1" in
+    -factory)    glidein_factory="$2";;
+    -name)       glidein_name="$2";;
+    -entry)      glidein_entry="$2";;
+    -clientname) client_name="$2";;
+    -clientgroup) client_group="$2";;
+    -web)        repository_url="$2";;
+    -proxy)      proxy_url="$2";;
+    -dir)        work_dir="$2";;
+    -sign)       sign_id="$2";;
+    -signtype)   sign_type="$2";;
+    -signentry)  sign_entry_id="$2";;
+    -cluster)    condorg_cluster="$2";;
+    -subcluster) condorg_subcluster="$2";;
+    -submitcredid) glidein_cred_id="$2";;
+    -schedd)     condorg_schedd="$2";;
+    -descript)   descript_file="$2";;
+    -descriptentry)   descript_entry_file="$2";;
+    -clientweb)             client_repository_url="$2";;
+    -clientwebgroup)        client_repository_group_url="$2";;
+    -clientsign)            client_sign_id="$2";;
+    -clientsigntype)        client_sign_type="$2";;
+    -clientsigngroup)       client_sign_group_id="$2";;
+    -clientdescript)        client_descript_file="$2";;
+    -clientdescriptgroup)   client_descript_group_file="$2";;
+    -slotslayout)           slots_layout="$2";;
+    -v)          operation_mode="$2";;
+    -multiglidein)  multi_glidein="$2";;
+    -multirestart)  multi_glidein_restart="$2";;
+    -param_*)    params="$params $(echo "$1" | awk '{print substr($0,8)}') $2";;
+    *)  (warn "Unknown option $1"; usage) 1>&2; exit 1
+esac
+shift 2
+done
+
+# make sure we have a valid slots_layout
+if (echo "x${slots_layout}" | grep -i fixed) >/dev/null 2>&1 ; then
+    slots_layout="fixed"
+else
+    slots_layout="partitionable"
+fi
+
+####################################
+# Cleaup, print out message and exit
+work_dir_created=0
+glide_local_tmp_dir_created=0
 
 ################
 # Parse and verify arguments
@@ -786,17 +1433,17 @@ fi
 repository_entry_url="${repository_url}/entry_${glidein_entry}"
 
 if [ -z "${proxy_url}" ]; then
-  proxy_url="None"
+    proxy_url="None"
 fi
 
 if [ "${proxy_url}" = "OSG" ]; then
-  if [ -z "${OSG_SQUID_LOCATION}" ]; then
-     # if OSG does not define a Squid, then don't use any
-     proxy_url="None"
-     warn "OSG_SQUID_LOCATION undefined, not using any Squid URL" 1>&2
-  else
-     proxy_url="$(echo "${OSG_SQUID_LOCATION}" | awk -F ':' '{if ($2 =="") {print $1 ":3128"} else {print $0}}')"
-  fi
+    if [ -z "${OSG_SQUID_LOCATION}" ]; then
+        # if OSG does not define a Squid, then don't use any
+        proxy_url="None"
+        warn "OSG_SQUID_LOCATION undefined, not using any Squid URL" 1>&2
+    else
+        proxy_url="$(echo "${OSG_SQUID_LOCATION}" | awk -F ':' '{if ($2 =="") {print $1 ":3128"} else {print $0}}')"
+    fi
 fi
 
 if [ -z "${sign_id}" ]; then
@@ -819,80 +1466,34 @@ if [ "${sign_type}" != "sha1" ]; then
 fi
 
 if [ -n "${client_repository_url}" ]; then
-  # client data is optional, user url as a switch
-  if [ -z "${client_sign_type}" ]; then
-      client_sign_type="sha1"
-  fi
-
-  if [ "${client_sign_type}" != "sha1" ]; then
-    warn "Unsupported clientsigntype ${client_sign_type} found."
-    usage
-  fi
-
-  if [ -z "${client_descript_file}" ]; then
-    warn "Missing client descript fname."
-    usage
-  fi
-
-  if [ -n "${client_repository_group_url}" ]; then
-      # client group data is optional, user url as a switch
-      if [ -z "${client_group}" ]; then
-          warn "Missing client group name."
-          usage
-      fi
-
-      if [ -z "${client_descript_group_file}" ]; then
-          warn "Missing client descript fname for group."
-          usage
-      fi
-  fi
-fi
-
-md5wrapper() {
-    # $1 - file name
-    # $2 - option (quiet)
-    # Result returned on stdout
-    local ERROR_RESULT="???"
-    local ONLY_SUM
-    if [ "x$2" = "xquiet" ]; then
-        ONLY_SUM=yes
+    # client data is optional, user url as a switch
+    if [ -z "${client_sign_type}" ]; then
+        client_sign_type="sha1"
     fi
-    local executable=md5sum
-    if which ${executable} 1>/dev/null 2>&1; then
-        [ -n "${ONLY_SUM}" ] && executable="md5sum \"$1\" | cut -d ' ' -f 1" ||  executable="md5sum \"$1\""
-    else
-        executable=md5
-        if ! which ${executable} 1>/dev/null 2>&1; then
-            echo "${ERROR_RESULT}"
-            warn "md5wrapper error: can't neither find md5sum nor md5"
-            return 1
+
+    if [ "${client_sign_type}" != "sha1" ]; then
+        warn "Unsupported clientsigntype ${client_sign_type} found."
+        usage
+    fi
+
+    if [ -z "${client_descript_file}" ]; then
+        warn "Missing client descript fname."
+        usage
+    fi
+
+    if [ -n "${client_repository_group_url}" ]; then
+        # client group data is optional, user url as a switch
+        if [ -z "${client_group}" ]; then
+            warn "Missing client group name."
+            usage
         fi
-        [ -n "${ONLY_SUM}" ] && executable="md5 -q \"$1\"" || executable="md5 \"$1\""
-    fi
-    local res
-    # Flagged by some checkers but OK
-    if ! res="$(eval "${executable}" 2>/dev/null)"; then
-        echo "${ERROR_RESULT}"
-        warn "md5wrapper error: can't calculate md5sum using ${executable}"
-        return 1
-    fi
-    echo "${res}"
-}
 
-# Generate directory ID
-dir_id() {
-    # create an id to distinguish the directories when preserved
-    [[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,nocleanup,* ]] && return
-    local dir_id=""
-    local tmp="${repository_url%%.*}"
-    tmp="${tmp#*//}"
-    dir_id="${tmp: -4}"
-    tmp="${client_repository_url%%.*}"
-    tmp="${tmp#*//}"
-    dir_id="${dir_id}${tmp: -4}"
-    [[ -z "${dir_id}" ]] && dir_id='debug'
-    echo "${dir_id}_"
-}
+        if [ -z "${client_descript_group_file}" ]; then
+            warn "Missing client descript fname for group."
+            usage
+        fi
+    fi
+fi
 
 # Generate glidein UUID
 if command -v uuidgen >/dev/null 2>&1; then
@@ -945,16 +1546,16 @@ echo
 echo "Running on $(uname -n)"
 echo "System: $(uname -a)"
 if [ -e '/etc/redhat-release' ]; then
- echo "Release: $(cat /etc/redhat-release 2>&1)"
+    echo "Release: $(cat /etc/redhat-release 2>&1)"
 fi
 echo "As: $(id)"
 echo "PID: $$"
 echo
 
 if [ ${set_debug} -ne 0 ]; then
-  echo "------- Initial environment ---------------"  1>&2
-  env 1>&2
-  echo "------- =================== ---------------" 1>&2
+    echo "------- Initial environment ---------------"  1>&2
+    env 1>&2
+    echo "------- =================== ---------------" 1>&2
 fi
 
 # Before anything else, spawn multiple glideins and wait, if asked to do so
@@ -984,45 +1585,34 @@ fi
 if [ -r "${OSG_GRID}/setup.sh" ]; then
     . "${OSG_GRID}/setup.sh"
 else
-  if [ -r "${GLITE_LOCAL_CUSTOMIZATION_DIR}/cp_1.sh" ]; then
-    . "${GLITE_LOCAL_CUSTOMIZATION_DIR}/cp_1.sh"
-  fi
+    if [ -r "${GLITE_LOCAL_CUSTOMIZATION_DIR}/cp_1.sh" ]; then
+        . "${GLITE_LOCAL_CUSTOMIZATION_DIR}/cp_1.sh"
+    fi
 fi
 
 if [ -z "${GLOBUS_PATH}" ]; then
-  if [ -z "${GLOBUS_LOCATION}" ]; then
-    # if GLOBUS_LOCATION not defined, try to guess it
-    if [ -r "/opt/globus/etc/globus-user-env.sh" ]; then
-       GLOBUS_LOCATION=/opt/globus
-    elif  [ -r "/osgroot/osgcore/globus/etc/globus-user-env.sh" ]; then
-       GLOBUS_LOCATION=/osgroot/osgcore/globus
-    else
-       warn "GLOBUS_LOCATION not defined and could not guess it."
-       warn "Looked in:"
-       warn ' /opt/globus/etc/globus-user-env.sh'
-       warn ' /osgroot/osgcore/globus/etc/globus-user-env.sh'
-       warn 'Continuing like nothing happened'
+    if [ -z "${GLOBUS_LOCATION}" ]; then
+        # if GLOBUS_LOCATION not defined, try to guess it
+        if [ -r "/opt/globus/etc/globus-user-env.sh" ]; then
+            GLOBUS_LOCATION=/opt/globus
+        elif  [ -r "/osgroot/osgcore/globus/etc/globus-user-env.sh" ]; then
+            GLOBUS_LOCATION=/osgroot/osgcore/globus
+        else
+            warn "GLOBUS_LOCATION not defined and could not guess it."
+            warn "Looked in:"
+            warn ' /opt/globus/etc/globus-user-env.sh'
+            warn ' /osgroot/osgcore/globus/etc/globus-user-env.sh'
+            warn 'Continuing like nothing happened'
+        fi
     fi
-  fi
 
-  if [ -r "${GLOBUS_LOCATION}/etc/globus-user-env.sh" ]; then
-    . "${GLOBUS_LOCATION}/etc/globus-user-env.sh"
-  else
-    warn "GLOBUS_PATH not defined and ${GLOBUS_LOCATION}/etc/globus-user-env.sh does not exist."
-    warn 'Continuing like nothing happened'
-  fi
+    if [ -r "${GLOBUS_LOCATION}/etc/globus-user-env.sh" ]; then
+        . "${GLOBUS_LOCATION}/etc/globus-user-env.sh"
+    else
+        warn "GLOBUS_PATH not defined and ${GLOBUS_LOCATION}/etc/globus-user-env.sh does not exist."
+        warn 'Continuing like nothing happened'
+    fi
 fi
-
-set_proxy_fullpath() {
-    # Set the X509_USER_PROXY path to full path to the file
-    if fullpath="$(readlink -f "${X509_USER_PROXY}")"; then
-        echo "Setting X509_USER_PROXY ${X509_USER_PROXY} to canonical path ${fullpath}" 1>&2
-        export X509_USER_PROXY="${fullpath}"
-    else
-        echo "Unable to get canonical path for X509_USER_PROXY, using ${X509_USER_PROXY}" 1>&2
-    fi
-}
-
 
 [ -n "${X509_USER_PROXY}" ] && set_proxy_fullpath
 
@@ -1200,6 +1790,7 @@ mv "${start_dir}/url_dirs.desc" .
 #fi
 
 # Extract and source all the data contained at the end of this script as tarball
+# the below function also sources add_config_line.source; make sure that gconfig_xxx are invoked after this line
 extract_all_data
 
 wrapper_list="${PWD}/wrapper_list.lst"
@@ -1279,600 +1870,8 @@ log_init "${glidein_uuid}" "${work_dir}"
 rm -rf tokens.tgz url_dirs.desc tokens
 log_setup "${glidein_config}"
 
-############################################
-# get the proper descript file based on id
-# Arg: type (main/entry/client/client_group)
-get_repository_url() {
-    case "$1" in
-        main) echo "${repository_url}";;
-        entry) echo "${repository_entry_url}";;
-        client) echo "${client_repository_url}";;
-        client_group) echo "${client_repository_group_url}";;
-        *) echo "[get_repository_url] Invalid id: $1" 1>&2
-           return 1
-           ;;
-    esac
-}
-
-#####################
-# Check signature
-check_file_signature() {
-    cfs_id="$1"
-    cfs_fname="$2"
-
-    cfs_work_dir="$(get_work_dir "${cfs_id}")"
-
-    cfs_desc_fname="${cfs_work_dir}/${cfs_fname}"
-    cfs_signature="${cfs_work_dir}/signature.sha1"
-
-    if [ "${check_signature}" -gt 0 ]; then # check_signature is global for simplicity
-        tmp_signname="${cfs_signature}_$$_$(date +%s)_${RANDOM}"
-        if ! grep " ${cfs_fname}$" "${cfs_signature}" > "${tmp_signname}"; then
-            rm -f "${tmp_signname}"
-            echo "No signature for ${cfs_desc_fname}." 1>&2
-        else
-            (cd "${cfs_work_dir}" && sha1sum -c "${tmp_signname}") 1>&2
-            cfs_rc=$?
-            if [ ${cfs_rc} -ne 0 ]; then
-                "${main_dir}"/error_augment.sh -init
-                "${main_dir}"/error_gen.sh -error "check_file_signature" "Corruption" "File $cfs_desc_fname is corrupted." "file" "${cfs_desc_fname}" "source_type" "${cfs_id}"
-                "${main_dir}"/error_augment.sh  -process ${cfs_rc} "check_file_signature" "${PWD}" "sha1sum -c ${tmp_signname}" "$(date +%s)" "(date +%s)"
-                "${main_dir}"/error_augment.sh -concat
-                warn "File ${cfs_desc_fname} is corrupted."
-                rm -f "${tmp_signname}"
-                return 1
-            fi
-            rm -f "${tmp_signname}"
-            echo "Signature OK for ${cfs_id}:${cfs_fname}." 1>&2
-        fi
-    fi
-    return 0
-}
-
-#####################
-# Untar support func
-
-get_untar_subdir() {
-    gus_id="$1"
-    gus_fname="$2"
-
-    gus_prefix="$(get_prefix "${gus_id}")"
-    gus_config_cfg="${gus_prefix}UNTAR_CFG_FILE"
-
-    gus_config_file="$(grep "^${gus_config_cfg} " glidein_config | cut -d ' ' -f 2-)"
-    if [ -z "${gus_config_file}" ]; then
-        warn "Error, cannot find '${gus_config_cfg}' in glidein_config."
-        glidein_exit 1
-    fi
-
-    gus_dir="$(grep -i "^${gus_fname} " "${gus_config_file}" | cut -s -f 2-)"
-    if [ -z "${gus_dir}" ]; then
-        warn "Error, untar dir for '${gus_fname}' cannot be empty."
-        glidein_exit 1
-    fi
-
-    echo "${gus_dir}"
-    return 0
-}
-
-#####################
-# Periodic execution support function and global variable
+# global variable for periodic execution support
 add_startd_cron_counter=0
-add_periodic_script() {
-    # schedules a script for periodic execution using startd_cron
-    # parameters: wrapper full path, period, cwd, executable path (from cwd),
-    # config file path (from cwd), ID
-    # global variable: add_startd_cron_counter
-    #TODO: should it allow for variable number of parameters?
-    local include_fname=condor_config_startd_cron_include
-    local s_wrapper="$1"
-    local s_period_sec="${2}s"
-    local s_cwd="$3"
-    local s_fname="$4"
-    local s_config="$5"
-    local s_ffb_id="$6"
-    local s_cc_prefix="$7"
-    if [ ${add_startd_cron_counter} -eq 0 ]; then
-        # Make sure that no undesired file is there when called for first cron
-        rm -f ${include_fname}
-    fi
-
-    let add_startd_cron_counter=add_startd_cron_counter+1
-    local name_prefix=GLIDEIN_PS_
-    local s_name="${name_prefix}${add_startd_cron_counter}"
-
-    # Append the following to the startd configuration
-    # Instead of Periodic and Kill wait for completion:
-    # STARTD_CRON_DATE_MODE = WaitForExit
-    cat >> ${include_fname} << EOF
-STARTD_CRON_JOBLIST = \$(STARTD_CRON_JOBLIST) ${s_name}
-STARTD_CRON_${s_name}_MODE = Periodic
-STARTD_CRON_${s_name}_KILL = True
-STARTD_CRON_${s_name}_PERIOD = ${s_period_sec}
-STARTD_CRON_${s_name}_EXECUTABLE = ${s_wrapper}
-STARTD_CRON_${s_name}_ARGS = ${s_config} ${s_ffb_id} ${s_name} ${s_fname} ${s_cc_prefix}
-STARTD_CRON_${s_name}_CWD = ${s_cwd}
-STARTD_CRON_${s_name}_SLOTS = 1
-STARTD_CRON_${s_name}_JOB_LOAD = 0.01
-EOF
-    # NOPREFIX is a keyword for not setting the prefix for all condor attributes
-    [ "xNOPREFIX" != "x${s_cc_prefix}" ] && echo "STARTD_CRON_${s_name}_PREFIX = ${s_cc_prefix}" >> ${include_fname}
-    add_config_line "GLIDEIN_condor_config_startd_cron_include" "${include_fname}"
-    add_config_line "# --- Lines starting with ${s_cc_prefix} are from periodic scripts ---"
-}
-
-#####################
-# Fetch a single file
-#
-# Check cWDictFile/FileDictFile for the number and type of parameters (has to be consistent)
-fetch_file_regular() {
-    fetch_file "$1" "$2" "$2" "regular" 0 "GLIDEIN_PS_" "TRUE" "FALSE"
-}
-
-fetch_file() {
-    # custom_scripts parameters format is set in the GWMS configuration (creation/lib)
-    # 1. ID
-    # 2. target fname
-    # 3. real fname
-    # 4. file type (regular, exec, exec:s, untar, nocache)
-    # 5. period (0 if not a periodic file)
-    # 6. periodic scripts prefix
-    # 7. config check TRUE,FALSE
-    # 8. config out TRUE,FALSE
-    # The above is the most recent list, below some adaptations for different versions
-    if [ $# -gt 8 ]; then
-        # For compatibility w/ future versions (add new parameters at the end)
-        echo "More then 8 arguments, considering the first 8 ($#/${ifs_str}): $*" 1>&2
-    elif [ $# -ne 8 ]; then
-        if [ $# -eq 7 ]; then
-            #TODO: remove in version 3.3
-            # For compatibility with past versions (old file list formats)
-            # 3.2.13 and older: prefix (par 6) added in #12705, 3.2.14?
-            # 3.2.10 and older: period (par 5) added:  fetch_file_try "$1" "$2" "$3" "$4" 0 "GLIDEIN_PS_" "$5" "$6"
-            if ! fetch_file_try "$1" "$2" "$3" "$4" "$5" "GLIDEIN_PS_" "$6" "$7"; then
-                glidein_exit 1
-            fi
-            return 0
-        fi
-        if [ $# -eq 6 ]; then
-            # added to maintain compatibility with older (3.2.10) file list format
-            #TODO: remove in version 3.3
-            if ! fetch_file_try "$1" "$2" "$3" "$4" 0 "GLIDEIN_PS_" "$5" "$6"; then
-                glidein_exit 1
-            fi
-            return 0
-        fi
-        local ifs_str
-        printf -v ifs_str '%q' "${IFS}"
-        warn "Not enough arguments in fetch_file, 8 expected ($#/${ifs_str}): $*"
-        glidein_exit 1
-    fi
-
-    if ! fetch_file_try "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8"; then
-        glidein_exit 1
-    fi
-    return 0
-}
-
-fetch_file_try() {
-    # Verifies if the file should be downloaded and acted upon (extracted, executed, ...) or not
-    # There are 2 mechanisms to control the download
-    # 1. tar files have the attribute "cond_attr" that is a name of a variable in glidein_config.
-    #    if the named variable has value 1, then the file is downloaded. TRUE (default) means always download
-    #    even if the mechanism is generic, there is no way to specify "cond_attr" for regular files in the configuration
-    # 2. if the file name starts with "gconditional_AAA_", the file is downloaded only if a variable GLIDEIN_USE_AAA
-    #    exists in glidein_config and the value is not empty
-    # Both conditions are checked. If either one fails the file is not downloaded
-    fft_id="$1"
-    fft_target_fname="$2"
-    fft_real_fname="$3"
-    fft_file_type="$4"
-    fft_period="$5"
-    fft_cc_prefix="$6"
-    fft_config_check="$7"
-    fft_config_out="$8"
-
-    if [[ "${fft_config_check}" != "TRUE" ]]; then
-        # TRUE is a special case, always downloaded and processed
-        local fft_get_ss
-        fft_get_ss=$(grep -i "^${fft_config_check} " glidein_config | cut -d ' ' -f 2-)
-        # Stop download and processing if the cond_attr variable is not defined or has a value different from 1
-        [[ "${fft_get_ss}" != "1" ]] && return 0
-        # TODO: what if fft_get_ss is not 1? nothing, still skip the file?
-    fi
-
-    local fft_base_name fft_condition_attr fft_condition_attr_val
-    fft_base_name=$(basename "${fft_real_fname}")
-    if [[ "${fft_base_name}" = gconditional_* ]]; then
-        fft_condition_attr="${fft_base_name#gconditional_}"
-        fft_condition_attr="GLIDEIN_USE_${fft_condition_attr%%_*}"
-        fft_condition_attr_val=$(grep -i "^${fft_condition_attr} " glidein_config | cut -d ' ' -f 2-)
-        # if the variable fft_condition_attr is not defined or empty, do not download
-        [[ -z "${fft_condition_attr_val}" ]] && return 0
-    fi
-
-    fetch_file_base "${fft_id}" "${fft_target_fname}" "${fft_real_fname}" "${fft_file_type}" "${fft_config_out}" "${fft_period}" "${fft_cc_prefix}"
-    # returning the exit code of fetch_file_base
-}
-
-perform_wget() {
-    wget_args=("$@")
-    arg_len="${#wget_args[@]}"
-    ffb_url="${wget_args[0]}"
-    ffb_repository=$(dirname "${ffb_url}")
-    ffb_real_fname=$(basename "${ffb_url}")
-    proxy_url="None"
-    for ((i=0; i<arg_len; i++));
-    do
-        if [ "${wget_args[${i}]}" = "--output-document" ]; then
-            ffb_tmp_outname=${wget_args[${i}+1]}
-        fi
-        if [ "${wget_args[${i}]}" = "--proxy" ]; then
-            proxy_url=${wget_args[${i}+1]}
-        fi
-    done
-    START=$(date +%s)
-    if [ "${proxy_url}" != "None" ]; then
-        wget_args=(${wget_args[@]:0:${arg_len}-2})
-        wget_cmd=$(echo "env http_proxy=${proxy_url} wget" "${wget_args[@]}"| sed 's/"/\\\"/g')
-        wget_resp=$(env http_proxy="${proxy_url}" wget "${wget_args[@]}" 2>&1)
-        wget_retval=$?
-    else
-        wget_cmd=$(echo "wget" "${wget_args[@]}"| sed 's/"/\\\"/g')
-        wget_resp=$(wget "${wget_args[@]}" 2>&1)
-        wget_retval=$?
-    fi
-
-    if [ ${wget_retval} -ne 0 ]; then
-        wget_version=$(wget --version 2>&1 | head -1)
-        warn "${wget_cmd} failed. version:${wget_version}  exit code ${wget_retval} stderr: ${wget_resp}"
-        # cannot use error_*.sh helper functions
-        # may not have been loaded yet, and wget fails often
-        echo "<OSGTestResult id=\"perform_wget\" version=\"4.3.1\">
-  <operatingenvironment>
-    <env name=\"cwd\">${PWD}</env>
-    <env name=\"uname\">$(uname -a)</env>
-    <env name=\"release\">$(cat /etc/system-release)</env>
-    <env name=\"wget_version\">${wget_version}</env>
-  </operatingenvironment>
-  <test>
-    <cmd>${wget_cmd}</cmd>
-    <tStart>$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
-    <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
-  </test>
-  <result>
-    <status>ERROR</status>
-    <metric name=\"failure\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Network</metric>
-    <metric name=\"URL\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_url}</metric>
-    <metric name=\"http_proxy\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${proxy_url}</metric>
-    <metric name=\"source_type\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
-  </result>
-  <detail>
-  Failed to load file '${ffb_real_fname}' from '${ffb_repository}' using proxy '${proxy_url}'.  ${wget_resp}
-  </detail>
-</OSGTestResult>" > otrb_output.xml
-        warn "Failed to load file '${ffb_real_fname}' from '${ffb_repository}'."
-
-        if [ -f otr_outlist.list ]; then
-            chmod u+w otr_outlist.list
-        else
-            touch otr_outlist.list
-        fi
-        cat otrb_output.xml >> otr_outlist.list
-        echo "<?xml version=\"1.0\"?>" > otrx_output.xml
-        cat otrb_output.xml >> otrx_output.xml
-        rm -f otrb_output.xml
-        chmod a-w otr_outlist.list
-    fi
-    return ${wget_retval}
-}
-
-perform_curl() {
-    curl_args=("$@")
-    arg_len="${#curl_args[@]}"
-    ffb_url="${curl_args[0]}"
-    ffb_repository="$(dirname "${ffb_url}")"
-    ffb_real_fname="$(basename "${ffb_url}")"
-    for ((i=0; i<arg_len; i++));
-    do
-        if [ "${curl_args[${i}]}" = "--output" ]; then
-            ffb_tmp_outname="${curl_args[${i}+1]}"
-        fi
-        if [ "${curl_args[${i}]}" = "--proxy" ]; then
-            proxy_url="${curl_args[${i}+1]}"
-        fi
-    done
-
-    START="$(date +%s)"
-    curl_cmd="$(echo "curl" "${curl_args[@]}" | sed 's/"/\\\"/g')"
-    curl_resp="$(curl "${curl_args[@]}" 2>&1)"
-    curl_retval=$?
-    if [ ${curl_retval} -eq 0 ] && [ ! -e "${ffb_tmp_outname}" ] ; then
-        touch "${ffb_tmp_outname}"
-    fi
-
-
-    if [ "${curl_retval}" -ne 0 ]; then
-        curl_version="$(curl --version 2>&1 | head -1)"
-        warn "${curl_cmd} failed. version:${curl_version}  exit code ${curl_retval} stderr: ${curl_resp} "
-        # cannot use error_*.sh helper functions
-        # may not have been loaded yet, and wget fails often
-        echo "<OSGTestResult id=\"perform_curl\" version=\"4.3.1\">
-  <operatingenvironment>
-    <env name=\"cwd\">${PWD}</env>
-    <env name=\"uname\">$(uname -a)</env>
-    <env name=\"release\">$(cat /etc/system-release)</env>
-    <env name=\"curl_version\">${curl_version}</env>
-  </operatingenvironment>
-  <test>
-    <cmd>${curl_cmd}</cmd>
-    <tStart>$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)</tStart>
-    <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
-  </test>
-  <result>
-    <status>ERROR</status>
-    <metric name=\"failure\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Network</metric>
-    <metric name=\"URL\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_url}</metric>
-    <metric name=\"http_proxy\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${proxy_url}</metric>
-    <metric name=\"source_type\" ts=\"$(date --date=@"${START}" +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
-  </result>
-  <detail>
-  Failed to load file '${ffb_real_fname}' from '${ffb_repository}' using proxy '${proxy_url}'.  ${curl_resp}
-  </detail>
-</OSGTestResult>" > otrb_output.xml
-        warn "Failed to load file '${ffb_real_fname}' from '${ffb_repository}'."
-
-        if [ -f otr_outlist.list ]; then
-            chmod u+w otr_outlist.list
-        else
-            touch otr_outlist.list
-        fi
-        cat otrb_output.xml >> otr_outlist.list
-        echo "<?xml version=\"1.0\"?>" > otrx_output.xml
-        cat otrb_output.xml >> otrx_output.xml
-        rm -f otrb_output.xml
-        chmod a-w otr_outlist.list
-    fi
-    return ${curl_retval}
-}
-
-fetch_file_base() {
-    # Perform the file download and corresponding action (untar, execute, ...)
-    ffb_id="$1"
-    ffb_target_fname="$2"
-    ffb_real_fname="$3"
-    ffb_file_type="$4"
-    ffb_config_out="$5"
-    ffb_period=$6
-    # condor cron prefix, used only for periodic executables
-    ffb_cc_prefix="$7"
-
-    ffb_work_dir="$(get_work_dir "${ffb_id}")"
-
-    ffb_repository="$(get_repository_url "${ffb_id}")"
-
-    ffb_tmp_outname="${ffb_work_dir}/${ffb_real_fname}"
-    ffb_outname="${ffb_work_dir}/${ffb_target_fname}"
-
-    # Create a dummy default in case something goes wrong
-    # cannot use error_*.sh helper functions
-    # may not have been loaded yet
-    have_dummy_otrx=1
-    echo "<?xml version=\"1.0\"?>
-<OSGTestResult id=\"fetch_file_base\" version=\"4.3.1\">
-  <operatingenvironment>
-    <env name=\"cwd\">${PWD}</env>
-  </operatingenvironment>
-  <test>
-    <cmd>Unknown</cmd>
-    <tStart>$(date +%Y-%m-%dT%H:%M:%S%:z)</tStart>
-    <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
-  </test>
-  <result>
-    <status>ERROR</status>
-    <metric name=\"failure\" ts=\"$(date +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">Unknown</metric>
-    <metric name=\"source_type\" ts=\"$(date +%Y-%m-%dT%H:%M:%S%:z)\" uri=\"local\">${ffb_id}</metric>
-  </result>
-  <detail>
-     An unknown error occurred.
-  </detail>
-</OSGTestResult>" > otrx_output.xml
-    user_agent="glidein/${glidein_entry}/${condorg_schedd}/${condorg_cluster}.${condorg_subcluster}/${client_name}"
-    ffb_url="${ffb_repository}/${ffb_real_fname}"
-    curl_version=$(curl --version | head -1 )
-    wget_version=$(wget --version | head -1 )
-    #old wget command:
-    #wget --user-agent="wget/glidein/$glidein_entry/$condorg_schedd/$condorg_cluster.$condorg_subcluster/$client_name" "$ffb_nocache_str" -q  -O "$ffb_tmp_outname" "$ffb_repository/$ffb_real_fname"
-    #equivalent to:
-    #wget ${ffb_url} --user-agent=${user_agent} -q  -O "${ffb_tmp_outname}" "${ffb_nocache_str}"
-    #with env http_proxy=$proxy_url set if proxy_url != "None"
-    #
-    #construct curl equivalent so we can try either
-
-    wget_args=("${ffb_url}" "--user-agent" "wget/${user_agent}"  "--quiet"  "--output-document" "${ffb_tmp_outname}" )
-    curl_args=("${ffb_url}" "--user-agent" "curl/${user_agent}" "--silent"  "--show-error" "--output" "${ffb_tmp_outname}")
-
-    if [ "${ffb_file_type}" = "nocache" ]; then
-        if [ "${curl_version}" != "" ]; then
-            curl_args+=("--header")
-            curl_args+=("'Cache-Control: no-cache'")
-        fi
-        if [ "${wget_version}" != "" ]; then
-            if wget --help | grep -q "\-\-no-cache "; then
-                wget_args+=("--no-cache")
-            elif wget --help |grep -q "\-\-cache="; then
-                wget_args+=("--cache=off")
-            else
-                warn "wget ${wget_version} cannot disable caching"
-            fi
-         fi
-    fi
-
-    if [ "${proxy_url}" != "None" ];then
-        if [ "${curl_version}" != "" ]; then
-            curl_args+=("--proxy")
-            curl_args+=("${proxy_url}")
-        fi
-        if [ "${wget_version}" != "" ]; then
-            #these two arguments have to be last as coded, put any future
-            #wget args earlier in wget_args array
-            wget_args+=("--proxy")
-            wget_args+=("${proxy_url}")
-        fi
-    fi
-
-    fetch_completed=1
-    if [ ${fetch_completed} -ne 0 ] && [ "${wget_version}" != "" ]; then
-        perform_wget "${wget_args[@]}"
-        fetch_completed=$?
-    fi
-    if [ ${fetch_completed} -ne 0 ] && [ "${curl_version}" != "" ]; then
-        perform_curl "${curl_args[@]}"
-        fetch_completed=$?
-    fi
-
-    if [ ${fetch_completed} -ne 0 ]; then
-        return ${fetch_completed}
-    fi
-
-    # check signature
-    if ! check_file_signature "${ffb_id}" "${ffb_real_fname}"; then
-        # error already displayed inside the function
-        return 1
-    fi
-
-    # rename it to the correct final name, if needed
-    if [ "${ffb_tmp_outname}" != "${ffb_outname}" ]; then
-        if ! mv "${ffb_tmp_outname}" "${ffb_outname}"; then
-            warn "Failed to rename ${ffb_tmp_outname} into ${ffb_outname}"
-            return 1
-        fi
-    fi
-
-    # if executable, execute
-    if [[ "${ffb_file_type}" = "exec" || "${ffb_file_type}" = "exec:"* ]]; then
-        if ! chmod u+x "${ffb_outname}"; then
-            warn "Error making '${ffb_outname}' executable"
-            return 1
-        fi
-        if [ "${ffb_id}" = "main" ] && [ "${ffb_target_fname}" = "${last_script}" ]; then  # last_script global for simplicity
-            echo "Skipping last script ${last_script}" 1>&2
-        elif [[ "${ffb_target_fname}" = "cvmfs_umount.sh" ]] || [[ -n "${cleanup_script}" && "${ffb_target_fname}" = "${cleanup_script}" ]]; then  # cleanup_script global for simplicity
-            # TODO: temporary OR checking for cvmfs_umount.sh; to be removed after Bruno's ticket on cleanup [#25073]
-            echo "Skipping cleanup script ${ffb_outname} (${cleanup_script})" 1>&2
-            cp "${ffb_outname}" "$gwms_exec_dir/cleanup/${ffb_target_fname}"
-            chmod a+x "${gwms_exec_dir}/cleanup/${ffb_target_fname}"
-        else
-            echo "Executing (flags:${ffb_file_type#exec}) ${ffb_outname}"
-            # have to do it here, as this will be run before any other script
-            chmod u+rx "${main_dir}"/error_augment.sh
-
-            # the XML file will be overwritten now, and hopefully not an error situation
-            have_dummy_otrx=0
-            "${main_dir}"/error_augment.sh -init
-            START=$(date +%s)
-            if [[ "${ffb_file_type}" = "exec:s" ]]; then
-                "${main_dir}/singularity_wrapper.sh" "${ffb_outname}" glidein_config "${ffb_id}"
-            else
-                "${ffb_outname}" glidein_config "${ffb_id}"
-            fi
-            ret=$?
-            END=$(date +%s)
-            "${main_dir}"/error_augment.sh -process ${ret} "${ffb_id}/${ffb_target_fname}" "${PWD}" "${ffb_outname} glidein_config" "${START}" "${END}" #generating test result document
-            "${main_dir}"/error_augment.sh -concat
-            if [ ${ret} -ne 0 ]; then
-                echo "=== Validation error in ${ffb_outname} ===" 1>&2
-                warn "Error running '${ffb_outname}'"
-                < otrx_output.xml awk 'BEGIN{fr=0;}/<[/]detail>/{fr=0;}{if (fr==1) print $0}/<detail>/{fr=1;}' 1>&2
-                return 1
-            else
-                # If ran successfully and periodic, schedule to execute with schedd_cron
-                echo "=== validation OK in ${ffb_outname} (${ffb_period}) ===" 1>&2
-                if [ "${ffb_period}" -gt 0 ]; then
-                    add_periodic_script "${main_dir}/script_wrapper.sh" "${ffb_period}" "${work_dir}" "${ffb_outname}" glidein_config "${ffb_id}" "${ffb_cc_prefix}"
-                fi
-            fi
-        fi
-    elif [ "${ffb_file_type}" = "wrapper" ]; then
-        echo "${ffb_outname}" >> "${wrapper_list}"
-    elif [ "${ffb_file_type}" = "untar" ]; then
-        ffb_short_untar_dir="$(get_untar_subdir "${ffb_id}" "${ffb_target_fname}")"
-        ffb_untar_dir="${ffb_work_dir}/${ffb_short_untar_dir}"
-        START=$(date +%s)
-        (mkdir "${ffb_untar_dir}" && cd "${ffb_untar_dir}" && tar -xmzf "${ffb_outname}") 1>&2
-        ret=$?
-        if [ ${ret} -ne 0 ]; then
-            "${main_dir}"/error_augment.sh -init
-            "${main_dir}"/error_gen.sh -error "tar" "Corruption" "Error untarring '${ffb_outname}'" "file" "${ffb_outname}" "source_type" "${cfs_id}"
-            "${main_dir}"/error_augment.sh  -process ${cfs_rc} "tar" "${PWD}" "mkdir ${ffb_untar_dir} && cd ${ffb_untar_dir} && tar -xmzf ${ffb_outname}" "${START}" "$(date +%s)"
-            "${main_dir}"/error_augment.sh -concat
-            warn "Error untarring '${ffb_outname}'"
-            return 1
-        fi
-    fi
-
-    if [ "${ffb_config_out}" != "FALSE" ]; then
-        ffb_prefix="$(get_prefix "${ffb_id}")"
-        if [ "${ffb_file_type}" = "untar" ]; then
-            # when untaring the original file is less interesting than the untar dir
-            if ! add_config_line "${ffb_prefix}${ffb_config_out}" "${ffb_untar_dir}"; then
-                glidein_exit 1
-            fi
-        else
-            if ! add_config_line "${ffb_prefix}${ffb_config_out}" "${ffb_outname}"; then
-                glidein_exit 1
-            fi
-        fi
-    fi
-
-    if [ "${have_dummy_otrx}" -eq 1 ]; then
-        # no one should really look at this file, but just to avoid confusion
-        echo "<?xml version=\"1.0\"?>
-<OSGTestResult id=\"fetch_file_base\" version=\"4.3.1\">
-  <operatingenvironment>
-    <env name=\"cwd\">${PWD}</env>
-  </operatingenvironment>
-  <test>
-    <cmd>Unknown</cmd>
-    <tStart>$(date +%Y-%m-%dT%H:%M:%S%:z)</tStart>
-    <tEnd>$(date +%Y-%m-%dT%H:%M:%S%:z)</tEnd>
-  </test>
-  <result>
-    <status>OK</status>
-  </result>
-</OSGTestResult>" > otrx_output.xml
-    fi
-
-   return 0
-}
-
-# Adds $1 to GWMS_PATH and update PATH
-add_to_path() {
-    logdebug "Adding to GWMS_PATH: $1"
-    local old_path=":${PATH%:}:"
-    old_path="${old_path//:$GWMS_PATH:/}"
-    local old_gwms_path=":${GWMS_PATH%:}:"
-    old_gwms_path="${old_gwms_path//:$1:/}"
-    old_gwms_path="${1%:}:${old_gwms_path#:}"
-    export GWMS_PATH="${old_gwms_path%:}"
-    old_path="${GWMS_PATH}:${old_path#:}"
-    export PATH="${old_path%:}"
-}
-
-fixup_condor_dir() {
-    # All files in the native condor tarballs have a directory like condor-9.0.11-1-x86_64_CentOS7-stripped
-    # However the (not used anymore) gwms create_condor_tarball removes that dir
-    # Here we remove that dir as well to allow factory ops to use native condor tarballs
-
-    # Check if the condor dir has only one subdir, the one like "condor-9.0.11-1-x86_64_CentOS7-stripped"
-    # See https://stackoverflow.com/questions/32429333/how-to-test-if-a-linux-directory-contain-only-one-subdirectory-and-no-other-file
-    if [ $(find "${gs_id_work_dir}/condor" -maxdepth 1 -type d -printf 1 | wc -m) -eq 2 ]; then
-        echo "Fixing directory structure of condor tarball"
-        mv "${gs_id_work_dir}"/condor/condor*/* "${gs_id_work_dir}"/condor > /dev/null
-    else
-        echo "Condor tarball does not need to be fixed"
-    fi
-}
 
 echo "Downloading files from Factory and Frontend"
 log_write "glidein_startup.sh" "text" "Downloading file from Factory and Frontend" "debug"
@@ -1886,40 +1885,40 @@ check_signature=0
 
 for gs_id in main entry client client_group
 do
-  if [ -z "${client_repository_url}" ]; then
-      if [ "${gs_id}" = "client" ]; then
-          # no client file when no cilent_repository
-          continue
-      fi
-  fi
-  if [ -z "${client_repository_group_url}" ]; then
-      if [ "${gs_id}" = "client_group" ]; then
-          # no client group file when no cilent_repository_group
-          continue
-      fi
-  fi
+    if [ -z "${client_repository_url}" ]; then
+        if [ "${gs_id}" = "client" ]; then
+            # no client file when no cilent_repository
+            continue
+        fi
+    fi
+    if [ -z "${client_repository_group_url}" ]; then
+        if [ "${gs_id}" = "client_group" ]; then
+            # no client group file when no cilent_repository_group
+            continue
+        fi
+    fi
 
-  gs_id_work_dir="$(get_work_dir ${gs_id})"
+    gs_id_work_dir="$(get_work_dir ${gs_id})"
 
-  # Fetch description file
-  gs_id_descript_file="$(get_descript_file ${gs_id})"
-  fetch_file_regular "${gs_id}" "${gs_id_descript_file}"
-  if ! signature_file_line="$(grep "^signature " "${gs_id_work_dir}/${gs_id_descript_file}")"; then
-      warn "No signature in description file ${gs_id_work_dir}/${gs_id_descript_file} (wc: $(wc < "${gs_id_work_dir}/${gs_id_descript_file}" 2>/dev/null))."
-      glidein_exit 1
-  fi
-  signature_file=$(echo "${signature_file_line}" | cut -s -f 2-)
+    # Fetch description file
+    gs_id_descript_file="$(get_descript_file ${gs_id})"
+    fetch_file_regular "${gs_id}" "${gs_id_descript_file}"
+    if ! signature_file_line="$(grep "^signature " "${gs_id_work_dir}/${gs_id_descript_file}")"; then
+        warn "No signature in description file ${gs_id_work_dir}/${gs_id_descript_file} (wc: $(wc < "${gs_id_work_dir}/${gs_id_descript_file}" 2>/dev/null))."
+        glidein_exit 1
+    fi
+    signature_file=$(echo "${signature_file_line}" | cut -s -f 2-)
 
-  # Fetch signature file
-  gs_id_signature="$(get_signature ${gs_id})"
-  fetch_file_regular "${gs_id}" "${signature_file}"
-  echo "${gs_id_signature}  ${signature_file}" > "${gs_id_work_dir}/signature.sha1.test"
-  if ! (cd "${gs_id_work_dir}" && sha1sum -c signature.sha1.test) 1>&2 ; then
-      warn "Corrupted signature file '${gs_id_work_dir}/${signature_file}'."
-      glidein_exit 1
-  fi
-  # for simplicity use a fixed name for signature file
-  mv "${gs_id_work_dir}/${signature_file}" "${gs_id_work_dir}/signature.sha1"
+    # Fetch signature file
+    gs_id_signature="$(get_signature ${gs_id})"
+    fetch_file_regular "${gs_id}" "${signature_file}"
+    echo "${gs_id_signature}  ${signature_file}" > "${gs_id_work_dir}/signature.sha1.test"
+    if ! (cd "${gs_id_work_dir}" && sha1sum -c signature.sha1.test) 1>&2 ; then
+        warn "Corrupted signature file '${gs_id_work_dir}/${signature_file}'."
+        glidein_exit 1
+    fi
+    # for simplicity use a fixed name for signature file
+    mv "${gs_id_work_dir}/${signature_file}" "${gs_id_work_dir}/signature.sha1"
 done
 
 # re-enable for everything else
@@ -1931,25 +1930,25 @@ check_signature=1
 # the description file
 for gs_id in main entry client client_group
 do
-  if [ -z "${client_repository_url}" ]; then
-      if [ "${gs_id}" = "client" ]; then
-          # no client file when no cilent_repository
-          continue
-      fi
-  fi
-  if [ -z "${client_repository_group_url}" ]; then
-      if [ "${gs_id}" = "client_group" ]; then
-          # no client group file when no cilent_repository_group
-          continue
-      fi
-  fi
+    if [ -z "${client_repository_url}" ]; then
+        if [ "${gs_id}" = "client" ]; then
+            # no client file when no cilent_repository
+            continue
+        fi
+    fi
+    if [ -z "${client_repository_group_url}" ]; then
+        if [ "${gs_id}" = "client_group" ]; then
+            # no client group file when no cilent_repository_group
+            continue
+        fi
+    fi
 
-  gs_id_descript_file="$(get_descript_file ${gs_id})"
-  if ! check_file_signature "${gs_id}" "${gs_id_descript_file}"; then
-      gs_id_work_dir="$(get_work_dir ${gs_id})"
-      warn "Corrupted description file ${gs_id_work_dir}/${gs_id_descript_file}."
-      glidein_exit 1
-  fi
+    gs_id_descript_file="$(get_descript_file ${gs_id})"
+    if ! check_file_signature "${gs_id}" "${gs_id_descript_file}"; then
+        gs_id_work_dir="$(get_work_dir ${gs_id})"
+        warn "Corrupted description file ${gs_id_work_dir}/${gs_id_descript_file}."
+        glidein_exit 1
+    fi
 done
 
 ###################################################
@@ -1962,8 +1961,7 @@ if [ -z "${last_script}" ]; then
     glidein_exit 1
 fi
 #cleanup_script="$(grep "^cleanup_script " "${gs_id_work_dir}/${gs_id_descript_file}" | cut -s -f 2-)"
-cleanup_script=$(grep "^GLIDEIN_CLEANUP_SCRIPT " "${glidein_config}" | cut -d ' ' -f 2-)
-
+cleanup_script=$(gconfig_get GLIDEIN_CLEANUP_SCRIPT "${glidein_config}")
 
 ##############################
 # Fetch all the other files
@@ -2041,7 +2039,7 @@ fixup_condor_dir
 
 ##############################
 # Start the glidein main script
-add_config_line "GLIDEIN_INITIALIZED" "1"
+gconfig_add "GLIDEIN_INITIALIZED" "1"
 
 log_write "glidein_startup.sh" "text" "Starting the glidein main script" "info"
 log_write "glidein_startup.sh" "file" "${glidein_config}" "debug"

--- a/creation/web_base/gwms-python
+++ b/creation/web_base/gwms-python
@@ -12,6 +12,7 @@ my_path=$(cd "$(dirname "$0")"; pwd)
 if [ -f "$1" ]; then
     glidein_config="$1"
     # TODO: find a better way to recognize that is invoked in configuration w/ glidein_config as parameter (e.g header)
+    # retained the use of grep since these are the only occurrences where variables values are being fetched and both these variables are immutable by scripts
     error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | awk '{print $2}')
     work_dir=$(grep '^GLIDEIN_WORK_DIR ' "$glidein_config" | awk '{print $2}')
 fi

--- a/creation/web_base/java_setup.sh
+++ b/creation/web_base/java_setup.sh
@@ -18,7 +18,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/java_setup.sh
+++ b/creation/web_base/java_setup.sh
@@ -16,16 +16,16 @@
 glidein_config="$1"
 tmp_fname="${glidein_config}.$$.tmp"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
-
-condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
-
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
 
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
+
 # Is java required?
-need_java=`grep '^GLIDEIN_Java_Use ' "$glidein_config" | cut -d ' ' -f 2-`
+need_java=$(gconfig_get GLIDEIN_Java_Use "$glidein_config")
 if [ -z "$need_java" ]; then
     echo "`date` GLIDEIN_Java_Use not configured. Defaulting it to NEVER"
     need_java="NEVER"
@@ -55,16 +55,16 @@ fi
 
 echo "`date` Using Java in $java_bin"
 
-add_config_line "JAVA" "$java_bin"
+gconfig_add "JAVA" "$java_bin"
 add_condor_vars_line "JAVA" "C" "-" "+" "Y" "N" "-"
 
-add_config_line "JAVA_MAXHEAP_ARGUMENT" "-Xmx"
+gconfig_add "JAVA_MAXHEAP_ARGUMENT" "-Xmx"
 add_condor_vars_line "JAVA_MAXHEAP_ARGUMENT" "C" "-" "+" "Y" "N" "-"
 
-add_config_line "JAVA_CLASSPATH_ARGUMENT" "-classpath"
+gconfig_add "JAVA_CLASSPATH_ARGUMENT" "-classpath"
 add_condor_vars_line "JAVA_CLASSPATH_ARGUMENT" "C" "-" "+" "Y" "N" "-"
 
-add_config_line "JAVA_CLASSPATH_DEFAULT" '$(LIB),$(LIB)/scimark2lib.jar,.'
+gconfig_add "JAVA_CLASSPATH_DEFAULT" '$(LIB),$(LIB)/scimark2lib.jar,.'
 add_condor_vars_line "JAVA_CLASSPATH_DEFAULT" "C" "-" "+" "Y" "N" "-"
 
 "$error_gen" -ok "java_setup.sh" "Java_check" "java"

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -140,7 +140,8 @@ log_init() {
         return 2
     else
         add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "${glidein_config}" | cut -d ' ' -f 2-)
-        source "${add_config_line_source}"
+        # shellcheck source=./add_config_line.source
+        . "${add_config_line_source}"
     fi
 
     logdir="logs/${1}"

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -139,7 +139,7 @@ log_init() {
         warn "log_init: glidein_config not defined in ${0}. Logging will not work here."
         return 2
     else
-        add_config_line_source="$(grep '^ADD_CONFIG_LINE_SOURCE ' "${glidein_config}" | cut -d ' ' -f 2-)"
+        add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "${glidein_config}" | cut -d ' ' -f 2-)
         source "${add_config_line_source}"
     fi
 
@@ -150,17 +150,17 @@ log_init() {
     log_relative_basepath="${2}"
 
     # Export configuration
-    add_config_line "GLIDEIN_LOGDIR" "${logdir}"
-    add_config_line "GLIDEIN_STDOUT_LOGFILE" "${stdout_logfile}"
-    add_config_line "GLIDEIN_STDERR_LOGFILE" "${stderr_logfile}"
-    add_config_line "GLIDEIN_LOG_LOGFILE" "${log_logfile}"
-    add_config_line "GLIDEIN_LOG_RELATIVE_BASEPATH" "${log_relative_basepath}"
+    gconfig_add "GLIDEIN_LOGDIR" "${logdir}"
+    gconfig_add "GLIDEIN_STDOUT_LOGFILE" "${stdout_logfile}"
+    gconfig_add "GLIDEIN_STDERR_LOGFILE" "${stderr_logfile}"
+    gconfig_add "GLIDEIN_LOG_LOGFILE" "${log_logfile}"
+    gconfig_add "GLIDEIN_LOG_RELATIVE_BASEPATH" "${log_relative_basepath}"
     if [ -n "${LOG_RECIPIENTS}" ]; then
-        add_config_line "GLIDEIN_LOG_RECIPIENTS" "${LOG_RECIPIENTS}"
+        gconfig_add "GLIDEIN_LOG_RECIPIENTS" "${LOG_RECIPIENTS}"
     fi
 
     # Setup tokens to authenticate with log servers
-    log_recipients=($(grep '^GLIDEIN_LOG_RECIPIENTS ' "${glidein_config}" | cut -d ' ' -f 2-))
+    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
     local no_send=0
     if [ "${#log_recipients[@]}" -eq 0 ]; then
         warn "log_init: no recipients configured. Logs will still be produced, but not forwarded to remote servers."
@@ -179,8 +179,8 @@ log_init() {
         no_send=1
     fi
 
-    add_config_line "CURL_VERSION" "${curl_version}"
-    add_config_line "GLIDEIN_LOG_NO_SEND" "${no_send}"
+    gconfig_add "CURL_VERSION" "${curl_version}"
+    gconfig_add "GLIDEIN_LOG_NO_SEND" "${no_send}"
 
     # Create the necessary folders
     mkdir -p "${logdir}/shards/creating"
@@ -197,7 +197,7 @@ log_init() {
     echo "$(date): Started logging stdout on file too"
     echo "$(date): Started logging stderr on file too" >&2
 
-    add_config_line "GLIDEIN_LOG_INITIALIZED" "1"
+    gconfig_add "GLIDEIN_LOG_INITIALIZED" "1"
 }
 
 
@@ -218,20 +218,20 @@ log_setup() {
         return 1
     fi
 
-    log_initialized="$(grep '^GLIDEIN_LOG_INITIALIZED ' "${glidein_config}" | cut -d ' ' -f 2-)"
+    log_initialized=$(gconfig_get GLIDEIN_LOG_INITIALIZED "${glidein_config}")
     if [ "${log_initialized}" != 1 ]; then
         warn_ready "log_setup: apparently the logging configuration has not been initialiazed yet (${0}). Logging will not work here."
         return 1
     fi
 
-    logdir="$(grep '^GLIDEIN_LOGDIR ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    stdout_logfile="$(grep '^GLIDEIN_STDOUT_LOGFILE ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    stderr_logfile="$(grep '^GLIDEIN_STDERR_LOGFILE ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    log_logfile="$(grep '^GLIDEIN_LOG_LOGFILE ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    log_recipients=($(grep '^GLIDEIN_LOG_RECIPIENTS ' "${glidein_config}" | cut -d ' ' -f 2-))
-    log_no_send="$(grep '^GLIDEIN_LOG_NO_SEND ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    log_relative_basepath="$(grep '^GLIDEIN_LOG_RELATIVE_BASEPATH ' "${glidein_config}" | cut -d ' ' -f 2-)"
-    curl_version="$(grep '^CURL_VERSION ' "${glidein_config}" | cut -d ' ' -f 2-)"
+    logdir=$(gconfig_get GLIDEIN_LOGDIR "${glidein_config}")
+    stdout_logfile=$(gconfig_get GLIDEIN_STDOUT_LOGFILE "${glidein_config}")
+    stderr_logfile=$(gconfig_get GLIDEIN_STDERR_LOGFILE "${glidein_config}")
+    log_logfile=$(gconfig_get GLIDEIN_LOG_LOGFILE "${glidein_config}")
+    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
+    log_no_send=$(gconfig_get GLIDEIN_LOG_NO_SEND "${glidein_config}")
+    log_relative_basepath=$(gconfig_get GLIDEIN_LOG_RELATIVE_BASEPATH "${glidein_config}")
+    curl_version=$(gconfig_get CURL_VERSION "${glidein_config}")
 
     if [ "${log_no_send}" -ne 0 ]; then
         log_no_send=1
@@ -282,7 +282,7 @@ log_write() {
     cur_time_ns=$(date +%s%N)   # enough to ensure that shards have different timestamps
 
     # Source encoding utilities
-    b64uuencode_source="$(grep '^B64UUENCODE_SOURCE ' "${glidein_config}" | cut -d ' ' -f 2-)"
+    b64uuencode_source=$(gconfig_get B64UUENCODE_SOURCE "${glidein_config}")
     source "${b64uuencode_source}"
 
     # Argument $1 (invoker)

--- a/creation/web_base/script_wrapper.sh
+++ b/creation/web_base/script_wrapper.sh
@@ -45,48 +45,16 @@ robust_realpath() {
     fi
 }
 
-# input parameters sanitized
-glidein_config=$(robust_realpath "$1")
-s_ffb_id="$2"
-# the name is used in the included functions
-s_name=$3
-s_fname=$(robust_realpath "$4")
-# This is the prefix used for the startd_cron. This wrapper uses GLIDEIN_PS_ for the lines added to config
-# and adds GLIDEIN_PS_ to stdout if the startd_cron has no prefix (s_prefix==NOPREFIX)
-s_prefix="$5"
-
-# Add the default GLIDEIN_PS_ prefix to stdout prints from this wrapper (sent to startd)
-# if there is no prefix (NOPREFIX special keyword)
-if [ "x${s_prefix}" = "xNOPREFIX" ]; then
-    add_prefix=YES
-else
-    add_prefix=
-fi
-
-# find error reporting helper script
-error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
-
-if [ -z "$3" ]; then
-    # no script passed, wrapper invoked by the initial test
-    "$error_gen" -ok  "script_wrapper.sh" GLIDEIN_PS_LAST "script_wrapper.sh" GLIDEIN_PS_LAST_END "0" GLIDEIN_PS_OK "True"
-    exit 0
-fi
-
-verbose=
-[[ -n "$DEBUG" ]] && verbose=yes
-
 # write to stderr only if verbose is set
 vmessage() {
     # echo `date` $@ 1>&2
     [ -n "$verbose" ] && echo "# script_wrapper.sh $(date)" "$@" 1>&2
 }
 
-
 # temporary function until the correct one is sourced
 add_config_line_safe() {
     echo "$@" >> "$glidein_config"
 }
-
 
 # publish to startd classad and to the glidein_config file, used by this wrapper
 # add the default "GLIDEIN_PS_" prefix when no prefix is set in HTCondor to avoid clashes
@@ -102,7 +70,6 @@ publish() {
     add_config_line_safe "${prefix}$*"
 }
 
-
 # Manage failure lists in glidein_config (GLIDEIN_PS_FAILED_LIST/GLIDEIN_PS_FAILING_LIST) and connected ads
 # GLIDEIN_PS_FAILING_LIST empty -> GLIDEIN_PS_OK True, GLIDEIN_PS_FAILING_LIST not empty -> GLIDEIN_PS_OK False
 # list_manage add|del name list_name
@@ -111,6 +78,7 @@ list_manage() {
     # $1 command (add|del), $2 value_to_add_to_list, $3 list_name (in glidein_config, case insensitive)
     # Uses $glidein_config
     local tmp_list
+    # grep-based fetching is retained since add_config_line.source is not sourced yet at this point
     tmp_list=",$(grep -i "^$3 " "$glidein_config" | cut -d ' ' -f 2-),"
     #  Trim commas (greedy, ^$ not needed) - bash <= 3.1 needs quoted regex, >=3.2 unquoted, variables are OK with both
     local re=",*([^,]|[^,].*[^,]),*"
@@ -131,7 +99,6 @@ list_manage() {
         fi
     fi
 }
-
 
 # Advertise failure, cleanup and exit
 # failed "message" [error_type [ec]]
@@ -168,6 +135,27 @@ failed() {
 
 ### Script wrapper starts
 
+# input parameters sanitized
+glidein_config=$(robust_realpath "$1")
+s_ffb_id="$2"
+# the name is used in the included functions
+s_name=$3
+s_fname=$(robust_realpath "$4")
+# This is the prefix used for the startd_cron. This wrapper uses GLIDEIN_PS_ for the lines added to config
+# and adds GLIDEIN_PS_ to stdout if the startd_cron has no prefix (s_prefix==NOPREFIX)
+s_prefix="$5"
+
+# Add the default GLIDEIN_PS_ prefix to stdout prints from this wrapper (sent to startd)
+# if there is no prefix (NOPREFIX special keyword)
+if [ "x${s_prefix}" = "xNOPREFIX" ]; then
+    add_prefix=YES
+else
+    add_prefix=
+fi
+
+verbose=
+[[ -n "$DEBUG" ]] && verbose=yes
+
 vmessage "Executing $s_name: $s_fname $glidein_config $s_ffb_id"
 
 # start_dir should be the same as work_dir in glidein_startup.sh and GLIDEIN_WORK_DIR
@@ -185,6 +173,14 @@ done
 
 source ./add_config_line.source
 
+# find error reporting helper script
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+if [ -z "$3" ]; then
+    # no script passed, wrapper invoked by the initial test
+    "$error_gen" -ok  "script_wrapper.sh" GLIDEIN_PS_LAST "script_wrapper.sh" GLIDEIN_PS_LAST_END "0" GLIDEIN_PS_OK "True"
+    exit 0
+fi
 
 ### Setup: move to personal temp dir not to step over other programs
 temp_base_dir="$start_dir"
@@ -192,7 +188,6 @@ if ! tmp_dir=$(mktemp -d --tmpdir="$temp_base_dir"); then
     failed "Failed to create temporary directory" wrapper
 fi
 cd "$tmp_dir" || failed "Failed to cd in temporary directory" wrapper
-
 
 ### Run the program (user script)
 
@@ -223,7 +218,6 @@ publish LAST_END "$END"
 echo "-"
 
 # This is invoked in the script: "$error_gen" -ok  "script_wrapper.sh" GLIDEIN_PS_LAST "$s_fname" GLIDEIN_PS_LAST_END "$END"
-
 
 ### End cleanup
 cd "$start_dir" || true

--- a/creation/web_base/script_wrapper.sh
+++ b/creation/web_base/script_wrapper.sh
@@ -171,7 +171,8 @@ for i in  "$main_dir/error_augment.sh" "$s_fname"; do
     [ -x "$i" ] || failed "Missing essential executable: $i" wrapper
 done
 
-source ./add_config_line.source
+# shellcheck source=./add_config_line.source
+. ./add_config_line.source
 
 # find error reporting helper script
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/setup_network.sh
+++ b/creation/web_base/setup_network.sh
@@ -21,25 +21,25 @@ function warn {
     echo "$(date)" "$@" 1>&2
 }
 
-error_gen=$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
-
-condor_vars_file=$(grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-)
-
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 source "$add_config_line_source"
+
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
 
 ##########################################################
 # check if it should use CCB
 ##########################################################
 out_ccb_str="False"
-use_ccb=$(grep '^USE_CCB ' $glidein_config | cut -d ' ' -f 2-)
+use_ccb=$(gconfig_get USE_CCB "$glidein_config")
 if [[ "$use_ccb" == "True" || "$use_ccb" == "TRUE" || "$use_ccb" == "T" || "$use_ccb" == "Yes" || "$use_ccb" == "Y" || "$use_ccb" == "1" ]]; then
     # ok, we need to define CCB variable
 
-    ccb_host=$(grep '^GLIDEIN_CCB ' $glidein_config | cut -d ' ' -f 2-)
+    ccb_host=$(gconfig_get GLIDEIN_CCB "$glidein_config")
     if [ -z "$ccb_host" ]; then
-        ccb_host=$(grep '^GLIDEIN_Collector ' $glidein_config | cut -d ' ' -f 2-)
+        ccb_host=$(gconfig_get GLIDEIN_Collector "$glidein_config")
         if [ -z "$ccb_host" ]; then
             #echo "No GLIDEIN_Collector found!" 1>&2
             STR="No GLIDEIN_CCB or GLIDEIN_Collector found!"
@@ -48,7 +48,7 @@ if [[ "$use_ccb" == "True" || "$use_ccb" == "TRUE" || "$use_ccb" == "T" || "$use
         fi
     fi
 
-    add_config_line CCB_ADDRESS "$ccb_host"
+    gconfig_add CCB_ADDRESS "$ccb_host"
     # and export it to Condor
     add_condor_vars_line CCB_ADDRESS C "-" "+" Y N "-"
     out_ccb_str="True"
@@ -59,18 +59,18 @@ fi
 # check if it should use the shared_port_daemon
 ##########################################################
 out_sharedp_str="False"
-use_sharedp=$(grep '^USE_SHARED_PORT ' $glidein_config | cut -d ' ' -f 2-)
+use_sharedp=$(gconfig_get USE_SHARED_PORT "$glidein_config")
 if [[ "$use_sharedp" == "True" || "$use_sharedp" == "TRUE" || "$use_sharedp" == "T" || "$use_sharedp" == "Yes" || "$use_sharedp" == "Y" || "$use_sharedp" == "1" ]]; then
     # ok, we need to enable the shared port
-    daemon_list=$(grep '^DAEMON_LIST ' $glidein_config | cut -d ' ' -f 2-)
+    daemon_list=$(gconfig_get DAEMON_LIST "$glidein_config")
     if [ -z "$daemon_list" ]; then
         # this is the default
         daemon_list="MASTER,STARTD"
     fi
     new_daemon_list="${daemon_list},SHARED_PORT"
-    add_config_line DAEMON_LIST "${new_daemon_list}"
+    gconfig_add DAEMON_LIST "${new_daemon_list}"
 
-    add_config_line USE_SHARED_PORT True
+    gconfig_add USE_SHARED_PORT True
     out_sharedp_str="True"
 fi
 

--- a/creation/web_base/setup_network.sh
+++ b/creation/web_base/setup_network.sh
@@ -23,7 +23,8 @@ function warn {
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/setup_script.sh
+++ b/creation/web_base/setup_script.sh
@@ -15,7 +15,8 @@ tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 GLIDEIN_WORK_DIR=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
 chmod u+x "$GLIDEIN_WORK_DIR/error_gen.sh"

--- a/creation/web_base/setup_script.sh
+++ b/creation/web_base/setup_script.sh
@@ -13,7 +13,11 @@
 glidein_config="$1"
 tmp_fname="${glidein_config}.$$.tmp"
 
-GLIDEIN_WORK_DIR="`grep '^GLIDEIN_WORK_DIR ' "$glidein_config" | cut -d ' ' -f 2-`"
+# import add_config_line and add_condor_vars_line functions
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+source "$add_config_line_source"
+
+GLIDEIN_WORK_DIR=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
 chmod u+x "$GLIDEIN_WORK_DIR/error_gen.sh"
 
 echo "ERROR_GEN_PATH $GLIDEIN_WORK_DIR/error_gen.sh" >> "$glidein_config"

--- a/creation/web_base/setup_x509.sh
+++ b/creation/web_base/setup_x509.sh
@@ -391,7 +391,7 @@ get_trust_domain() {
 
 _main() {
     # Aux scripts: import gconfig functions and define error_gen
-    add_config_line_source="$(grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
+    add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
     # shellcheck source=add_config_line.source
     . "$add_config_line_source"
     error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -530,7 +530,7 @@ if [[ -e "$glidein_config" ]]; then    # was: [ -n "$glidein_config" ] && [ "$gl
     if [[ -z "$SOURCED_ADD_CONFIG_LINE" ]]; then
         # import add_config_line and add_condor_vars_line functions used in advertise
         if [[ -z "$add_config_line_source" ]]; then
-            add_config_line_source=$(grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+            add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
             export add_config_line_source
         fi
         if [[ -e "$add_config_line_source" ]]; then

--- a/creation/web_base/singularity_setup.sh
+++ b/creation/web_base/singularity_setup.sh
@@ -28,10 +28,14 @@ glidein_config="$1"
 GWMS_THIS_SCRIPT="$0"
 GWMS_THIS_SCRIPT_DIR=$(dirname "$0")
 
-echo "`date` Starting singularity_setup.sh. Importing singularity_util.sh."
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+source $add_config_line_source
+
+echo "`date` Starting singularity_setup.sh. Importing singularity_lib.sh."
 
 # defined in singularity_lib.sh
-[[ -e "$glidein_config" ]] && error_gen="$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)"
+[[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 # Source utility files, outside and inside Singularity
 if [[ -e "$GWMS_THIS_SCRIPT_DIR"/singularity_lib.sh ]]; then
@@ -166,24 +170,24 @@ combine_requirements () {
 ###########################################################
 # check attributes from Frontend Group and Factory Entry set by admins
 
-GLIDEIN_DEBUG_OUTPUT=$(grep '^GLIDEIN_DEBUG_OUTPUT ' "$glidein_config" | cut -d ' ' -f 2-)
+GLIDEIN_DEBUG_OUTPUT=$(gconfig_get GLIDEIN_DEBUG_OUTPUT "$glidein_config")
 export GLIDEIN_DEBUG_OUTPUT
 
 # SINGULARITY_BIN is now different (from 3.4 or earlier). It allows to suggest a path (both in Factory and Frontend)
 # but no more controls whether Singularity should be used or not
 # undocumented (can still be used for compatibility or to force a path for Singularity)
 # TODO: this hackery to deal with spaces in SINGULARITY_BIN should no more be needed, check!
-temp_singularity_bin="`grep '^SINGULARITY_BIN ' "$glidein_config" | cut -d ' ' -f 2-`"
+temp_singularity_bin=$(gconfig_get SINGULARITY_BIN "$glidein_config")
 singularity_bin="$(echo $temp_singularity_bin)"
 
 # OSG_SINGULARITY_BINARY in glidein_config (if present and not empty) takes precedence to the environment one
-temp_singularity_bin="$(grep '^OSG_SINGULARITY_BINARY ' "$glidein_config" | cut -d ' ' -f 2-)"
+temp_singularity_bin=$(gconfig_get OSG_SINGULARITY_BINARY "$glidein_config")
 [[ -n "$temp_singularity_bin" ]] && export OSG_SINGULARITY_BINARY="$temp_singularity_bin"
 # GLIDEIN_SINGULARITY_BINARY_OVERRIDE is not controlled, expected to be done at the site level.
 # If Factory or Frontend set it in the configuration, they must make sure that goes into the Glidein environment
 
 # Does frontend want to use singularity?
-use_singularity=$(grep '^GLIDEIN_Singularity_Use ' "$glidein_config" | cut -d ' ' -f 2-)
+use_singularity=$(gconfig_get GLIDEIN_Singularity_Use "$glidein_config")
 if [[ -z "$use_singularity" ]]; then
     info_stdout "`date` GLIDEIN_Singularity_Use not configured. Defaulting to DISABLE_GWMS"
     # GWMS, when Group does not specify GLIDEIN_Singularity_Use, it should default to DISABLE_GWMS (2018-03-19 discussion)
@@ -191,14 +195,14 @@ if [[ -z "$use_singularity" ]]; then
 fi
 
 # Does entry require glidein to use singularity?
-require_singularity=$(grep '^GLIDEIN_SINGULARITY_REQUIRE ' "$glidein_config" | cut -d ' ' -f 2-)
+require_singularity=$(gconfig_get GLIDEIN_SINGULARITY_REQUIRE "$glidein_config")
 if [[ -z "$require_singularity" ]]; then
     info_stdout "`date` GLIDEIN_SINGULARITY_REQUIRE not configured. Defaulting to OPTIONAL"
     require_singularity="OPTIONAL"
 fi
 
 # What are the restrictions for the singularity image?
-image_restrictions=$(grep '^SINGULARITY_IMAGE_RESTRICTIONS ' "$glidein_config" | cut -d ' ' -f 2-)
+image_restrictions=$(gconfig_get SINGULARITY_IMAGE_RESTRICTIONS "$glidein_config")
 if [[ -z "$image_restrictions" ]]; then
     info_stdout "`date` SINGULARITY_IMAGE_RESTRICTIONS not configured. Defaulting to cvmfs"
     image_restrictions="cvmfs"
@@ -249,10 +253,10 @@ esac
 # So, if a VO wants to have their own _new_pre_singularity_setup.sh, they must copy and modify
 # generic_pre_singularity_setup.sh and also must put their default singularity images
 # under /cvmfs/singularity.opensciencegrid.org
-SINGULARITY_IMAGES_DICT=$(grep '^SINGULARITY_IMAGES_DICT ' "$glidein_config" | cut -d ' ' -f 2-)
-SINGULARITY_IMAGE_DEFAULT6=$(grep '^SINGULARITY_IMAGE_DEFAULT6 ' "$glidein_config" | cut -d ' ' -f 2-)
-SINGULARITY_IMAGE_DEFAULT7=$(grep '^SINGULARITY_IMAGE_DEFAULT7 ' "$glidein_config" | cut -d ' ' -f 2-)
-SINGULARITY_IMAGE_DEFAULT=$(grep '^SINGULARITY_IMAGE_DEFAULT ' "$glidein_config" | cut -d ' ' -f 2-)
+SINGULARITY_IMAGES_DICT=$(gconfig_get SINGULARITY_IMAGES_DICT "$glidein_config")
+SINGULARITY_IMAGE_DEFAULT6=$(gconfig_get SINGULARITY_IMAGE_DEFAULT6 "$glidein_config")
+SINGULARITY_IMAGE_DEFAULT7=$(gconfig_get SINGULARITY_IMAGE_DEFAULT7 "$glidein_config")
+SINGULARITY_IMAGE_DEFAULT=$(gconfig_get SINGULARITY_IMAGE_DEFAULT "$glidein_config")
 
 # Select the singularity image:  singularity_get_image platforms restrictions
 # Uses SINGULARITY_IMAGES_DICT and legacy SINGULARITY_IMAGE_DEFAULT, SINGULARITY_IMAGE_DEFAULT6, SINGULARITY_IMAGE_DEFAULT7
@@ -316,7 +320,7 @@ advertise GLIDEIN_REQUIRED_OS "any" "S"
 if [[ -n "$GLIDEIN_DEBUG_OUTPUT" ]]; then
     advertise GLIDEIN_DEBUG_OUTPUT "$GLIDEIN_DEBUG_OUTPUT" "S"
 fi
-glidein_provides="$(grep '^GLIDEIN_PROVIDES ' "$glidein_config" | cut -d ' ' -f 2-)"
+glidein_provides=$(gconfig_get GLIDEIN_PROVIDES "$glidein_config")
 # TODO: Add CONTAINERSW, GWMS_CONTAINERSW_MODE once discovery, negotiation and use are defined
 #       maybe "containersw/NAME/MODE" define use of GLIDEIN_PROVIDES. should move to dictionaries?
 advertise GLIDEIN_PROVIDES "${glidein_provides:+"$glidein_provides,"}singularity/$GWMS_SINGULARITY_MODE" "S"

--- a/creation/web_base/singularity_setup.sh
+++ b/creation/web_base/singularity_setup.sh
@@ -29,8 +29,9 @@ GWMS_THIS_SCRIPT="$0"
 GWMS_THIS_SCRIPT_DIR=$(dirname "$0")
 
 # import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
-source $add_config_line_source
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. $add_config_line_source
 
 echo "`date` Starting singularity_setup.sh. Importing singularity_lib.sh."
 

--- a/creation/web_base/singularity_wrapper.sh
+++ b/creation/web_base/singularity_wrapper.sh
@@ -94,8 +94,12 @@ fi
 
 # TODO: Should I quit if glidein_config is not available?
 
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
+source $add_config_line_source
+
 # error_gen defined also in singularity_lib.sh
-[[ -e "$glidein_config" ]] && error_gen="$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)"
+[[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 if [[ -z "$3" ]]; then
     # initial invocation w/o script

--- a/creation/web_base/singularity_wrapper.sh
+++ b/creation/web_base/singularity_wrapper.sh
@@ -94,12 +94,8 @@ fi
 
 # TODO: Should I quit if glidein_config is not available?
 
-# import add_config_line function
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}')
-source $add_config_line_source
-
 # error_gen defined also in singularity_lib.sh
-[[ -e "$glidein_config" ]] && error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+[[ -e "$glidein_config" ]] && error_gen=$(grep -m1 '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)
 
 if [[ -z "$3" ]]; then
     # initial invocation w/o script

--- a/creation/web_base/smart_partitionable.sh
+++ b/creation/web_base/smart_partitionable.sh
@@ -21,9 +21,9 @@ function warn {
 }
 
 # import add_config_line function
-add_config_line_source="$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
 # shellcheck source=./add_config_line.source
-source "$add_config_line_source"
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 

--- a/creation/web_base/smart_partitionable.sh
+++ b/creation/web_base/smart_partitionable.sh
@@ -21,20 +21,20 @@ function warn {
 }
 
 # import add_config_line function
-add_config_line_source="`grep '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-`"
+add_config_line_source="$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)"
 # shellcheck source=./add_config_line.source
 source "$add_config_line_source"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-`"
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
 
 # not used - to remove
-# condor_vars_file="`grep -i "^CONDOR_VARS_FILE " "$glidein_config" | cut -d ' ' -f 2-`"
+# condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
 
-slots_layout=`grep '^SLOTS_LAYOUT ' "$glidein_config" | cut -d ' ' -f 2-`
+slots_layout=$(gconfig_get SLOTS_LAYOUT "$glidein_config")
 # fixed slot layout with resources added to the main slot can cause the startd to fail
 # if the number of resources is insufficient for the available slots
 # mainextra adds extra virtual cpus for the resource, so it is sure to fail with fixed slots
-condor_config_resource_slots="`grep -i "^GLIDEIN_Resource_Slots " "$glidein_config" | cut -d ' ' -f 2-`"
+condor_config_resource_slots=$(gconfig_get GLIDEIN_Resource_Slots "$glidein_config")
 echo "$condor_config_resource_slots" | grep mainextra > /dev/null
 if [[ "$?" -eq 0 ]]; then
   # sure error with fixed: force partitionable
@@ -53,7 +53,7 @@ fi
 # 2. If mainextra ResourceSlot is defined then switch fixed to partitionable
 if [[ "X$slots_layout" = "Xpartitionable" ]]; then
   # only need to worry about the partitionable use case
-  num_cpus=`grep '^GLIDEIN_CPUS ' "$glidein_config" | cut -d ' ' -f 2-`
+  num_cpus=$(gconfig_get GLIDEIN_CPUS "$glidein_config")
   if [[ -z "$num_cpus" ]]; then
     # the default is single core
     # there could be virtual cpus (mainextra) or more real CPUs (due to RSL request) both not in GLIDEIN_CPUS
@@ -64,7 +64,7 @@ if [[ "X$slots_layout" = "Xpartitionable" ]]; then
     # matches 1, 01, ... no match for other numbers or string values (AUTO, ...)
     # do not want single core partitionable slots
 
-    force_part=`grep '^FORCE_PARTITIONABLE ' "$glidein_config" | cut -d ' ' -f 2-`
+    force_part=$(gconfig_get FORCE_PARTITIONABLE "$glidein_config")
     if [[ "X$force_part" = "XTrue" ]]; then
       # unless forced to
       "$error_gen" -ok "smart_partitionable.sh" "Action" "ForcedSinglePartitionable"
@@ -72,7 +72,7 @@ if [[ "X$slots_layout" = "Xpartitionable" ]]; then
       # unless resource slot have mainextra type
       "$error_gen" -ok "smart_partitionable.sh" "Action" "ResourceSlotKeptPartitionable"
     else
-      add_config_line SLOTS_LAYOUT fixed
+      gconfig_add SLOTS_LAYOUT fixed
       "$error_gen" -ok "smart_partitionable.sh" "Action" "SwitchSingleToFixed"
     fi
   else
@@ -83,7 +83,7 @@ else
     # shellcheck disable=SC2071   # mean to compare first non numeric values of num_cpus, numeric comparison follows
     if [[ "X$RES_SLOT" = "Xmainextra" ]]; then
       # do not want fixed with mainextra resource slots (sure problem)
-      add_config_line SLOTS_LAYOUT partitionable
+      gconfig_add SLOTS_LAYOUT partitionable
       "$error_gen" -ok "smart_partitionable.sh" "Action" "SwitchResourceSlotToPartitionable"
     elif [[ "X$RES_SLOT" = "Xmain" ]] && [[ "$num_cpus" > "1" ||  "$num_cpus" -gt "1" ]]; then
       # do not want fixed with main resource slots and more than one CPU (possible problem)
@@ -93,7 +93,7 @@ else
       # -  "$num_cpus" -gt "1" catches numbers with prefixed 0s, e.g. 03 -gt 1
       # conditions are separated to be safer and more clear:
       #  tests show precedence left to right, but documentation no: https://www.tldp.org/LDP/abs/html/opprecedence.html
-      add_config_line SLOTS_LAYOUT partitionable
+      gconfig_add SLOTS_LAYOUT partitionable
       "$error_gen" -ok "smart_partitionable.sh" "Action" "SwitchResourceSlotToPartitionable"
     else
       "$error_gen" -ok "smart_partitionable.sh" "Action" "None"

--- a/creation/web_base/validate_node.sh
+++ b/creation/web_base/validate_node.sh
@@ -74,7 +74,8 @@ config_file="$1"
 
 # import add_config_line and add_condor_vars_line functions
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
-source "$add_config_line_source"
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
 error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 

--- a/creation/web_base/validate_node.sh
+++ b/creation/web_base/validate_node.sh
@@ -72,7 +72,11 @@ function check_quotas {
 # Assume all functions exit on error
 config_file="$1"
 
-error_gen="`grep '^ERROR_GEN_PATH ' "$config_file" | cut -d ' ' -f 2-`"
+# import add_config_line and add_condor_vars_line functions
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+source "$add_config_line_source"
+
+error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 
 #
 # Check space on current directory


### PR DESCRIPTION
Until now, `grep` was being used to read values from/write values to `glidein_config` when running system scripts during the glidein startup process. In 3.9.6, `add_config_line.source` was updated to include two utilities primarily to replace the grep-based logic in these scripts. The two functions, `gconfig_get` (for reading) and `gconfig_add` (for writing) will be used from release 3.9.7 onwards and therefore, the use of `grep`, for the purposes of reading and writing to `glidein_config` will be deprecated hereafter.

Note that, the `add_config_line.source` will need to be imported inside the script before either of the `gconfig_xxx` utilities can be invoked/used. It is only for this that `grep` and `cut` commands will continue to be used like before.