### PR TITLE
Deprecation of getchildren() in ElementTree

### DIFF
--- a/creation/lib/check_python3_expr.py
+++ b/creation/lib/check_python3_expr.py
@@ -123,7 +123,7 @@ def findall_path(root, tag, elements=[]):
     else:
         element = root
 
-    for child in element.data.getchildren():
+    for child in list(element.data):
         newElement = SimpleNamespace()
         newElement.data = child
         newElement.parent = element
@@ -165,7 +165,7 @@ def match_attrs_to_tuples(match_attrs):
     """
 
     tuples = []
-    for attr in match_attrs.getchildren():
+    for attr in list(match_attrs):
         tuples.append((attr.attrib["name"], attr.attrib["type"]))
     return tuples
 


### PR DESCRIPTION
Fixes #299.

A [quick search](https://github.com/ocrmypdf/OCRmyPDF/issues/583#issuecomment-647787355) of the `AttributeError` revealed that `getchildren()` method has been deprecated since Python 3.2 but has not been warned about until v3.8. Further, the deprecation has been removed in Python 3.9. [This was also suspected by Bruno Coimbra during a discussion]

Ref: [Python 3.8 documentation](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren)

As part of the investigation, also checked to compare the deprecated behavior of `getchildren()` [from Python 3.6] with `list()` from v3.8+ to make sure the outputs were identical (i.e. the result set and the type of the result). The outputs, along with their type, from the deprecated and the current approaches seems to be consistent with one another.
(Thanks to @BrunoCoimbra for recommending to do this exercise as part of the investigation!)

Following is the code snippet from the testing: ()
```
[root@fermicloud512 gwms-frontend]# python3
Python 3.6.8 (default, Nov 10 2020, 07:30:01) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import xml.etree.ElementTree as ET
>>> a = ET.Element('a')
>>> b = ET.SubElement(a, 'b')
>>> c = ET.SubElement(a, 'c')
>>> d = ET.SubElement(a, 'd')
>>> e = ET.SubElement(b, 'e')
>>> f = ET.SubElement(d, 'f')
>>> g = ET.SubElement(d, 'g')
>>> for child in a.getchildren():
...     print(child)
... 
<Element 'b' at 0x7f29cf306f98>
<Element 'c' at 0x7f29cf28b958>
<Element 'd' at 0x7f29cf28b2c8>
>>> for child in a.getchildren():
...     print(type(child))
... 
<class 'xml.etree.ElementTree.Element'>
<class 'xml.etree.ElementTree.Element'>
<class 'xml.etree.ElementTree.Element'>
>>> for child in list(a):
...     print(child)
... 
<Element 'b' at 0x7f29cf306f98>
<Element 'c' at 0x7f29cf28b958>
<Element 'd' at 0x7f29cf28b2c8>
>>> for child in list(a):
...     print(type(child))
... 
<class 'xml.etree.ElementTree.Element'>
<class 'xml.etree.ElementTree.Element'>
<class 'xml.etree.ElementTree.Element'>
>>> 
```
