### PR TITLE
Fix nullglob problems

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: python-check-blanket-type-ignore
       - id: python-use-type-annotations
   - repo: "https://github.com/pycqa/isort"
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: "https://github.com/psf/black"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 ### Bug Fixes
 
 -   Make sure default value does not overwrite global one for idtoken_lifetime (PR #261)
--   Protect OSG_autoconf from OSG collector unavailability (PR #276) 
+-   Protect OSG_autoconf from OSG collector unavailability (PR #276)
 
 ### Testing / Development
 

--- a/creation/lib/cgWCreate.py
+++ b/creation/lib/cgWCreate.py
@@ -171,7 +171,7 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
         enc_input_files.append("$ENV(IDTOKENS_FILE:)")
         self.add_environment("IDTOKENS_FILE=$ENV(IDTOKENS_FILE:)")
 
-        if gridtype not in ["ec2", "gce"] and not (gridtype=="arc" and auth_method=="grid_proxy"):
+        if gridtype not in ["ec2", "gce"] and not (gridtype == "arc" and auth_method == "grid_proxy"):
             self.add("+SciTokensFile", '"$ENV(SCITOKENS_FILE:)"')
 
         # Folders and files of tokens for glidein logging authentication
@@ -243,7 +243,7 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
             self.populate_condorc_grid()
         elif gridtype == "arc":
             # not adding a function for one line for the moment
-            self.add("x509UserProxy", '$ENV(X509_USER_PROXY:)')
+            self.add("x509UserProxy", "$ENV(X509_USER_PROXY:)")
         else:
             self.populate_standard_grid(rsl, auth_method, gridtype, entry_enabled, entry_name, enc_input_files)
 

--- a/creation/web_base/glidein_paths.source
+++ b/creation/web_base/glidein_paths.source
@@ -50,7 +50,8 @@ gwms_process_scripts() {
         return
     fi
     for i in * ; do
-        [[ "$i" = *.ignore ]] && continue
+        [[ -e "$i" ]] || continue  # protect against nullglob (no match)
+        [[ "$i" != *.ignore ]] || continue
         if [[ -x "$i" ]]; then
             # run w/ some protection?
             "./$i" "$cfg_file"

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -117,7 +117,7 @@ copy_all() {
    # should it copy also hidden files?
    mkdir -p "$2"
    for f in *; do
-       [[ -e "${f}" ]] || break    # TODO: should this be a continue?
+       [[ -e "${f}" ]] || break    # protect for nullglob TODO: should this be a continue?
        if [[ "${f}" = ${1}* ]]; then
            continue
        fi
@@ -1028,31 +1028,6 @@ set_proxy_fullpath() {
 
 num_gct=0
 
-# TODO: this is covered in setup_x590,sh - remove once verified
-#for tk in "$(pwd)/credential_"*".idtoken"; do
-#  echo "Setting GLIDEIN_CONDOR_TOKEN to ${tk} " 1>&2
-#  num_gct=$(( num_gct + 1 ))
-#  export GLIDEIN_CONDOR_TOKEN="${tk}"
-#  fullpath="$(readlink -f "${tk}" )"
-#  if [ $? -eq 0 ]; then
-#     echo "Setting GLIDEIN_CONDOR_TOKEN ${tk} to canonical path ${fullpath}" 1>&2
-#     export GLIDEIN_CONDOR_TOKEN="${fullpath}"
-#  else
-#     echo "Unable to get canonical path for GLIDEIN_CONDOR_TOKEN ${tk}" 1>&2
-#  fi
-#done
-#if [ ! -f "${GLIDEIN_CONDOR_TOKEN}" ] ; then
-#    token_err_msg="problem setting GLIDEIN_CONDOR_TOKEN"
-#    token_err_msg="${token_err_msg} will attempt to recover, but condor IDTOKEN auth may fail"
-#    echo "${token_err_msg}"
-#    echo "${token_err_msg}" 1>&2
-#fi
-#if [ ! "${num_gct}" -eq  1 ] ; then
-#    token_err_msg="WARNING  GLIDEIN_CONDOR_TOKEN set ${num_gct} times, should be 1 !"
-#    token_err_msg="${token_err_msg} condor IDTOKEN auth may fail"
-#    echo "${token_err_msg}"
-#    echo "${token_err_msg}" 1>&2
-#fi
 
 ########################################
 # prepare and move to the work directory

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -373,6 +373,7 @@ log_coalesce_shards() {
             pushd shards/coalescing > /dev/null
             sed -i '$ {s/]$/,/}' "${log_logfile}"   # replace last square bracket with comma
             for shd in *.shard; do                  # concatenate separating with comma
+                [[ -e "$shd" ]] || continue  # protect against nullglob (no match)
                 cat "${shd}"
                 echo ","
             done >> "${log_logfile}"

--- a/creation/web_base/setup_x509.sh
+++ b/creation/web_base/setup_x509.sh
@@ -69,6 +69,7 @@ refresh_credentials() {
         to_dir=$(dirname "${token_to}")
         if [[ -d "${from_dir}" && -d "${to_dir}" ]]; then
             for tok in "${from_dir}"/*.idtoken; do
+                [[ -e "$tok" ]] || continue  # protect against nullglob (no match)
                 cp "${tok}" "${to_dir}" && refreshed="True"
             done
         else
@@ -313,6 +314,7 @@ copy_idtokens() {
         return 1
     fi
     for i in *.idtoken; do
+        [[ -e "$i" ]] || continue  # protect against nullglob (no match)
         if cp "$i" "$to_dir/$i"; then
             if [[ "$i" == ce_*.idtoken ]]; then
                 warn "Copied CE collector token '${i}' to '${to_dir}/'"
@@ -468,7 +470,7 @@ _main() {
                     export X509_USER_PROXY_ORIG="$X509_USER_PROXY"
                     export X509_USER_PROXY="$out"
                     if out=$(get_x509_expiration "$X509_USER_PROXY"); then
-                        # Copy succesfull and proxy valid, set values in glidein_config
+                        # Copy successful and proxy valid, set values in glidein_config
                         gconfig_add X509_CERT_DIR   "$X509_CERT_DIR"
                         gconfig_add X509_USER_PROXY "$X509_USER_PROXY"
                         gconfig_add X509_USER_PROXY_ORIG "$X509_USER_PROXY_ORIG"

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -382,7 +382,8 @@ gwms_process_scripts() {
         return
     fi
     for i in * ; do
-        [[ "$i" = *.ignore ]] && continue
+        [[ -e "$i" ]] || continue  # protect against nullglob (no match)
+        [[ "$i" != *.ignore ]] || continue
         if [[ -x "$i" ]]; then
             # run w/ some protection?
             "./$i" "$cfg_file"

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -239,7 +239,8 @@ SPDX-License-Identifier: Apache-2.0
             <a href="#security"
               >&lt;security classad_proxy="/etc/grid-security/hostcert.pem"
               comment="use hostcert here if not doing GSI authentication through
-              GWMS versions 3.6.5" idtoken_lifetime="24" idtoken_keyname="FRONTEND"
+              GWMS versions 3.6.5" idtoken_lifetime="24"
+              idtoken_keyname="FRONTEND"
               proxy_DN="/DC=org/DC=doegrids/OU=Services/CN=frontend-server.fnal.gov"
               proxy_selection_plugin="ProxyAll" security_name="frontenduser"
               sym_key="aes_256_cbc"&gt;</a
@@ -713,8 +714,9 @@ SPDX-License-Identifier: Apache-2.0
               factory. <br />
               The idtoken_lifetime is used to indicate the number of hours the
               idtoken is valid. The idtoken is used on the worker node to
-              connect back to the VO collector. It is possible to set the
-              key used to generate these token by using the idtoken_keyname parameter.
+              connect back to the VO collector. It is possible to set the key
+              used to generate these token by using the idtoken_keyname
+              parameter.
               <br />For A GSI free configuration, set the classad_proxy to
               "/etc/grid-security/hostcert.pem" and set up a scitoken in the
               &lt;credentials&gt; section below.

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -1809,6 +1809,7 @@ def get_submit_environment(
         if "frontend_condortoken" in submit_credentials.identity_credentials:
             exe_env.append("IDTOKENS_FILE=%s" % submit_credentials.identity_credentials["frontend_condortoken"])
         else:
+            # TODO: this ends up transferring an empty file called 'null' in the Glidein start dir. Find a better way
             exe_env.append("IDTOKENS_FILE=/dev/null")
 
         # The parameter list to be added to the arguments for glidein_startup.sh

--- a/factory/tools/OSG_autoconf.py
+++ b/factory/tools/OSG_autoconf.py
@@ -40,8 +40,8 @@ def parse_opts():
 
     parser.add_argument(
         "--cache-fallback",
-        action='store_true',
-        help="Apply changes in the whitelist yaml files even if the collector is not responding. Uses the OSG_YAML cached data"
+        action="store_true",
+        help="Apply changes in the whitelist yaml files even if the collector is not responding. Uses the OSG_YAML cached data",
     )
 
     args = parser.parse_args()
@@ -617,7 +617,10 @@ def main(args):
         # Write the received information to the OSG.yml file
         write_to_yaml_file(config["OSG_YAML"], result)
     except htcondor.HTCondorIOError as e:
-        print("\033[91mWARNING!\033[0m The query to the collector %s returned the following error '%s'." % (config["OSG_COLLECTOR"], str(e)))
+        print(
+            "\033[91mWARNING!\033[0m The query to the collector %s returned the following error '%s'."
+            % (config["OSG_COLLECTOR"], str(e))
+        )
         if args.cache_fallback is True:
             print("Will continue and merge the yaml file using the old cached data in %s." % config["OSG_YAML"])
         else:
@@ -632,7 +635,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    # Argument parsing out of the try/except because it has its own error handling/exception throwing 
+    # Argument parsing out of the try/except because it has its own error handling/exception throwing
     args = parse_opts()
     try:
         main(args)


### PR DESCRIPTION
Fixing possible nullglob problems:
- when using wildcards in a for loop, e.g. `for i in *.txt`, if there is no match the shell will return the string with wildcards as value in the loop
- to solve you have to check for file existence (`[ -e "$i" ] || continue`) or use `shopt -s nullglob` to change the behavior in bash

This PR upgrades also the isort version in pre-commit to 5.11.5 to fix an isort bug w/ poetry and maintain python 3.7 compatibility