### PR TITLE
imp module deprecated in favor of importlib module

### DIFF
--- a/creation/lib/matchPolicy.py
+++ b/creation/lib/matchPolicy.py
@@ -14,7 +14,7 @@
 #   Parag Mhashilkar
 #
 
-import imp
+import importlib
 import os
 
 # import imp
@@ -83,9 +83,10 @@ class MatchPolicy:
             self.searchPath = search_path
             try:
                 # First find the module
-                f, path, desc = imp.find_module(self.name, self.searchPath)
+                f, path, desc = importlib.util.find_spec(self.name, self.searchPath)
                 # Load the module
-                self.pyObject = imp.load_module(self.name, f, path, desc)
+                spec = importlib.util.spec_from_file_location(self.name, path)
+                self.pyObject = importlib.util.module_from_spec(spec)
             except:
                 raise MatchPolicyLoadError(file=file, search_path=self.searchPath)
         else:

--- a/creation/lib/matchPolicy.py
+++ b/creation/lib/matchPolicy.py
@@ -16,8 +16,6 @@
 
 import importlib
 import os
-
-# import imp
 import os.path
 
 # import copy


### PR DESCRIPTION
Fixes #300.

Per documentation available [here](https://docs.python.org/3/library/imp.html), the imp module is deprecated since version 3.4 and will be removed in version 3.12. Additionally, this module is deprecated in favor of [importlib](https://docs.python.org/3/library/importlib.html#module-importlib).

The `find_module` and `load_module` methods are to be replaced with a combination of importlib.util.spec_from_file_location() and importlib.util.module_from_spec() respectively, since `imp.load_module` was previously called directly with file path arguments