### PR TITLE
Fix argmuent parsing for gwms-factory upgrade

### DIFF
--- a/creation/templates/factory_initd_startup_template
+++ b/creation/templates/factory_initd_startup_template
@@ -473,23 +473,21 @@ upgrade() {
         writeback=$DEFAULT_WRITEBACK
         force_delete=""
         fix_rrd=""
-        if [ -n "$@" ]; then
-            for var in "$@"
-            do
-                case "$var" in
-                yes | no) writeback="$var"
-                    ;;
-                "-force_delete") force_delete="-force_delete"
-                    ;;
-                "-fix_rrd") fix_rrd="-fix_rrd"
-                    ;;
-                *)  echo "Invalid option: $var"
-                    help_usage
-                    exit 2
-                    ;;
-                esac
-            done
-        fi
+        for var in "$@"
+        do
+            case "$var" in
+            yes | no) writeback="$var"
+                ;;
+            "-force_delete") force_delete="-force_delete"
+                ;;
+            "-fix_rrd") fix_rrd="-fix_rrd"
+                ;;
+            *)  echo "Invalid option: $var"
+                help_usage
+                exit 2
+                ;;
+            esac
+        done
 
         pushd $factory_dir 1>/dev/null
         if [ "$RPM_INSTALL" = "True" ]; then

--- a/creation/templates/factory_initd_startup_template_sl7
+++ b/creation/templates/factory_initd_startup_template_sl7
@@ -467,23 +467,21 @@ upgrade() {
         writeback=$DEFAULT_WRITEBACK
         force_delete=""
         fix_rrd=""
-        if [ -n "$@" ]; then
-            for var in "$@"
-            do
-                case "$var" in
-                yes | no) writeback="$var"
-                    ;;
-                "-force_delete") force_delete="-force_delete"
-                    ;;
-                "-fix_rrd") fix_rrd="-fix_rrd"
-                    ;;
-                *)  echo "Invalid option: $var"
-                    help_usage
-                    exit 2
-                    ;;
-                esac
-            done
-        fi
+        for var in "$@"
+        do
+            case "$var" in
+            yes | no) writeback="$var"
+                ;;
+            "-force_delete") force_delete="-force_delete"
+                ;;
+            "-fix_rrd") fix_rrd="-fix_rrd"
+                ;;
+            *)  echo "Invalid option: $var"
+                help_usage
+                exit 2
+                ;;
+            esac
+        done
 
         pushd $factory_dir 1>/dev/null
         if [ "$RPM_INSTALL" = "True" ]; then

--- a/unittests/fixtures/factory/work-dir/factory_startup
+++ b/unittests/fixtures/factory/work-dir/factory_startup
@@ -466,23 +466,21 @@ upgrade() {
         writeback=$DEFAULT_WRITEBACK
         force_delete=""
         fix_rrd=""
-        if [ -n "$@" ]; then
-            for var in "$@"
-            do
-                case "$var" in
-                yes | no) writeback="$var"
-                    ;;
-                "-force_delete") force_delete="-force_delete"
-                    ;;
-                "-fix_rrd") fix_rrd="-fix_rrd"
-                    ;;
-                *)  echo "Invalid option: $var"
-                    help_usage
-                    exit 2
-                    ;;
-                esac
-            done
-        fi
+        for var in "$@"
+        do
+            case "$var" in
+            yes | no) writeback="$var"
+                ;;
+            "-force_delete") force_delete="-force_delete"
+                ;;
+            "-fix_rrd") fix_rrd="-fix_rrd"
+                ;;
+            *)  echo "Invalid option: $var"
+                help_usage
+                exit 2
+                ;;
+            esac
+        done
 
         pushd $factory_dir 1>/dev/null
         if [ "$RPM_INSTALL" = "True" ]; then


### PR DESCRIPTION
This PR removes a redundant `if` statement that contained a bash syntax error. The extra statement prevented commands such as `gwms-factory upgrade -force_delete` from working as expected, making it impossible to remove entries from Factories.

From shellcheck:
```
Arrays don't work as operands in [ ]. Use a loop (or concatenate with * instead of @).
```