### PR TITLE
Removing wrong classad Python module from requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## Changes Since Last Release
+
+Changes since the last release
+
+### New features / functionalities
+
+### Changed defaults / behaviours
+
+### Deprecated / removed options and commands
+
+### Security Related Fixes
+
+### Bug Fixes
+
+-   Removed `classad` from requirements.txt. The HTCSS team distributes only the `htcondor` library in PyPI which includes a different version of classad
+
+### Testing / Development
+
+### Known Issues
+
 ## v3.10.2 \[2023-5-10\]
 
 ### New features / functionalities

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # for runtime
 htcondor
-classad
+# This is not from the HTCondor team. HTCSS classad is included in the htcondor package (J.Patton,C.Bollig)
+# classad  # pure python 3rd party classad implementation
 m2crypto
 requests
 pyyaml


### PR DESCRIPTION
Removing classad from requirements.txt as suggested by the HTCondor team (J.Patton, C.Bollig)

classad was pulling a pure Python implementation from  https://pypi.org/project/classad

Regular installations use the `python3-condor` RPM instead of PyPI.