### PR TITLE
Improved regexes for issue labeler workflow

### DIFF
--- a/.github/issue-labeler-config-regexes.yaml
+++ b/.github/issue-labeler-config-regexes.yaml
@@ -56,7 +56,9 @@ factory-mon:
   - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]actory(?= [Mm]onitoring)\]?'
 frontend-mon:
   - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]rontend(?= [Mm]onitoring)\]?'
-# TODO: discuss if there are any other possible components that need to be listed above; add them here when needed
+other:
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?(?![Ff]rontend(?= [Mm]onitoring)|[Ff]actory(?! [Mm]onitoring)|[Gg]lidein|[Dd]ocumentation|(CI|ci|[Tt]esting)|[Rr]elease|[Ff]actory(?= [Mm]onitoring)|[Ff]rontend(?= [Mm]onitoring))\]?'
+# if there are any other possible components that need to be added to the list above, add them here when needed
 
 # TODO: regular expressions for labeling release info for an issue is listed in this block
 # 3.9.5:

--- a/.github/issue-labeler-config-regexes.yaml
+++ b/.github/issue-labeler-config-regexes.yaml
@@ -5,13 +5,13 @@
 
 # regular expressions for labeling priority of the issue is listed in this block
 Critical:
-  - "Priority: *([Cc]ritical|[Uu]rgent)"
+  - 'Priority: *(Priority level (of|for) this (bug|feature) *)?\[?([Cc]ritical|[Uu]rgent)\]?'
 High:
-  - "Priority: *[Hh]igh"
+  - 'Priority: *(Priority level (of|for) this (bug|feature) *)?\[?[Hh]igh\]?'
 Medium:
-  - "Priority: *[Mm]edium"
+  - 'Priority: *(Priority level (of|for) this (bug|feature) *)?\[?[Mm]edium\]?'
 Low:
-  - "Priority: *[Ll]ow"
+  - 'Priority: *(Priority level (of|for) this (bug|feature) *)?\[?[Ll]ow\]?'
 
 # regular expressions for labeling issue type is listed in this block
 BUG:
@@ -25,42 +25,40 @@ FEATURE:
 
 # regular expressions for labeling stakeholders for an issue is listed in this block
 cms:
-  - "Stakeholder: *(CMS|Cms|cms)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?(CMS|Cms|cms)\]?'
 factoryops:
-  - "Stakeholder: *([Ff]actory[Oo]ps)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?([Ff]actory[Oo]ps)\]?'
 fermilab:
-  - "Stakeholder: *([Ff]ermilab)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?([Ff]ermilab)\]?'
 fife:
-  - "Stakeholder: *(FIFE|Fife|fife)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?(FIFE|Fife|fife)\]?'
 # Historically IGWN had the LIGO name
 igwn:
-  - "Stakeholder: *(IGWN|Igwn|igwn|LIGO|Ligo|ligo)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?(IGWN|Igwn|igwn|LIGO|Ligo|ligo)\]?'
 osg:
-  - "Stakeholder: ?(OSG|Osg|osg)"
+  - 'Stakeholder: *(Concerned stakeholder\(s\) *)?\[?(OSG|Osg|osg)\]?'
+# if new stakeholders need to be included, add them here
 
 # regular expressions for labeling affected components for an issue is listed in this block
 frontend:
-  - "Component: *([Ff]rontend)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]rontend(?! [Mm]onitoring)\]?'
 factory:
-  - "Component: *([Ff]actory)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]actory(?! [Mm]onitoring)\]?'
 glidein:
-  - "Component: *([Gg]lidein)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Gg]lidein\]?'
 documentation:
-  - "Component: *([Dd]ocumentation)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?([Dd]ocumentation)\]?'
 ci-testing:
-  - "Component: *(CI|ci|[Tt]esting)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?(CI|ci|[Tt]esting)\]?'
 release:
-  - "Component: *([Rr]elease)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Rr]elease\]?'
 factory-mon:
-  - "Component: *([Ff]actory [Mm]onitoring)"
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]actory(?= [Mm]onitoring)\]?'
 frontend-mon:
-  - "Component: *([Ff]rontend [Mm]onitoring)"
-other:
-  - "Component: *.*"
-# TODO: discuss if there are any other possible components that need to be listed above
+  - 'Component: *(The affected component,? (due to this bug|if any, from this feature) *)?\[?[Ff]rontend(?= [Mm]onitoring)\]?'
+# TODO: discuss if there are any other possible components that need to be listed above; add them here when needed
 
 # TODO: regular expressions for labeling release info for an issue is listed in this block
-# 3.7.5:
 # 3.9.5:
 # 3.9.6:
 # 3.11:


### PR DESCRIPTION
Based on the recent runs of the issue labeler workflow deployed on the GWMS repository, this PR addresses some of the modifications to the existing workflow. The workflow runs revealed that
1. the label `other` gets always assigned, even when the issue description includes other affected components. The expected behavior was to have the `other` label assigned only when the issue description lists an affected component that is not listed in the set of components considered.
2. the labels did not get assigned when the descriptions of the categories/keywords were included along with the user-specified value for that keyword. The initial assumption was that users when opening issues will remove the descriptions and only mention the values for those keywords. But there may be times when that might not happen, meaning the descriptions might be preserved as-is along with the values specified by users when opening issues. 

For 1, the generic regular expression (regex) pattern is removed and instead an improvised regex pattern has been added where component names not listed in the starter set will be matched and assigned the `other` label. For 2, the regular expressions have been improvised to process descriptions of categories when determining labels for the corresponding category.