### PR TITLE
Avoid invocation of cvmfsexec distros building if not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes since the last release
 -   Removed `classad` from requirements.txt. The HTCSS team distributes only the `htcondor` library in PyPI which includes a different version of classad (PR #301)
 -   Fixing Python 3.9 deprecations (`imp`, `getchildren()` in `xml.etree.ElementTree`) (PR #302, PR #303)
 -   Populate missing Entry parameters for ARC CEs submissions (PR #304)
+-   Do not for call cvmfsexec script if not necessary (PR #309)
 
 ### Testing / Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes since the last release
 -   Removed `classad` from requirements.txt. The HTCSS team distributes only the `htcondor` library in PyPI which includes a different version of classad (PR #301)
 -   Fixing Python 3.9 deprecations (`imp`, `getchildren()` in `xml.etree.ElementTree`) (PR #302, PR #303)
 -   Populate missing Entry parameters for ARC CEs submissions (PR #304)
--   Do not for call cvmfsexec script if not necessary (PR #309)
+-   Modified the usage of subprocess module, for building/rebuilding cvmfsexec distributions, only when necessary (PR #309)
 
 ### Testing / Development
 

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -326,8 +326,9 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         # framing the arguments to the subprocess wrapper as a string
         # executing the cvmfsexec distribution building script can be done without explicitly specifying the location of the script since it is in the PATH variable (directory is /usr/bin/ which is set as the standard for the RPM installation)
         args = " ".join(["create_cvmfsexec_distros.sh", "--work-dir", self.work_dir, cfgs, mtypes])
-        cvmfsexec_distros_build_out = subprocessSupport.iexe_cmd(args)
-        print(cvmfsexec_distros_build_out)  # prints the output from the shell script executed in the previous line
+        if cfgs != "" and mtypes != "":
+            cvmfsexec_distros_build_out = subprocessSupport.iexe_cmd(args)
+            print(cvmfsexec_distros_build_out)  # prints the output from the shell script executed in the previous line
         if cfgs:  # since 'sources' is a required attribute and therefore used as a control knob
             # get the location of the tarballs created during reconfig/upgrade
             distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -326,10 +326,9 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         # framing the arguments to the subprocess wrapper as a string
         # executing the cvmfsexec distribution building script can be done without explicitly specifying the location of the script since it is in the PATH variable (directory is /usr/bin/ which is set as the standard for the RPM installation)
         args = " ".join(["create_cvmfsexec_distros.sh", "--work-dir", self.work_dir, cfgs, mtypes])
-        if cfgs != "" and mtypes != "":
+        if cfgs:  # since 'sources' is a required attribute and therefore used as a control knob
             cvmfsexec_distros_build_out = subprocessSupport.iexe_cmd(args)
             print(cvmfsexec_distros_build_out)  # prints the output from the shell script executed in the previous line
-        if cfgs:  # since 'sources' is a required attribute and therefore used as a control knob
             # get the location of the tarballs created during reconfig/upgrade
             distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
             try:
@@ -377,6 +376,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                     self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
             ### for dynamic selection of cvmfsexec distribution -- block end
         else:
+            if not mtypes:
+                print("No sources specified. Building/Rebuilding of cvmfsexec distributions disabled!\n")
             print("=======================!!WARNING!!========================")
             print(
                 "There might be existing cvmfsexec distributions, from a \nprevious factory reconfig that might be obsolete in case \n"


### PR DESCRIPTION
As identified in #308, this PR brings in a change to the existing use of `subprocess` module (via the GWMS `subprocessSupport` module) for efficiency purposes.

Currently, the `subprocessSupport` module is used to execute `/usr/bin/create_cvmfsexec_distros.sh` always, regardless of whether cvmfsexec distributions are required to be built or rebuilt. If CVMFS is not needed and the `cvmfsexec_distro` tag is not defined in the factory configuration (disabled mode), then calling `subprocessSupport` to execute the script is basically unnecessary. Additionally, since `subprocess` spawns a new process to execute the script, this might result in a memory-intensive operation in a production setting. 