### PR TITLE
Fixed idtoken error

### DIFF
--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -1152,7 +1152,7 @@ class glideinFrontendElement:
                     # The token file is read as text file below. Writing fixed to be consistent
                     with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=tkn_dir) as fd:
                         os.chmod(fd.name, 0o600)
-                        fd.write(tkn_str.encode())
+                        fd.write(tkn_str)
                         os.replace(fd.name, tkn_file)
                     logSupport.log.debug("created token %s" % tkn_file)
                 elif os.path.exists(tkn_file):

--- a/lib/defaults.py
+++ b/lib/defaults.py
@@ -35,11 +35,12 @@ def force_bytes(instr, encoding=BINARY_ENCODING_CRYPTO):
         ValueError: if it detects an improper str conversion (b'' around the string)
     """
     if isinstance(instr, str):
-        # raise Exception("ALREADY str!")
+        # raise Exception("ALREADY str!")  # Use this for investigations
         if instr.startswith("b'"):
             raise ValueError(
                 "Input was improperly converted into string (resulting in b'' characters added): %s" % instr
             )
+        # If the encoding is known codecs can be used for more efficiency, e.g. codecs.latin_1_encode(x)[0]
         return instr.encode(encoding)
     return instr
 


### PR DESCRIPTION
Fixed writing of cached token as str 
and removed in token_util.py extra decoding that was corrupting idtokens and causing the Glidein schedd authentication to fail.

jwt.encode can accept a string as a key, but will encode it in utf-8, not latin-1, causing a different value (corrupted token)