### PR TITLE
Minor updates for on-demand cvmfsexec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Changes since the last release
 
 ### Known Issues
 
+-   When generating cvmfsexec distribution for el9 machine type on an el7 machine, the factory reconfig and/or upgrade fails as a result of an error in `create_cvmfsexec_distros.sh`. This is possibly due to the tools for el7 being unable to handle el9 files (as per Dave Dykstra). Please exercise caution if using `rhel9-x86_64` in the `mtypes` list for the `cvmfsexec_distro` tag in factory configuration.
+    -   Our workaround: the el9 machine type has been removed from the default list of machine types supported by the custom distros creation script.
+
 ## v3.10.2 \[2023-5-10\]
 
 ### New features / functionalities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
--   Added `cvmfsexec_distro` tag as part of out-of-the-box factory configuration after a fresh installation; its behavior (on-demand cvmfsexec in disabled mode) remains unchanged (PR #312)
+-   Added `cvmfsexec_distro` tag to be included in the factory configuration out-of-the-box (fresh installation) as well as through an upgrade; its behavior (on-demand cvmfsexec in disabled mode) remains unchanged (PR #312)
 
 ### Deprecated / removed options and commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
+-   Added `cvmfsexec_distro` tag as part of out-of-the-box factory configuration after a fresh installation; its behavior (on-demand cvmfsexec in disabled mode) remains unchanged (PR #312)
+
 ### Deprecated / removed options and commands
 
 ### Security Related Fixes
@@ -27,7 +29,7 @@ Changes since the last release
 ### Known Issues
 
 -   When generating cvmfsexec distribution for el9 machine type on an el7 machine, the factory reconfig and/or upgrade fails as a result of an error in `create_cvmfsexec_distros.sh`. This is possibly due to the tools for el7 being unable to handle el9 files (as per Dave Dykstra). Please exercise caution if using `rhel9-x86_64` in the `mtypes` list for the `cvmfsexec_distro` tag in factory configuration.
-    -   Our workaround: the el9 machine type has been removed from the default list of machine types supported by the custom distros creation script.
+    -   Our workaround: the el9 machine type has been removed from the default list of machine types supported by the custom distros creation script (PR #312)
 
 ## v3.10.2 \[2023-5-10\]
 

--- a/build/packaging/rpm/glideinWMS.xml
+++ b/build/packaging/rpm/glideinWMS.xml
@@ -63,6 +63,7 @@ SPDX-License-Identifier: Apache-2.0
    <condor_tarballs>
       <condor_tarball arch="default" base_dir="/usr" os="default" version="default"/>
    </condor_tarballs>
+   <cvmfsexec_distro sources="" platforms="" />
    <files>
    </files>
 </glidein>

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -9,8 +9,9 @@
 # Hardcoded variables
 CVMFSEXEC_REPO="https://www.github.com/cvmfs/cvmfsexec.git"
 DEFAULT_WORK_DIR="/var/lib/gwms-factory/work-dir"
-# TODO: add rhel9, other rhel derivatives and opensuse derivatives to the default list below eventually
-DEFAULT_MACHINE_TYPES="rhel7-x86_64,rhel8-x86_64,suse15-x86_64"
+# TODO: periodically add rhel, suse and other derivatives as supported by cvmfsexec
+# NOTE: ignoring rhel9-x86_64 (although supported) since el7 tools cannot work with el9 files at the moment (as suggested by Dave Dykstra)
+DEFAULT_MACHINE_TYPES="rhel7-x86_64,rhel8-x86_64,suse15-x86_64,rhel8-aarch64,rhel8-ppc64le"
 
 usage() {
 cat << EOF
@@ -24,7 +25,7 @@ or a comma-separated list of values from the options {osg|egi|default}.
 
 PLATFORMS_LIST (optional): indicates machine types (platform- and architecture-based)
 for which distributions is to be built. Can be empty, a single value or a
-comma-separated list of values from the options {rhel7-x86_64|rhel8-x86_64|suse15-x86_64}.
+comma-separated list of values from the options {rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel8-aarch64|rhel8-ppc64le}.
 EOF
 }
 
@@ -117,6 +118,9 @@ build_cvmfsexec_distros() {
 						if tar -cvzf "$cvmfsexec_tarballs"/cvmfsexec_"${cvmfs_src}"_"${os}"_"${arch}".tar.gz -C "$cvmfsexec_distros" cvmfsexec-"${cvmfs_src}"-"${os}"-"${arch}" &> /dev/null; then
 							((successful_builds+=1))
 						fi
+					else
+						echo "Something went wrong!"
+						exit 1
 					fi
 				else
 					echo " Failed! REASON: $cvmfs_src may not yet have a $mach_type build."
@@ -177,8 +181,8 @@ fi
 
 # after confirming that the remaining number of arguments to be either 1 or 2
 re_sources="^((osg|egi|default),)*(osg|egi|default),?$"
-# TODO: update the regex for machine types upon checking with `makedist -h` periodically
-re_mtypes="^((rhel(7|8)|suse15)(-x86_64),?)+$"
+# TODO: update the regex for rhel9 and other machine types upon checking with `makedist -h` periodically
+re_mtypes="^((rhel(7|8)|suse15)(-(x86_64|aarch64|ppc64le),?))+$"
 # check whether the first argument is sources (strict ordering followed)
 if ! [[ "$1" =~ $re_sources ]]; then
 	error_handler "Invalid source(s) provided (comma-separated list with osg|egi|default), not '$1'"
@@ -190,7 +194,7 @@ elif [[ "$2" =~ $re_mtypes ]]; then
 	machine_types=$2
 else
 	# handle if there were typos in the arguments passed
-	error_handler "Invalid platform provided. Must be empty or comma-separated list with (rhel7-x86_64|rhel8-x86_64|suse15-x86_64), not '$2'"
+	error_handler "Invalid platform provided. Must be empty or comma-separated list with (rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel8-aarch64|rhel8-ppc64le), not '$2'"
 fi
 
 echo "(Re)Building of cvmfsexec distributions enabled!"

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -25,7 +25,7 @@ or a comma-separated list of values from the options {osg|egi|default}.
 
 PLATFORMS_LIST (optional): indicates machine types (platform- and architecture-based)
 for which distributions is to be built. Can be empty, a single value or a
-comma-separated list of values from the options {rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel8-aarch64|rhel8-ppc64le}.
+comma-separated list of values from the options {rhel9-x86_64|rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel8-aarch64|rhel8-ppc64le}.
 EOF
 }
 
@@ -182,7 +182,7 @@ fi
 # after confirming that the remaining number of arguments to be either 1 or 2
 re_sources="^((osg|egi|default),)*(osg|egi|default),?$"
 # TODO: update the regex for rhel9 and other machine types upon checking with `makedist -h` periodically
-re_mtypes="^((rhel(7|8)|suse15)(-(x86_64|aarch64|ppc64le),?))+$"
+re_mtypes="^((rhel(7|8|9)|suse15)(-(x86_64|aarch64|ppc64le),?))+$"
 # check whether the first argument is sources (strict ordering followed)
 if ! [[ "$1" =~ $re_sources ]]; then
 	error_handler "Invalid source(s) provided (comma-separated list with osg|egi|default), not '$1'"
@@ -194,7 +194,7 @@ elif [[ "$2" =~ $re_mtypes ]]; then
 	machine_types=$2
 else
 	# handle if there were typos in the arguments passed
-	error_handler "Invalid platform provided. Must be empty or comma-separated list with (rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel8-aarch64|rhel8-ppc64le), not '$2'"
+	error_handler "Invalid platform provided. Must be empty or comma-separated list with (rhel7-x86_64|rhel8-x86_64|suse15-x86_64|rhel9-x86_64|rhel8-aarch64|rhel8-ppc64le), not '$2'"
 fi
 
 echo "(Re)Building of cvmfsexec distributions enabled!"

--- a/creation/lib/factoryXmlConfig.py
+++ b/creation/lib/factoryXmlConfig.py
@@ -197,8 +197,9 @@ class CvmfsexecDistroElement(xmlConfig.DictElement):
         return self["platforms"]
 
     def setPlatforms(self):
-        # TODO: add rhel9, other rhel derivatives and other suse derivatives supported by cvmfsexec eventually
-        self["platforms"] = "rhel7-x86_64,rhel8-x86_64,suse15-x86_64"
+        # TODO: periodically add rhel, suse and other derivatives as supported by cvmfsexec
+        # NOTE: ignoring rhel9-x86_64 (although supported) since el7 tools cannot work with el9 files at the moment (as suggested by Dave Dykstra)
+        self["platforms"] = "rhel7-x86_64,rhel8-x86_64,suse15-x86_64,rhel8-aarch64,rhel8-ppc64le"
 
 
 xmlConfig.register_tag_classes({"cvmfsexec_distro": CvmfsexecDistroElement})


### PR DESCRIPTION
This PR brings in a couple of updates to the existing on-demand cvmfs provisioning support in GlideinWMS. 

1. While `rhel9-x86_64` is supported as a machine type by _cvmfsexec_, the `makedist` script fails when trying to generate a cvmfsexec distribution for this machine type on an el7 platform which causes the factory reconfig/upgrade to fail. Since a majority of the worker nodes are on el7, the suggestion was to exclude `rhel9-x86_64` from our list of possible machine types until the _cvmfsexec_ package is able to handle this. CHANGELOG has been updated about generating an el9 distro on an el7 machine for cvmfsexec (see Known Issues section). 

2. The `cvmfsexec_distro` tag is now included in the factory configuration to be available out-of-the-box with a fresh install/upgrade of GWMS. Although previously, building of cvmfsexec distributions was disabled by default (even without this tag in the xml), the tag was added to enforce consistency.