### PR TITLE
Add PyYAML to the factory dependencies

### DIFF
--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -261,6 +261,7 @@ Requires: python36-requests
 Requires: python36-jwt
 %endif
 Requires: python3-rrdtool
+Requires: PyYAML
 Requires(post): /sbin/service
 Requires(post): /usr/sbin/useradd
 Requires(post): /sbin/chkconfig


### PR DESCRIPTION
In order to get `OSG_autoconf` to work this has been installed in the factory:

```
PyYAML.x86_64                        3.10-11.el7                    @base 
```

I think it should be added as a dependency to the factory RPM.

PS: I have not tested this PR, hopefully I got it right. Please double check.