### PR TITLE
Fix for failing GWMS rpms build jobs

### DIFF
--- a/.github/actions/build-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/build-in-sl7-docker/entrypoint.sh
@@ -6,12 +6,12 @@
 export PYVER=${1:-"3.6"}
 GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-`pwd`}
 export SW_VER=${RELEASE_VERSION:-"master"}
-export RPM_VER=${RPM_VERSION:-"3.7.5"}
+# export RPM_VER=${RPM_VERSION:-"3.7.5"}
 export RPM_REL=${RPM_RELESE:-"55"}
 export RPM_FULLREL="$RPM_REL.post.$(date +"%Y%m%d%H%M")"
 export HERE="`pwd`"
 mkdir rel
-glideinwms/build/ReleaseManager/release.py --no-mock --release-version=$SW_VER --source-dir="$HERE"/glideinwms --release-dir="$HERE"/rel --rpm-release=$RPM_FULLREL --rpm-version=$RPM_VER
+glideinwms/build/ReleaseManager/release.py --no-mock --release-version=$SW_VER --source-dir="$HERE"/glideinwms --release-dir="$HERE"/rel --rpm-release=$RPM_FULLREL
 status=$?
 mkdir gwms_rpms
 #mkdir rpm_logs


### PR DESCRIPTION
When contributors push commits to their forked GWMS repository, one of the Github workflows that runs a check for building GWMS RPMs was failing. This PR provides the fix for the same.

Upon inspecting the log file corresponding to the rpm build workflow, the following error was reported:
```
release.py: error: no such option: --rpm-version
```

The usage documentation for `release.py` does not include/mention any option named `rpm-version`. The `release.py` script when invoked as part of the Github action, among other options, included an option named `rpm-version` even though the script did not support such an option. Removing the option from the invocation line results in the build workflow to complete successfully without any further errors.

