### PR TITLE
Use correct variable for $exit_code in singularity_exec_simple

### DIFF
--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1251,7 +1251,7 @@ singularity_exec_simple() {
     local error exit_code
     { error=$(singularity_exec "$singularity_bin" "$singularity_image" "$singularity_binds" \
             "$GLIDEIN_SINGULARITY_OPTS" "$GLIDEIN_SINGULARITY_GLOBAL_OPTS" "" "${@}" 2>&1 >&3 3>&-); } 3>&1
-    exit_code=$1
+    exit_code=$?
     echo "$error" >&2
     if [[ $exit_code -eq 0 ]] && echo "$error" | grep -q "^FATAL:"; then
         warn "singularity/apptainer exited w/ 0 but seems to have a FATAL error reported in stderr"


### PR DESCRIPTION
this was causing the code
```
singularity_exec_simple /usr/bin/singularity /cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el8:latest cat /proc/self/uid_map
```
to try to do a `return cat` which resulted in failure