### PR TITLE
Added support for structured logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since the last release
 ### New features / functionalities
 
 -   Added support for Debian 11 and Ubuntu 22 worker nodes (PR #320)
+-   Added structured logging. It is a hybrid format with some fields followed by a JSON dictionary. The exact format of the messages may change in the future, and we plan for it to become the default. Now it is disabled by default. Add `structured="True"` to all `<process_log>` elements (PR #327)
 
 ### Changed defaults / behaviours
 

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -185,11 +185,13 @@ Requires: python3-pyyaml
 Requires: python3-jwt
 Requires: python3-cryptography
 Requires: python3-m2crypto
+#Requires: python3-structlog
 %else
 Requires: PyYAML
 Requires: python36-jwt
 Requires: python36-cryptography
 Requires: python36-m2crypto
+Requires: python36-structlog
 %endif
 Requires: python3-rrdtool
 %description libs

--- a/creation/lib/cWParamDict.py
+++ b/creation/lib/cWParamDict.py
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Frontend creation module
 #   Classes and functions needed to handle dictionary files
@@ -17,12 +11,9 @@
 
 import os.path
 
+from glideinwms.lib.util import is_true
+
 from . import cWConsts, cWDictFile
-
-
-def is_true(s):
-    """Case insensitive string parsing helper. Return True for true (case insensitive matching), False otherwise."""
-    return type(s) == str and s.lower() == "true"
 
 
 def has_file_wrapper(dicts):

--- a/creation/lib/cWParams.py
+++ b/creation/lib/cWParams.py
@@ -1,21 +1,8 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This module contains the generic params classes
-#
-# Extracted from:
-#   cgWParams.py
-#
-# Author:
-#   Igor Sfiligoi
-#
 
 import copy
 import os
@@ -95,6 +82,7 @@ class SubParams(Mapping):
 
         """
         for k in self.data:
+            # TODO: MMBFIX is the next line doing anything? should it be removed? check history?
             self.data
             if k not in base:
                 # element not in base, report
@@ -663,7 +651,7 @@ def shorten_text(text, width):
 
 
 def defdict2string(defaults, indent, width=80):
-    """Convert defualts to a string
+    """Convert defaults to a string
 
     Args:
         defaults:

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -1,11 +1,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Glidein creation module
 #   Classes and functions needed to handle dictionary files

--- a/creation/lib/cgWParams.py
+++ b/creation/lib/cgWParams.py
@@ -1,18 +1,8 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Desscription:
 #   This module contains the create_glidein params class
-#
-# Author:
-#   Igor Sfiligoi
-#
 
 import copy
 import os
@@ -28,10 +18,6 @@ from glideinwms.lib.util import safe_boolcomp
 from glideinwms.lib.xmlParse import OrderedDict
 
 from . import cWParams
-
-# import types
-# import traceback
-# from collections import OrderedDict
 
 
 ######################################################
@@ -297,6 +283,7 @@ class GlideinParams(cWParams.CommonParams):
         self.defaults["monitor_footer"] = monitor_footer_defaults
 
         process_log_defaults = copy.deepcopy(one_log_retention_defaults)
+        process_log_defaults["structured"] = ["False", "Bool", "True to use structured logs", None]
         process_log_defaults["extension"] = ["all", "string", "name of the log extention", None]
         process_log_defaults["msg_types"] = ["INFO, WARN, ERR", "string", "types of log messages", None]
         process_log_defaults["backup_count"] = ["5", "string", "Number of backup logs to keep", None]

--- a/creation/lib/cvWParams.py
+++ b/creation/lib/cvWParams.py
@@ -406,6 +406,7 @@ class VOFrontendParams(cWParams.CommonParams):
         self.defaults["work"] = work_defaults
 
         process_log_defaults = cWParams.CommentedOrderedDict()
+        process_log_defaults["structured"] = ["False", "Bool", "True to use structured logs", None]
         process_log_defaults["min_days"] = [
             "3.0",
             "days",

--- a/creation/lib/factory_defaults.xml
+++ b/creation/lib/factory_defaults.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
       <job_logs max_days="7.0" max_mbytes="100.0" min_days="2.0"/>
       <summary_logs max_days="31.0" max_mbytes="100.0" min_days="3.0"/>
       <process_logs>
-         <process_log max_days="7.0" max_mbytes="100.0" min_days="3.0" backup_count="5" compression="" extension="all" msg_types="INFO, WARN, ERR"/>
+         <process_log structured="False" max_days="7.0" max_mbytes="100.0" min_days="3.0" backup_count="5" compression="" extension="all" msg_types="INFO, WARN, ERR"/>
       </process_logs>
    </log_retention>
    <!-- hard coding rpm paths for now -->

--- a/creation/reconfig_glidein
+++ b/creation/reconfig_glidein
@@ -61,31 +61,7 @@ def logReconfig(msg):
     # Set the Log directory
     logSupport.log_dir = os.path.join(glideinDescript.data["LogDir"], "factory")
     # Configure factory process logging
-    process_logs = eval(glideinDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        if "ADMIN" in plog["msg_types"]:
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                "DEBUG,INFO,WARN,ERR",
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                plog["compression"],
-            )
-        else:
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                plog["compression"],
-            )
-    logSupport.log = logSupport.getLogger("factoryadmin")
+    logSupport.log = logSupport.get_logger_with_handlers("factoryadmin", logSupport.log_dir, glideinDescript.data)
     logSupport.log.info("Reconfiguring factory: %s" % msg)
 
 

--- a/creation/reconfig_glidein
+++ b/creation/reconfig_glidein
@@ -85,7 +85,7 @@ def logReconfig(msg):
                 int(float(plog["max_mbytes"])),
                 plog["compression"],
             )
-    logSupport.log = logging.getLogger("factoryadmin")
+    logSupport.log = logSupport.getLogger("factoryadmin")
     logSupport.log.info("Reconfiguring factory: %s" % msg)
 
 

--- a/creation/web_base/factoryCompletedStats.html
+++ b/creation/web_base/factoryCompletedStats.html
@@ -179,7 +179,7 @@ Description:
         "aggwsum",
         "aggavgf",
         "affwsumf",
-        "fail",
+        "fail"
       );
       var ENTRY;
 
@@ -224,7 +224,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry]),
+            new Option(entries[entry], entries[entry])
           );
           ec_added++;
         } else {
@@ -254,7 +254,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend]),
+            new Option(frontend_list[entry][frontend])
           );
         }
       }
@@ -831,7 +831,7 @@ Description:
           for (var i = 0; i < gtype_filtered_list.length; i++) {
             rrd_filtered_data = new RRDFilterDS(
               rrd_data1,
-              gtype_DSs[gtype_filtered_list[i]],
+              gtype_DSs[gtype_filtered_list[i]]
             );
             var DS_list = [];
             for (var j = 0; j < rrd_filtered_data.getNrDSs(); j++) {
@@ -849,7 +849,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null,
+            null
           );
         } else if (gtype_id == "fail") {
           var DS_list = [];
@@ -872,8 +872,8 @@ Description:
           op_list.push(
             new FractionDS(
               rrd_data1.getDS(failed_idx).getName(),
-              rrd_data1.getDS(glidein_idx).getName(),
-            ),
+              rrd_data1.getDS(glidein_idx).getName()
+            )
           );
           rrd_data1 = new RRDFilterOp(rrd_data1, op_list);
           var f = new rrdFlot(
@@ -881,7 +881,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null,
+            null
           );
         }
         //Non-Aggregated InfoGroups
@@ -903,12 +903,12 @@ Description:
               continue;
             }
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i),
+              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i)
             );
           }
           if (flag == 1) {
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0),
+              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0)
             );
           }
 
@@ -950,7 +950,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            { num_cb_rows: x },
+            { num_cb_rows: x }
           );
         }
 

--- a/creation/web_base/factoryCompletedStats.html
+++ b/creation/web_base/factoryCompletedStats.html
@@ -179,7 +179,7 @@ Description:
         "aggwsum",
         "aggavgf",
         "affwsumf",
-        "fail"
+        "fail",
       );
       var ENTRY;
 
@@ -224,7 +224,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -254,7 +254,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -831,7 +831,7 @@ Description:
           for (var i = 0; i < gtype_filtered_list.length; i++) {
             rrd_filtered_data = new RRDFilterDS(
               rrd_data1,
-              gtype_DSs[gtype_filtered_list[i]]
+              gtype_DSs[gtype_filtered_list[i]],
             );
             var DS_list = [];
             for (var j = 0; j < rrd_filtered_data.getNrDSs(); j++) {
@@ -849,7 +849,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null
+            null,
           );
         } else if (gtype_id == "fail") {
           var DS_list = [];
@@ -872,8 +872,8 @@ Description:
           op_list.push(
             new FractionDS(
               rrd_data1.getDS(failed_idx).getName(),
-              rrd_data1.getDS(glidein_idx).getName()
-            )
+              rrd_data1.getDS(glidein_idx).getName(),
+            ),
           );
           rrd_data1 = new RRDFilterOp(rrd_data1, op_list);
           var f = new rrdFlot(
@@ -881,7 +881,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null
+            null,
           );
         }
         //Non-Aggregated InfoGroups
@@ -903,12 +903,12 @@ Description:
               continue;
             }
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i)
+              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i),
             );
           }
           if (flag == 1) {
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0)
+              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0),
             );
           }
 
@@ -950,7 +950,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            { num_cb_rows: x }
+            { num_cb_rows: x },
           );
         }
 

--- a/creation/web_base/factoryEntryStatusNow.html
+++ b/creation/web_base/factoryEntryStatusNow.html
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientJobsIdle",
         "ClientGlideTotal",
         "ClientCoresTotal",
-        "ClientInfoAge"
+        "ClientInfoAge",
       );
 
       var xmlAttStatusArry = new Array(
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageIn",
         "StageOut",
         "IdleOther",
-        "Held"
+        "Held",
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       var xmlAttCMArry = new Array(
@@ -96,7 +96,7 @@ SPDX-License-Identifier: Apache-2.0
         "JobsIdle",
         "GlideTotal",
         "CoresTotal",
-        "InfoAge"
+        "InfoAge",
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -123,7 +123,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmGlideinIdle",
         "cmGlideinJobsIdle",
         "cmGlideinTotal",
-        "cmGlideinInfoAge"
+        "cmGlideinInfoAge",
       );
 
       var exactCols = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Registered",
         "Info age",
         "Diff(Status: Running - CM: Registered)",
-        "Diff(Status: Idle - Requested: Idle)"
+        "Diff(Status: Idle - Requested: Idle)",
       );
       var prTxtArry = new Array("Now", "2 hours", "24 hours", "7 days");
 
@@ -171,7 +171,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Stage out",
         "Status: Unknown",
         "Status: Held",
-        "Client Monitor: Info age"
+        "Client Monitor: Info age",
       );
       var indivTableAttColors = new Array(
         0,
@@ -192,7 +192,7 @@ SPDX-License-Identifier: Apache-2.0
         0,
         0,
         0,
-        2
+        2,
       );
 
       var indivAtts = new Array(
@@ -214,7 +214,7 @@ SPDX-License-Identifier: Apache-2.0
         5,
         6,
         7,
-        16
+        16,
       );
 
       var indivChild;
@@ -315,10 +315,10 @@ SPDX-License-Identifier: Apache-2.0
                 .attributes[0].value
             ) {
               feArryMaster.push(
-                totalEntries[optionIndex].childNodes[feChild].childNodes[x]
+                totalEntries[optionIndex].childNodes[feChild].childNodes[x],
               );
               feArryPMaster.push(
-                totalEntriesP[optionIndex].childNodes[3].childNodes[x]
+                totalEntriesP[optionIndex].childNodes[3].childNodes[x],
               );
             }
           }
@@ -342,7 +342,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -446,8 +446,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .name
-                )
+                    .name,
+                ),
               );
               cellsD[count].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsD[count]);
@@ -456,8 +456,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .value
-                )
+                    .value,
+                ),
               );
               rowsD[i].appendChild(cellsD[count]);
               count++;
@@ -483,8 +483,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .name
-                )
+                    .name,
+                ),
               );
               cellsT[count2].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsT[count2]);
@@ -493,8 +493,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .value
-                )
+                    .value,
+                ),
               );
               rowsD[i].appendChild(cellsT[count2]);
               count2++;
@@ -528,7 +528,7 @@ SPDX-License-Identifier: Apache-2.0
           if (xmlhttp.readyState == 4) {
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated"
+                "updated",
               );
             totalEntriesMaster =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -760,7 +760,7 @@ SPDX-License-Identifier: Apache-2.0
                   totStatChild,
                   totStatChild,
                   totStatChild,
-                  totCMChild
+                  totCMChild,
                 );
 
                 indivChildFE = new Array(
@@ -782,7 +782,7 @@ SPDX-License-Identifier: Apache-2.0
                   feStatChild,
                   feStatChild,
                   feStatChild,
-                  feCMChild
+                  feCMChild,
                 );
                 break;
               }
@@ -815,7 +815,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "makeTotTable(document.getElementById('choose').value)"
+          "makeTotTable(document.getElementById('choose').value)",
         );
         head = document.createElement("option");
         txt0 = document.createTextNode("No Entry Selected");
@@ -885,7 +885,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild
+                  document.getElementsByTagName("div")[index].firstChild,
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -895,7 +895,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild
+                  document.getElementsByTagName("div")[index + 1].firstChild,
                 );
             }
             index++;
@@ -928,7 +928,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild
+                  document.getElementsByTagName("div")[index].firstChild,
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -938,7 +938,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild
+                  document.getElementsByTagName("div")[index + 1].firstChild,
                 );
             }
             index++;
@@ -982,7 +982,7 @@ SPDX-License-Identifier: Apache-2.0
           cell_num - 1,
           cell_num - 1,
           cell_num,
-          cell_num - 1
+          cell_num - 1,
         );
 
         table = document.createElement("table");
@@ -1081,7 +1081,7 @@ SPDX-License-Identifier: Apache-2.0
               k != 2 - (cell_num - cell_numArry[c])
             ) {
               cont = document.createTextNode(
-                feArryMaster[k - 3].attributes[0].value
+                feArryMaster[k - 3].attributes[0].value,
               );
             } else if (c == 0 && k == 2 - (cell_num - cell_numArry[c])) {
               cont = document.createTextNode("Total");
@@ -1145,7 +1145,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days"
+            "7 Days",
           );
           rowLength = rowsTwoTxt.length;
         } else {
@@ -1198,7 +1198,7 @@ SPDX-License-Identifier: Apache-2.0
           if (j % (rowLength / 2) == 0) {
             cols[j].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1234,7 +1234,7 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k) % (rowLength / 2) == 0) {
             cols[j + k].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1268,10 +1268,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l) % (rowLength / 2) == 0) {
             cols[j + k + l].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1304,10 +1304,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l + m) % (rowLength / 2) == 0) {
             cols[j + k + l + m].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l + m] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1341,10 +1341,10 @@ SPDX-License-Identifier: Apache-2.0
           ) {
             cols[j + k + l + m + n].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l + m + n] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1724,7 +1724,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days"
+            "7 Days",
           );
         else feRowTwoTxt = new Array("", "Now", "", "Now");
         index = 0;
@@ -1803,7 +1803,7 @@ SPDX-License-Identifier: Apache-2.0
             if (j % (feRowTwoTxt.length / 2) == 0) {
               feCell[j].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j] = document.createTextNode(indivTableAtts[attribute]);
               attribute++;
@@ -1841,10 +1841,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1882,10 +1882,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1921,10 +1921,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l + m) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l + m].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l + m] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1963,10 +1963,10 @@ SPDX-License-Identifier: Apache-2.0
             ) {
               feCell[j + k + l + m + n].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l + m + n] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -2002,7 +2002,7 @@ SPDX-License-Identifier: Apache-2.0
 
           paramRow[0] =
             document.createElement(
-              "tr"
+              "tr",
             ); /* Will hold parameter table header. */
           paramCell = document.createElement("td");
 
@@ -2011,7 +2011,7 @@ SPDX-License-Identifier: Apache-2.0
               .length <= 1
           ) {
             paramTxtHead = document.createTextNode(
-              "(" + feArryMaster[i].attributes[0].value + ") No Parameters "
+              "(" + feArryMaster[i].attributes[0].value + ") No Parameters ",
             );
           } else paramTxtHead = document.createTextNode("Parameters: ");
           paramCell.appendChild(paramTxtHead);
@@ -2034,11 +2034,11 @@ SPDX-License-Identifier: Apache-2.0
             paramCell[j] = document.createElement("td");
             paramCellTxt[j - 1] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[0].value
+                .attributes[0].value,
             );
             paramCellTxt[j] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[1].value
+                .attributes[1].value,
             );
             paramCell[j - 1].appendChild(paramCellTxt[j - 1]);
             paramCell[j].appendChild(paramCellTxt[j]);
@@ -2490,7 +2490,7 @@ SPDX-License-Identifier: Apache-2.0
         font-size: 40px;
         color: #000;
         font-weight: bold;
-        font-family: 'Times New Roman', Times;
+        font-family: &quot;Times New Roman&quot;, Times;
         text-decoration: none;
         left: 50%;
       "

--- a/creation/web_base/factoryEntryStatusNow.html
+++ b/creation/web_base/factoryEntryStatusNow.html
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientJobsIdle",
         "ClientGlideTotal",
         "ClientCoresTotal",
-        "ClientInfoAge",
+        "ClientInfoAge"
       );
 
       var xmlAttStatusArry = new Array(
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageIn",
         "StageOut",
         "IdleOther",
-        "Held",
+        "Held"
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       var xmlAttCMArry = new Array(
@@ -96,7 +96,7 @@ SPDX-License-Identifier: Apache-2.0
         "JobsIdle",
         "GlideTotal",
         "CoresTotal",
-        "InfoAge",
+        "InfoAge"
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -123,7 +123,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmGlideinIdle",
         "cmGlideinJobsIdle",
         "cmGlideinTotal",
-        "cmGlideinInfoAge",
+        "cmGlideinInfoAge"
       );
 
       var exactCols = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Registered",
         "Info age",
         "Diff(Status: Running - CM: Registered)",
-        "Diff(Status: Idle - Requested: Idle)",
+        "Diff(Status: Idle - Requested: Idle)"
       );
       var prTxtArry = new Array("Now", "2 hours", "24 hours", "7 days");
 
@@ -171,7 +171,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Stage out",
         "Status: Unknown",
         "Status: Held",
-        "Client Monitor: Info age",
+        "Client Monitor: Info age"
       );
       var indivTableAttColors = new Array(
         0,
@@ -192,7 +192,7 @@ SPDX-License-Identifier: Apache-2.0
         0,
         0,
         0,
-        2,
+        2
       );
 
       var indivAtts = new Array(
@@ -214,7 +214,7 @@ SPDX-License-Identifier: Apache-2.0
         5,
         6,
         7,
-        16,
+        16
       );
 
       var indivChild;
@@ -315,10 +315,10 @@ SPDX-License-Identifier: Apache-2.0
                 .attributes[0].value
             ) {
               feArryMaster.push(
-                totalEntries[optionIndex].childNodes[feChild].childNodes[x],
+                totalEntries[optionIndex].childNodes[feChild].childNodes[x]
               );
               feArryPMaster.push(
-                totalEntriesP[optionIndex].childNodes[3].childNodes[x],
+                totalEntriesP[optionIndex].childNodes[3].childNodes[x]
               );
             }
           }
@@ -342,7 +342,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend",
+                "frontend"
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -446,8 +446,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .name,
-                ),
+                    .name
+                )
               );
               cellsD[count].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsD[count]);
@@ -456,8 +456,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .value,
-                ),
+                    .value
+                )
               );
               rowsD[i].appendChild(cellsD[count]);
               count++;
@@ -483,8 +483,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .name,
-                ),
+                    .name
+                )
               );
               cellsT[count2].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsT[count2]);
@@ -493,8 +493,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .value,
-                ),
+                    .value
+                )
               );
               rowsD[i].appendChild(cellsT[count2]);
               count2++;
@@ -528,7 +528,7 @@ SPDX-License-Identifier: Apache-2.0
           if (xmlhttp.readyState == 4) {
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated",
+                "updated"
               );
             totalEntriesMaster =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend",
+                "frontend"
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -760,7 +760,7 @@ SPDX-License-Identifier: Apache-2.0
                   totStatChild,
                   totStatChild,
                   totStatChild,
-                  totCMChild,
+                  totCMChild
                 );
 
                 indivChildFE = new Array(
@@ -782,7 +782,7 @@ SPDX-License-Identifier: Apache-2.0
                   feStatChild,
                   feStatChild,
                   feStatChild,
-                  feCMChild,
+                  feCMChild
                 );
                 break;
               }
@@ -815,7 +815,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "makeTotTable(document.getElementById('choose').value)",
+          "makeTotTable(document.getElementById('choose').value)"
         );
         head = document.createElement("option");
         txt0 = document.createTextNode("No Entry Selected");
@@ -885,7 +885,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild,
+                  document.getElementsByTagName("div")[index].firstChild
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -895,7 +895,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild,
+                  document.getElementsByTagName("div")[index + 1].firstChild
                 );
             }
             index++;
@@ -928,7 +928,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild,
+                  document.getElementsByTagName("div")[index].firstChild
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -938,7 +938,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild,
+                  document.getElementsByTagName("div")[index + 1].firstChild
                 );
             }
             index++;
@@ -982,7 +982,7 @@ SPDX-License-Identifier: Apache-2.0
           cell_num - 1,
           cell_num - 1,
           cell_num,
-          cell_num - 1,
+          cell_num - 1
         );
 
         table = document.createElement("table");
@@ -1081,7 +1081,7 @@ SPDX-License-Identifier: Apache-2.0
               k != 2 - (cell_num - cell_numArry[c])
             ) {
               cont = document.createTextNode(
-                feArryMaster[k - 3].attributes[0].value,
+                feArryMaster[k - 3].attributes[0].value
               );
             } else if (c == 0 && k == 2 - (cell_num - cell_numArry[c])) {
               cont = document.createTextNode("Total");
@@ -1145,7 +1145,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days",
+            "7 Days"
           );
           rowLength = rowsTwoTxt.length;
         } else {
@@ -1198,7 +1198,7 @@ SPDX-License-Identifier: Apache-2.0
           if (j % (rowLength / 2) == 0) {
             cols[j].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]],
+              colorArry[indivTableAttColors[attribute]]
             );
             colsTxt[j] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1234,7 +1234,7 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k) % (rowLength / 2) == 0) {
             cols[j + k].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]],
+              colorArry[indivTableAttColors[attribute]]
             );
             colsTxt[j + k] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1268,10 +1268,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l) % (rowLength / 2) == 0) {
             cols[j + k + l].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]],
+              colorArry[indivTableAttColors[attribute]]
             );
             colsTxt[j + k + l] = document.createTextNode(
-              indivTableAtts[attribute],
+              indivTableAtts[attribute]
             );
             attribute++;
           } else {
@@ -1304,10 +1304,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l + m) % (rowLength / 2) == 0) {
             cols[j + k + l + m].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]],
+              colorArry[indivTableAttColors[attribute]]
             );
             colsTxt[j + k + l + m] = document.createTextNode(
-              indivTableAtts[attribute],
+              indivTableAtts[attribute]
             );
             attribute++;
           } else {
@@ -1341,10 +1341,10 @@ SPDX-License-Identifier: Apache-2.0
           ) {
             cols[j + k + l + m + n].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]],
+              colorArry[indivTableAttColors[attribute]]
             );
             colsTxt[j + k + l + m + n] = document.createTextNode(
-              indivTableAtts[attribute],
+              indivTableAtts[attribute]
             );
             attribute++;
           } else {
@@ -1724,7 +1724,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days",
+            "7 Days"
           );
         else feRowTwoTxt = new Array("", "Now", "", "Now");
         index = 0;
@@ -1803,7 +1803,7 @@ SPDX-License-Identifier: Apache-2.0
             if (j % (feRowTwoTxt.length / 2) == 0) {
               feCell[j].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]],
+                colorArry[indivTableAttColors[attribute]]
               );
               feCellTxt[j] = document.createTextNode(indivTableAtts[attribute]);
               attribute++;
@@ -1841,10 +1841,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]],
+                colorArry[indivTableAttColors[attribute]]
               );
               feCellTxt[j + k] = document.createTextNode(
-                indivTableAtts[attribute],
+                indivTableAtts[attribute]
               );
               attribute++;
             } else {
@@ -1882,10 +1882,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]],
+                colorArry[indivTableAttColors[attribute]]
               );
               feCellTxt[j + k + l] = document.createTextNode(
-                indivTableAtts[attribute],
+                indivTableAtts[attribute]
               );
               attribute++;
             } else {
@@ -1921,10 +1921,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l + m) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l + m].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]],
+                colorArry[indivTableAttColors[attribute]]
               );
               feCellTxt[j + k + l + m] = document.createTextNode(
-                indivTableAtts[attribute],
+                indivTableAtts[attribute]
               );
               attribute++;
             } else {
@@ -1963,10 +1963,10 @@ SPDX-License-Identifier: Apache-2.0
             ) {
               feCell[j + k + l + m + n].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]],
+                colorArry[indivTableAttColors[attribute]]
               );
               feCellTxt[j + k + l + m + n] = document.createTextNode(
-                indivTableAtts[attribute],
+                indivTableAtts[attribute]
               );
               attribute++;
             } else {
@@ -2002,7 +2002,7 @@ SPDX-License-Identifier: Apache-2.0
 
           paramRow[0] =
             document.createElement(
-              "tr",
+              "tr"
             ); /* Will hold parameter table header. */
           paramCell = document.createElement("td");
 
@@ -2011,7 +2011,7 @@ SPDX-License-Identifier: Apache-2.0
               .length <= 1
           ) {
             paramTxtHead = document.createTextNode(
-              "(" + feArryMaster[i].attributes[0].value + ") No Parameters ",
+              "(" + feArryMaster[i].attributes[0].value + ") No Parameters "
             );
           } else paramTxtHead = document.createTextNode("Parameters: ");
           paramCell.appendChild(paramTxtHead);
@@ -2034,11 +2034,11 @@ SPDX-License-Identifier: Apache-2.0
             paramCell[j] = document.createElement("td");
             paramCellTxt[j - 1] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[0].value,
+                .attributes[0].value
             );
             paramCellTxt[j] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[1].value,
+                .attributes[1].value
             );
             paramCell[j - 1].appendChild(paramCellTxt[j - 1]);
             paramCell[j].appendChild(paramCellTxt[j]);
@@ -2490,7 +2490,7 @@ SPDX-License-Identifier: Apache-2.0
         font-size: 40px;
         color: #000;
         font-weight: bold;
-        font-family: &quot;Times New Roman&quot;, Times;
+        font-family: 'Times New Roman', Times;
         text-decoration: none;
         left: 50%;
       "

--- a/creation/web_base/factoryLogStatus.html
+++ b/creation/web_base/factoryLogStatus.html
@@ -185,7 +185,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -240,7 +240,7 @@ Description:
           "EnteredRunning",
           "ExitedRunning",
           "EnteredCompleted",
-          "EnteredHeld"
+          "EnteredHeld",
         );
         gtype_DSs["idle"] = new Array(
           "StatusIdle",
@@ -250,7 +250,7 @@ Description:
           "EnteredWait",
           "ExitedWait",
           "EnteredRunning",
-          "EnteredHeld"
+          "EnteredHeld",
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
@@ -258,7 +258,7 @@ Description:
           "ExitedHeld",
           "EnteredRemoved",
           "EnteredIdle",
-          "EnteredRunning"
+          "EnteredRunning",
         );
         gtype_DSs["completed"] = new Array(
           "Lasted",
@@ -268,7 +268,7 @@ Description:
           "JobsGoodput",
           "Glideins",
           "FailedNr",
-          "JobsNr"
+          "JobsNr",
         );
 
         var gtype_formats = new Object();
@@ -471,7 +471,7 @@ Description:
           "mygraph",
           rrd_data1,
           null,
-          gtype_formats[gtype_id]
+          gtype_formats[gtype_id],
         );
 
         // Finally, update the files loaded so far

--- a/creation/web_base/factoryLogStatus.html
+++ b/creation/web_base/factoryLogStatus.html
@@ -185,7 +185,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry]),
+            new Option(entries[entry], entries[entry])
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend]),
+            new Option(frontend_list[entry][frontend])
           );
         }
       }
@@ -240,7 +240,7 @@ Description:
           "EnteredRunning",
           "ExitedRunning",
           "EnteredCompleted",
-          "EnteredHeld",
+          "EnteredHeld"
         );
         gtype_DSs["idle"] = new Array(
           "StatusIdle",
@@ -250,7 +250,7 @@ Description:
           "EnteredWait",
           "ExitedWait",
           "EnteredRunning",
-          "EnteredHeld",
+          "EnteredHeld"
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
@@ -258,7 +258,7 @@ Description:
           "ExitedHeld",
           "EnteredRemoved",
           "EnteredIdle",
-          "EnteredRunning",
+          "EnteredRunning"
         );
         gtype_DSs["completed"] = new Array(
           "Lasted",
@@ -268,7 +268,7 @@ Description:
           "JobsGoodput",
           "Glideins",
           "FailedNr",
-          "JobsNr",
+          "JobsNr"
         );
 
         var gtype_formats = new Object();
@@ -471,7 +471,7 @@ Description:
           "mygraph",
           rrd_data1,
           null,
-          gtype_formats[gtype_id],
+          gtype_formats[gtype_id]
         );
 
         // Finally, update the files loaded so far

--- a/creation/web_base/factoryRRDBrowse.html
+++ b/creation/web_base/factoryRRDBrowse.html
@@ -151,7 +151,7 @@ Description:
         "Log_Counts",
         "Log_Completed",
         "Log_Completed_Stats",
-        "Log_Completed_WasteTime"
+        "Log_Completed_WasteTime",
       );
       var ENTRY;
 
@@ -196,7 +196,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }

--- a/creation/web_base/factoryRRDBrowse.html
+++ b/creation/web_base/factoryRRDBrowse.html
@@ -151,7 +151,7 @@ Description:
         "Log_Counts",
         "Log_Completed",
         "Log_Completed_Stats",
-        "Log_Completed_WasteTime",
+        "Log_Completed_WasteTime"
       );
       var ENTRY;
 
@@ -196,7 +196,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry]),
+            new Option(entries[entry], entries[entry])
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend]),
+            new Option(frontend_list[entry][frontend])
           );
         }
       }

--- a/creation/web_base/factoryRRDEntryMatrix.html
+++ b/creation/web_base/factoryRRDEntryMatrix.html
@@ -224,7 +224,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", true)',
+              '", true)'
           );
 
           var but_el2 = document.createElement("input");
@@ -235,7 +235,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", false)',
+              '", false)'
           );
 
           var form_el = document.getElementById("selector");
@@ -390,7 +390,7 @@ Description:
           var fn_array = new Array();
           for (var j = 0; j < ent_list.length; j++) {
             fn_array.push(
-              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd",
+              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd"
             );
           }
           fnames.push(fn_array.join(","));
@@ -413,7 +413,7 @@ Description:
                 FetchBinaryURLAsync(
                   fn_array[j],
                   update_grouped_fname_handler,
-                  i,
+                  i
                 );
                 rrds_to_load++;
               }

--- a/creation/web_base/factoryRRDEntryMatrix.html
+++ b/creation/web_base/factoryRRDEntryMatrix.html
@@ -224,7 +224,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", true)'
+              '", true)',
           );
 
           var but_el2 = document.createElement("input");
@@ -235,7 +235,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", false)'
+              '", false)',
           );
 
           var form_el = document.getElementById("selector");
@@ -390,7 +390,7 @@ Description:
           var fn_array = new Array();
           for (var j = 0; j < ent_list.length; j++) {
             fn_array.push(
-              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd"
+              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd",
             );
           }
           fnames.push(fn_array.join(","));
@@ -413,7 +413,7 @@ Description:
                 FetchBinaryURLAsync(
                   fn_array[j],
                   update_grouped_fname_handler,
-                  i
+                  i,
                 );
                 rrds_to_load++;
               }

--- a/creation/web_base/factoryStatus.html
+++ b/creation/web_base/factoryStatus.html
@@ -201,7 +201,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -227,7 +227,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -261,7 +261,7 @@ Description:
           "ClientJobsIdle",
           "ReqIdle",
           "StatusIdle",
-          "ClientInfoAge"
+          "ClientInfoAge",
         );
         gtype_DSs["idle"] = new Array(
           "ReqIdle",
@@ -269,14 +269,14 @@ Description:
           "StatusWait",
           "StatusPending",
           "ClientJobsIdle",
-          "ClientInfoAge"
+          "ClientInfoAge",
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
           "StatusStageIn",
           "StatusStageOut",
           "StatusIdleOther",
-          "StatusIdle"
+          "StatusIdle",
         );
 
         gtype_formats = new Object();
@@ -519,7 +519,7 @@ Description:
             use_element_buttons: false,
           },
           gtype_DSs[gtype_id],
-          rra_ops
+          rra_ops,
         );
 
         // Finally, update the files loaded so far
@@ -636,7 +636,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone"
+          "timezone",
         );
         group = 0;
         var entrySpec;

--- a/creation/web_base/factoryStatus.html
+++ b/creation/web_base/factoryStatus.html
@@ -201,7 +201,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry]),
+            new Option(entries[entry], entries[entry])
           );
           ec_added++;
         } else {
@@ -227,7 +227,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend]),
+            new Option(frontend_list[entry][frontend])
           );
         }
       }
@@ -261,7 +261,7 @@ Description:
           "ClientJobsIdle",
           "ReqIdle",
           "StatusIdle",
-          "ClientInfoAge",
+          "ClientInfoAge"
         );
         gtype_DSs["idle"] = new Array(
           "ReqIdle",
@@ -269,14 +269,14 @@ Description:
           "StatusWait",
           "StatusPending",
           "ClientJobsIdle",
-          "ClientInfoAge",
+          "ClientInfoAge"
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
           "StatusStageIn",
           "StatusStageOut",
           "StatusIdleOther",
-          "StatusIdle",
+          "StatusIdle"
         );
 
         gtype_formats = new Object();
@@ -519,7 +519,7 @@ Description:
             use_element_buttons: false,
           },
           gtype_DSs[gtype_id],
-          rra_ops,
+          rra_ops
         );
 
         // Finally, update the files loaded so far
@@ -636,7 +636,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone",
+          "timezone"
         );
         group = 0;
         var entrySpec;

--- a/creation/web_base/factoryStatusNow.html
+++ b/creation/web_base/factoryStatusNow.html
@@ -110,7 +110,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age"
+        "Info age",
       );
 
       var headColArryPR = new Array(
@@ -133,7 +133,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age"
+        "Info age",
       );
 
       var headColArryTR = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle"
+        "Client: User Idle",
       );
 
       var headColArryTRPR = new Array(
@@ -157,7 +157,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle"
+        "Client: User Idle",
       );
 
       var columnArray = new Array(
@@ -181,7 +181,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmCoresIdle",
         "cmGlideinJobsIdle",
         "cmCoresTotal",
-        "cmGlideinInfoAge"
+        "cmGlideinInfoAge",
       );
       /* columnArrayStruct describes columnArray: total length (length) and length and offset of its component: DT, Status, Req, CM
    it is used to display the table w/ the values
@@ -217,7 +217,7 @@ SPDX-License-Identifier: Apache-2.0
         "Client Monitor: Unmatched cores",
         "Client Monitor: User idle",
         "Client Monitor: Registered cores",
-        "Client Monitor: Info age"
+        "Client Monitor: Info age",
       );
 
       var exactColumnsTR = new Array(
@@ -229,7 +229,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client Monitor: User Idle"
+        "Client Monitor: User Idle",
       );
 
       var xmlAttPeriodArry = new Array(
@@ -252,7 +252,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientCoresIdle",
         "ClientJobsIdle",
         "ClientCoresTotal",
-        "ClientInfoAge"
+        "ClientInfoAge",
       ); /* ONE LESS ATT THAN DEFAULT, no Downtime */
 
       var xmlAttDTArry = new Array("Status");
@@ -265,7 +265,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageOut",
         "IdleOther",
         "Held",
-        "RunningCores"
+        "RunningCores",
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       // var xmlAttCMArry = new Array("GlideRunning", "CoresRunning", "JobsRunHere", "JobsRunning", "GlideIdle", "CoresIdle", "JobsIdle", "GlideTotal", "CoresTotal", "InfoAge");
@@ -276,7 +276,7 @@ SPDX-License-Identifier: Apache-2.0
         "CoresIdle",
         "JobsIdle",
         "CoresTotal",
-        "InfoAge"
+        "InfoAge",
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -394,7 +394,7 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            totalEntries[row - 1].getAttribute("name")
+            totalEntries[row - 1].getAttribute("name"),
           );
           if (troubleshoot)
             attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -443,7 +443,7 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         nameTxtNode = document.createTextNode(
-          totalEntries[row - 1].getAttribute("name")
+          totalEntries[row - 1].getAttribute("name"),
         );
         if (troubleshoot)
           attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -520,7 +520,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":"
+              sortedFE[i].attributes[0].value + ":",
             );
             td2 = document.createElement("td");
 
@@ -546,12 +546,12 @@ SPDX-License-Identifier: Apache-2.0
               diff = 0;
               try {
                 val1 = parseInt(
-                  sortedFE[i].childNodes[child1].attributes[att1].value
+                  sortedFE[i].childNodes[child1].attributes[att1].value,
                 );
               } catch (err) {}
               try {
                 val2 = parseInt(
-                  sortedFE[i].childNodes[child2].attributes[att2].value
+                  sortedFE[i].childNodes[child2].attributes[att2].value,
                 );
               } catch (err) {}
               diff = val1 - val2;
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feStatChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -576,7 +576,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feReqChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -587,7 +587,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feCMChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -754,21 +754,21 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            tempTotalEntries[row].getAttribute("name")
+            tempTotalEntries[row].getAttribute("name"),
           );
 
           if (!diffCol)
             attTxtNode = document.createTextNode(
-              exactColumns[column + 1] + timeFrame
+              exactColumns[column + 1] + timeFrame,
             );
           else if (diffCol == 1)
             attTxtNode = document.createTextNode(
               "Diff(Status: Running cores, Client: Registered cores) " +
-                timeFrame
+                timeFrame,
             );
           else
             attTxtNode = document.createTextNode(
-              "Diff(Status: Idle, Requested: Idle) " + timeFrame
+              "Diff(Status: Idle, Requested: Idle) " + timeFrame,
             );
 
           NFE = document.createTextNode("No Frontends Exist");
@@ -815,18 +815,19 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         cont = document.createTextNode(
-          tempTotalEntries[row].getAttribute("name")
+          tempTotalEntries[row].getAttribute("name"),
         );
 
         if (!diffCol)
           cont2 = document.createTextNode(exactColumns[column + 1] + timeFrame);
         else if (diffCol == 1)
           cont2 = document.createTextNode(
-            "Diff(Status: Running cores, Client: Registered cores) " + timeFrame
+            "Diff(Status: Running cores, Client: Registered cores) " +
+              timeFrame,
           );
         else
           cont2 = document.createTextNode(
-            "Diff(Status: Idle, Requested: Idle) " + timeFrame
+            "Diff(Status: Idle, Requested: Idle) " + timeFrame,
           );
 
         td1.appendChild(cont);
@@ -894,7 +895,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":"
+              sortedFE[i].attributes[0].value + ":",
             );
             td2 = document.createElement("td");
 
@@ -936,7 +937,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[1]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value
+                      ].value,
                   );
                 } else {
                   /* 2ND DIFF COL */
@@ -946,7 +947,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[4]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value
+                      ].value,
                   );
                 }
               } else {
@@ -960,8 +961,8 @@ SPDX-License-Identifier: Apache-2.0
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[dCol2 - 1]
                       ].value) *
-                      100
-                  ) / 100
+                      100,
+                  ) / 100,
                 );
               }
             } else if (column < columnArrayDesc.Req.offset - 1) {
@@ -971,7 +972,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feStatChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -979,8 +980,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -994,7 +995,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feReqChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1002,8 +1003,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1014,7 +1015,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feCMChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1022,8 +1023,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1229,7 +1230,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "loadFrontEnd(document.getElementById('choose').value)"
+          "loadFrontEnd(document.getElementById('choose').value)",
         );
         def = document.createElement("option");
         defTxt = document.createTextNode("Total (Default)");
@@ -1655,7 +1656,7 @@ SPDX-License-Identifier: Apache-2.0
                     childView = j;
                     feEntries.push(totalEntries[i]);
                     feTotal.push(
-                      totalEntries[i].childNodes[feChild].childNodes[j]
+                      totalEntries[i].childNodes[feChild].childNodes[j],
                     );
                     feEntriesP.push(totalEntriesP[i]);
                     feTotalP.push(totalEntriesP[i].childNodes[3].childNodes[j]);
@@ -1894,12 +1895,12 @@ SPDX-License-Identifier: Apache-2.0
           links[i].setAttribute("onbrowseover", "hideEntryName()");
           links[i].setAttribute(
             "onmouseover",
-            "showPopUpSubEntries(this, '" + y + "')"
+            "showPopUpSubEntries(this, '" + y + "')",
           );
           links[i].setAttribute("onmouseout", "hidePopUpSubEntries()");
           links[i].setAttribute(
             "href",
-            "factoryEntryStatusNow.html?entry=" + y
+            "factoryEntryStatusNow.html?entry=" + y,
           );
           links[i].setAttribute("onclick", "entryClick(this)");
           table.rows[i].cells[0].appendChild(links[i]);
@@ -2084,7 +2085,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -2132,19 +2133,19 @@ SPDX-License-Identifier: Apache-2.0
         xmlhttp.onreadystatechange = function () {
           if (!active)
             document.getElementById(
-              "active"
+              "active",
             ).checked = false; /* Reset active check box. */
           if (!updating && !period && !prTr)
             document.getElementById(
-              "period"
+              "period",
             ).checked = false; /* Reset troubleshoot box. */
           if (!updating && !troubleshoot && !prTr)
             document.getElementById(
-              "troubleshoot"
+              "troubleshoot",
             ).checked = false; /* Reset troubleshoot box. */
           if (!periodV && !prTr)
             document.getElementById(
-              "period"
+              "period",
             ).checked = false; /* Reset active check box. */
 
           if (xmlhttp.readyState == 4) {
@@ -2157,7 +2158,7 @@ SPDX-License-Identifier: Apache-2.0
             /* GET ALL NECESSARY INFO FROM THE XML */
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated"
+                "updated",
               );
             showTime();
             totalEntriesMaster =
@@ -2166,13 +2167,13 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
             statusEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "StatusEntries"
+                "StatusEntries",
               );
             total =
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
@@ -2761,28 +2762,28 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length
+          columnArrayDesc.CM.length,
         );
         headTxt = new Array(
           "",
           "",
           "Status: ",
           "Requested: ",
-          "Client Monitor: "
+          "Client Monitor: ",
         );
         headId = new Array(
           "empty",
           "downtime",
           "status",
           "requested",
-          "client"
+          "client",
         );
         headClr = new Array(
           "#DCDCDC",
           "#DCDCDC",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95"
+          "#CDAF95",
         );
 
         /* HEADER */
@@ -3006,7 +3007,7 @@ SPDX-License-Identifier: Apache-2.0
           3,
           3,
           3,
-          3
+          3,
         ); /* 1 DT + 9 STAT + 4 REQ + 10 CM  = 24 */
         trSortColNumArry = new Array(
           0,
@@ -3026,7 +3027,7 @@ SPDX-License-Identifier: Apache-2.0
           0,
           0,
           8,
-          3
+          3,
         );
         feChildArry = new Array(feStatChild, feReqChild, feCMChild);
         totChildArry = new Array(totStatChild, totReqChild, totCMChild);
@@ -3878,7 +3879,7 @@ SPDX-License-Identifier: Apache-2.0
             "Status: Idle",
             "Requested: Idle",
             "Diff(Status: Idle, Requested: Idle)",
-            "Client: User Idle"
+            "Client: User Idle",
           );
           trColumnId = new Array(
             "entryLinks",
@@ -3889,7 +3890,7 @@ SPDX-License-Identifier: Apache-2.0
             "status",
             "requested",
             "difference",
-            "client"
+            "client",
           );
           colors = new Array(
             "#DCDCDC",
@@ -3900,7 +3901,7 @@ SPDX-License-Identifier: Apache-2.0
             "#FAF0E6",
             "#FFDAB9",
             "#7D9EC0",
-            "#CDAF95"
+            "#CDAF95",
           );
 
           /* SET CHILD ARRAY */
@@ -3910,7 +3911,7 @@ SPDX-License-Identifier: Apache-2.0
               feCMChild,
               feStatChild,
               feReqChild,
-              feCMChild
+              feCMChild,
             );
           else
             child = new Array(
@@ -3918,7 +3919,7 @@ SPDX-License-Identifier: Apache-2.0
               totCMChild,
               totStatChild,
               totReqChild,
-              totCMChild
+              totCMChild,
             );
 
           count = 0;
@@ -3982,7 +3983,7 @@ SPDX-License-Identifier: Apache-2.0
                   hrefs[i - 1].innerHTML = y;
                   hrefs[i - 1].setAttribute(
                     "href",
-                    "factoryEntryStatusNow.html?entry=" + y
+                    "factoryEntryStatusNow.html?entry=" + y,
                   );
                   hrefs[i - 1].setAttribute("onclick", "entryClick(this)");
                   cols[j].appendChild(hrefs[i - 1]);
@@ -4027,7 +4028,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 2]].attributes[
                             att[count - 2]
-                          ].value
+                          ].value,
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4037,7 +4038,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 1]].attributes[
                             att[count - 1]
-                          ].value
+                          ].value,
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4047,7 +4048,7 @@ SPDX-License-Identifier: Apache-2.0
                         val1 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 2]]
-                            .attributes[att[count - 2]].value
+                            .attributes[att[count - 2]].value,
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4056,7 +4057,7 @@ SPDX-License-Identifier: Apache-2.0
                         val2 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 1]]
-                            .attributes[att[count - 1]].value
+                            .attributes[att[count - 1]].value,
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4191,7 +4192,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "diff",
-          "Client: User Idle"
+          "Client: User Idle",
         );
         sortColNum = new Array(
           "statusRunning",
@@ -4200,11 +4201,11 @@ SPDX-License-Identifier: Apache-2.0
           "statusIdle",
           "requestIdle",
           "diff",
-          "cmGlideinJobsIdle"
+          "cmGlideinJobsIdle",
         );
         diffCol = new Array(
           "Diff(Status: Running cores, Client: Registered cores)",
-          "Diff(Status: Idle, Requested: Idle)"
+          "Diff(Status: Idle, Requested: Idle)",
         );
 
         if (!prTr) diffCell = new Array(4, 7);
@@ -4219,7 +4220,7 @@ SPDX-License-Identifier: Apache-2.0
             totStatChild,
             totCMChild,
             totStatChild,
-            totReqChild
+            totReqChild,
           );
 
         att = new Array(5, 2, 1, 0); // child and att are used only for the diff values
@@ -4255,7 +4256,7 @@ SPDX-License-Identifier: Apache-2.0
               sorted = temp;
             }
             trSortSignal(
-              tempHold + 2
+              tempHold + 2,
             ); /* ENTRY NAME COL + DOWNTIME STATUS COL = 2 */
             return;
           }
@@ -4281,14 +4282,14 @@ SPDX-License-Identifier: Apache-2.0
             if (!prTr) {
               for (k = 0; k < trTable.rows.length; k++) {
                 diffArry.push(
-                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML)
+                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML),
                 );
               }
             } else {
               for (k = 0; k < trpr_Table.rows.length; k++) {
                 if (k % 4 == 0) {
                   diffArry.push(
-                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML)
+                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML),
                   );
                 }
               }
@@ -4387,7 +4388,8 @@ SPDX-License-Identifier: Apache-2.0
                   try {
                     val1 = parseInt(
                       totalEntries[k].childNodes[feChild].childNodes[childView]
-                        .childNodes[child[helper]].attributes[att[helper]].value
+                        .childNodes[child[helper]].attributes[att[helper]]
+                        .value,
                     );
                   } catch (err) {}
                   try {
@@ -4395,7 +4397,7 @@ SPDX-License-Identifier: Apache-2.0
                       totalEntries[k].childNodes[feChild].childNodes[childView]
                         .childNodes[child[helper + 1]].attributes[
                         att[helper + 1]
-                      ].value
+                      ].value,
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4432,14 +4434,14 @@ SPDX-License-Identifier: Apache-2.0
                     val1 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper]
-                      ].attributes[att[helper]].value
+                      ].attributes[att[helper]].value,
                     );
                   } catch (err) {}
                   try {
                     val2 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper + 1]
-                      ].attributes[att[helper + 1]].value
+                      ].attributes[att[helper + 1]].value,
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4659,7 +4661,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "Diff(Status: Idle, Requested: Idle)",
-          "Client: User Idle"
+          "Client: User Idle",
         );
         colors = new Array(
           "#DCDCDC",
@@ -4671,7 +4673,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FAF0E6",
           "#FFDAB9",
           "#7D9EC0",
-          "#CDAF95"
+          "#CDAF95",
         );
         trColumnId = new Array(
           "entryLinks",
@@ -4683,7 +4685,7 @@ SPDX-License-Identifier: Apache-2.0
           "status",
           "requested",
           "difference",
-          "client"
+          "client",
         );
 
         /* FRONTEND VIEW */
@@ -4693,7 +4695,7 @@ SPDX-License-Identifier: Apache-2.0
             feCMChild,
             feStatChild,
             feReqChild,
-            feCMChild
+            feCMChild,
           );
         /* TOTAL VIEW */ else
           child = new Array(
@@ -4701,7 +4703,7 @@ SPDX-License-Identifier: Apache-2.0
             totCMChild,
             totStatChild,
             totReqChild,
-            totCMChild
+            totCMChild,
           );
 
         /* ARRAYS FOR INFO ACCESSING */
@@ -4713,7 +4715,7 @@ SPDX-License-Identifier: Apache-2.0
           totStatChild,
           totReqChild,
           0,
-          totCMChild
+          totCMChild,
         );
         trFEChildArry = new Array(
           feStatChild,
@@ -4722,19 +4724,19 @@ SPDX-License-Identifier: Apache-2.0
           feStatChild,
           feReqChild,
           0,
-          feCMChild
+          feCMChild,
         );
         // StatusRunningCores(Running cores) , ClientCoresTotal(Registered cores), StatusIdle(Idle), ReqIdle(Idle), ClientJobsIdle(User idle)
         // using columnArrayDesc, i starts w/ Entry_name, xmlAttTotalNumArry starts w/ DT (-1), xmlAttPeriodNumArry starts w/ Status (-columnArrayDesc.Status.offset)
         // In elements offset: 8, 5, -, 1, 1, -, 4
         trAttArry = new Array();
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8]
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8],
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.CM.offset - 1 + 5]);
         trAttArry.push(0);
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1]
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1],
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.Req.offset - 1 + 1]);
         trAttArry.push(0);
@@ -4745,20 +4747,20 @@ SPDX-License-Identifier: Apache-2.0
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 5
-          ]
+          ],
         );
         prAttArry.push(0);
         prAttArry.push(xmlAttPeriodNumArry[1]); // columnArrayDesc.Status.offset-columnArrayDesc.Status.offset+1
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.Req.offset - columnArrayDesc.Status.offset + 1
-          ]
+          ],
         );
         prAttArry.push(0);
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 4
-          ]
+          ],
         );
 
         rows = new Array();
@@ -4827,7 +4829,7 @@ SPDX-License-Identifier: Apache-2.0
                 cols[k].setAttribute("onmouseout", "hidePopUp()");
                 cols[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)"
+                  "showPopUpPeriod(this)",
                 );
                 cols[k - 1].setAttribute("id", c);
                 cols[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -4869,7 +4871,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y
+              "factoryEntryStatusNow.html?entry=" + y,
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             trpr_Table.rows[i].cells[0].appendChild(links[i]);
@@ -5166,7 +5168,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FFFAF0",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95"
+          "#CDAF95",
         );
         hArry2 = new Array(
           "",
@@ -5174,7 +5176,7 @@ SPDX-License-Identifier: Apache-2.0
           "Period:",
           "Status:",
           "Requested:",
-          "Client Monitor:"
+          "Client Monitor:",
         );
         // hArry3 = new Array(1, 1, 1,xmlAttStatNumArry.length, xmlAttReqNumArry.length, xmlAttCMNumArry.length);
         hArry3 = new Array(
@@ -5183,7 +5185,7 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length
+          columnArrayDesc.CM.length,
         );
 
         /*
@@ -5240,7 +5242,7 @@ SPDX-License-Identifier: Apache-2.0
                 cell[k].setAttribute("onmouseout", "hidePopUp()");
                 cell[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)"
+                  "showPopUpPeriod(this)",
                 );
                 cell[k - 1].setAttribute("id", c);
                 cell[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -5337,7 +5339,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y
+              "factoryEntryStatusNow.html?entry=" + y,
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             tableP.rows[i].cells[0].appendChild(links[i]);

--- a/creation/web_base/factoryStatusNow.html
+++ b/creation/web_base/factoryStatusNow.html
@@ -110,7 +110,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age",
+        "Info age"
       );
 
       var headColArryPR = new Array(
@@ -133,7 +133,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age",
+        "Info age"
       );
 
       var headColArryTR = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle",
+        "Client: User Idle"
       );
 
       var headColArryTRPR = new Array(
@@ -157,7 +157,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle",
+        "Client: User Idle"
       );
 
       var columnArray = new Array(
@@ -181,7 +181,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmCoresIdle",
         "cmGlideinJobsIdle",
         "cmCoresTotal",
-        "cmGlideinInfoAge",
+        "cmGlideinInfoAge"
       );
       /* columnArrayStruct describes columnArray: total length (length) and length and offset of its component: DT, Status, Req, CM
    it is used to display the table w/ the values
@@ -217,7 +217,7 @@ SPDX-License-Identifier: Apache-2.0
         "Client Monitor: Unmatched cores",
         "Client Monitor: User idle",
         "Client Monitor: Registered cores",
-        "Client Monitor: Info age",
+        "Client Monitor: Info age"
       );
 
       var exactColumnsTR = new Array(
@@ -229,7 +229,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client Monitor: User Idle",
+        "Client Monitor: User Idle"
       );
 
       var xmlAttPeriodArry = new Array(
@@ -252,7 +252,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientCoresIdle",
         "ClientJobsIdle",
         "ClientCoresTotal",
-        "ClientInfoAge",
+        "ClientInfoAge"
       ); /* ONE LESS ATT THAN DEFAULT, no Downtime */
 
       var xmlAttDTArry = new Array("Status");
@@ -265,7 +265,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageOut",
         "IdleOther",
         "Held",
-        "RunningCores",
+        "RunningCores"
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       // var xmlAttCMArry = new Array("GlideRunning", "CoresRunning", "JobsRunHere", "JobsRunning", "GlideIdle", "CoresIdle", "JobsIdle", "GlideTotal", "CoresTotal", "InfoAge");
@@ -276,7 +276,7 @@ SPDX-License-Identifier: Apache-2.0
         "CoresIdle",
         "JobsIdle",
         "CoresTotal",
-        "InfoAge",
+        "InfoAge"
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -394,7 +394,7 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            totalEntries[row - 1].getAttribute("name"),
+            totalEntries[row - 1].getAttribute("name")
           );
           if (troubleshoot)
             attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -443,7 +443,7 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         nameTxtNode = document.createTextNode(
-          totalEntries[row - 1].getAttribute("name"),
+          totalEntries[row - 1].getAttribute("name")
         );
         if (troubleshoot)
           attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -520,7 +520,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":",
+              sortedFE[i].attributes[0].value + ":"
             );
             td2 = document.createElement("td");
 
@@ -546,12 +546,12 @@ SPDX-License-Identifier: Apache-2.0
               diff = 0;
               try {
                 val1 = parseInt(
-                  sortedFE[i].childNodes[child1].attributes[att1].value,
+                  sortedFE[i].childNodes[child1].attributes[att1].value
                 );
               } catch (err) {}
               try {
                 val2 = parseInt(
-                  sortedFE[i].childNodes[child2].attributes[att2].value,
+                  sortedFE[i].childNodes[child2].attributes[att2].value
                 );
               } catch (err) {}
               diff = val1 - val2;
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feStatChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value,
+                  ].value
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -576,7 +576,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feReqChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value,
+                  ].value
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -587,7 +587,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feCMChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value,
+                  ].value
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -754,21 +754,21 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            tempTotalEntries[row].getAttribute("name"),
+            tempTotalEntries[row].getAttribute("name")
           );
 
           if (!diffCol)
             attTxtNode = document.createTextNode(
-              exactColumns[column + 1] + timeFrame,
+              exactColumns[column + 1] + timeFrame
             );
           else if (diffCol == 1)
             attTxtNode = document.createTextNode(
               "Diff(Status: Running cores, Client: Registered cores) " +
-                timeFrame,
+                timeFrame
             );
           else
             attTxtNode = document.createTextNode(
-              "Diff(Status: Idle, Requested: Idle) " + timeFrame,
+              "Diff(Status: Idle, Requested: Idle) " + timeFrame
             );
 
           NFE = document.createTextNode("No Frontends Exist");
@@ -815,19 +815,18 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         cont = document.createTextNode(
-          tempTotalEntries[row].getAttribute("name"),
+          tempTotalEntries[row].getAttribute("name")
         );
 
         if (!diffCol)
           cont2 = document.createTextNode(exactColumns[column + 1] + timeFrame);
         else if (diffCol == 1)
           cont2 = document.createTextNode(
-            "Diff(Status: Running cores, Client: Registered cores) " +
-              timeFrame,
+            "Diff(Status: Running cores, Client: Registered cores) " + timeFrame
           );
         else
           cont2 = document.createTextNode(
-            "Diff(Status: Idle, Requested: Idle) " + timeFrame,
+            "Diff(Status: Idle, Requested: Idle) " + timeFrame
           );
 
         td1.appendChild(cont);
@@ -895,7 +894,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":",
+              sortedFE[i].attributes[0].value + ":"
             );
             td2 = document.createElement("td");
 
@@ -937,7 +936,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[1]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value,
+                      ].value
                   );
                 } else {
                   /* 2ND DIFF COL */
@@ -947,7 +946,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[4]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value,
+                      ].value
                   );
                 }
               } else {
@@ -961,8 +960,8 @@ SPDX-License-Identifier: Apache-2.0
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[dCol2 - 1]
                       ].value) *
-                      100,
-                  ) / 100,
+                      100
+                  ) / 100
                 );
               }
             } else if (column < columnArrayDesc.Req.offset - 1) {
@@ -972,7 +971,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feStatChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value,
+                    ].value
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -980,8 +979,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100,
-                    ) / 100,
+                      ].value * 100
+                    ) / 100
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -995,7 +994,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feReqChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value,
+                    ].value
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1003,8 +1002,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100,
-                    ) / 100,
+                      ].value * 100
+                    ) / 100
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1015,7 +1014,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feCMChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value,
+                    ].value
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1023,8 +1022,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100,
-                    ) / 100,
+                      ].value * 100
+                    ) / 100
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1230,7 +1229,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "loadFrontEnd(document.getElementById('choose').value)",
+          "loadFrontEnd(document.getElementById('choose').value)"
         );
         def = document.createElement("option");
         defTxt = document.createTextNode("Total (Default)");
@@ -1656,7 +1655,7 @@ SPDX-License-Identifier: Apache-2.0
                     childView = j;
                     feEntries.push(totalEntries[i]);
                     feTotal.push(
-                      totalEntries[i].childNodes[feChild].childNodes[j],
+                      totalEntries[i].childNodes[feChild].childNodes[j]
                     );
                     feEntriesP.push(totalEntriesP[i]);
                     feTotalP.push(totalEntriesP[i].childNodes[3].childNodes[j]);
@@ -1895,12 +1894,12 @@ SPDX-License-Identifier: Apache-2.0
           links[i].setAttribute("onbrowseover", "hideEntryName()");
           links[i].setAttribute(
             "onmouseover",
-            "showPopUpSubEntries(this, '" + y + "')",
+            "showPopUpSubEntries(this, '" + y + "')"
           );
           links[i].setAttribute("onmouseout", "hidePopUpSubEntries()");
           links[i].setAttribute(
             "href",
-            "factoryEntryStatusNow.html?entry=" + y,
+            "factoryEntryStatusNow.html?entry=" + y
           );
           links[i].setAttribute("onclick", "entryClick(this)");
           table.rows[i].cells[0].appendChild(links[i]);
@@ -2085,7 +2084,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend",
+                "frontend"
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -2133,19 +2132,19 @@ SPDX-License-Identifier: Apache-2.0
         xmlhttp.onreadystatechange = function () {
           if (!active)
             document.getElementById(
-              "active",
+              "active"
             ).checked = false; /* Reset active check box. */
           if (!updating && !period && !prTr)
             document.getElementById(
-              "period",
+              "period"
             ).checked = false; /* Reset troubleshoot box. */
           if (!updating && !troubleshoot && !prTr)
             document.getElementById(
-              "troubleshoot",
+              "troubleshoot"
             ).checked = false; /* Reset troubleshoot box. */
           if (!periodV && !prTr)
             document.getElementById(
-              "period",
+              "period"
             ).checked = false; /* Reset active check box. */
 
           if (xmlhttp.readyState == 4) {
@@ -2158,7 +2157,7 @@ SPDX-License-Identifier: Apache-2.0
             /* GET ALL NECESSARY INFO FROM THE XML */
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated",
+                "updated"
               );
             showTime();
             totalEntriesMaster =
@@ -2167,13 +2166,13 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend",
+                "frontend"
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
             statusEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "StatusEntries",
+                "StatusEntries"
               );
             total =
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
@@ -2762,28 +2761,28 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length,
+          columnArrayDesc.CM.length
         );
         headTxt = new Array(
           "",
           "",
           "Status: ",
           "Requested: ",
-          "Client Monitor: ",
+          "Client Monitor: "
         );
         headId = new Array(
           "empty",
           "downtime",
           "status",
           "requested",
-          "client",
+          "client"
         );
         headClr = new Array(
           "#DCDCDC",
           "#DCDCDC",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95",
+          "#CDAF95"
         );
 
         /* HEADER */
@@ -3007,7 +3006,7 @@ SPDX-License-Identifier: Apache-2.0
           3,
           3,
           3,
-          3,
+          3
         ); /* 1 DT + 9 STAT + 4 REQ + 10 CM  = 24 */
         trSortColNumArry = new Array(
           0,
@@ -3027,7 +3026,7 @@ SPDX-License-Identifier: Apache-2.0
           0,
           0,
           8,
-          3,
+          3
         );
         feChildArry = new Array(feStatChild, feReqChild, feCMChild);
         totChildArry = new Array(totStatChild, totReqChild, totCMChild);
@@ -3879,7 +3878,7 @@ SPDX-License-Identifier: Apache-2.0
             "Status: Idle",
             "Requested: Idle",
             "Diff(Status: Idle, Requested: Idle)",
-            "Client: User Idle",
+            "Client: User Idle"
           );
           trColumnId = new Array(
             "entryLinks",
@@ -3890,7 +3889,7 @@ SPDX-License-Identifier: Apache-2.0
             "status",
             "requested",
             "difference",
-            "client",
+            "client"
           );
           colors = new Array(
             "#DCDCDC",
@@ -3901,7 +3900,7 @@ SPDX-License-Identifier: Apache-2.0
             "#FAF0E6",
             "#FFDAB9",
             "#7D9EC0",
-            "#CDAF95",
+            "#CDAF95"
           );
 
           /* SET CHILD ARRAY */
@@ -3911,7 +3910,7 @@ SPDX-License-Identifier: Apache-2.0
               feCMChild,
               feStatChild,
               feReqChild,
-              feCMChild,
+              feCMChild
             );
           else
             child = new Array(
@@ -3919,7 +3918,7 @@ SPDX-License-Identifier: Apache-2.0
               totCMChild,
               totStatChild,
               totReqChild,
-              totCMChild,
+              totCMChild
             );
 
           count = 0;
@@ -3983,7 +3982,7 @@ SPDX-License-Identifier: Apache-2.0
                   hrefs[i - 1].innerHTML = y;
                   hrefs[i - 1].setAttribute(
                     "href",
-                    "factoryEntryStatusNow.html?entry=" + y,
+                    "factoryEntryStatusNow.html?entry=" + y
                   );
                   hrefs[i - 1].setAttribute("onclick", "entryClick(this)");
                   cols[j].appendChild(hrefs[i - 1]);
@@ -4028,7 +4027,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 2]].attributes[
                             att[count - 2]
-                          ].value,
+                          ].value
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4038,7 +4037,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 1]].attributes[
                             att[count - 1]
-                          ].value,
+                          ].value
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4048,7 +4047,7 @@ SPDX-License-Identifier: Apache-2.0
                         val1 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 2]]
-                            .attributes[att[count - 2]].value,
+                            .attributes[att[count - 2]].value
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4057,7 +4056,7 @@ SPDX-License-Identifier: Apache-2.0
                         val2 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 1]]
-                            .attributes[att[count - 1]].value,
+                            .attributes[att[count - 1]].value
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4192,7 +4191,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "diff",
-          "Client: User Idle",
+          "Client: User Idle"
         );
         sortColNum = new Array(
           "statusRunning",
@@ -4201,11 +4200,11 @@ SPDX-License-Identifier: Apache-2.0
           "statusIdle",
           "requestIdle",
           "diff",
-          "cmGlideinJobsIdle",
+          "cmGlideinJobsIdle"
         );
         diffCol = new Array(
           "Diff(Status: Running cores, Client: Registered cores)",
-          "Diff(Status: Idle, Requested: Idle)",
+          "Diff(Status: Idle, Requested: Idle)"
         );
 
         if (!prTr) diffCell = new Array(4, 7);
@@ -4220,7 +4219,7 @@ SPDX-License-Identifier: Apache-2.0
             totStatChild,
             totCMChild,
             totStatChild,
-            totReqChild,
+            totReqChild
           );
 
         att = new Array(5, 2, 1, 0); // child and att are used only for the diff values
@@ -4256,7 +4255,7 @@ SPDX-License-Identifier: Apache-2.0
               sorted = temp;
             }
             trSortSignal(
-              tempHold + 2,
+              tempHold + 2
             ); /* ENTRY NAME COL + DOWNTIME STATUS COL = 2 */
             return;
           }
@@ -4282,14 +4281,14 @@ SPDX-License-Identifier: Apache-2.0
             if (!prTr) {
               for (k = 0; k < trTable.rows.length; k++) {
                 diffArry.push(
-                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML),
+                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML)
                 );
               }
             } else {
               for (k = 0; k < trpr_Table.rows.length; k++) {
                 if (k % 4 == 0) {
                   diffArry.push(
-                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML),
+                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML)
                   );
                 }
               }
@@ -4388,8 +4387,7 @@ SPDX-License-Identifier: Apache-2.0
                   try {
                     val1 = parseInt(
                       totalEntries[k].childNodes[feChild].childNodes[childView]
-                        .childNodes[child[helper]].attributes[att[helper]]
-                        .value,
+                        .childNodes[child[helper]].attributes[att[helper]].value
                     );
                   } catch (err) {}
                   try {
@@ -4397,7 +4395,7 @@ SPDX-License-Identifier: Apache-2.0
                       totalEntries[k].childNodes[feChild].childNodes[childView]
                         .childNodes[child[helper + 1]].attributes[
                         att[helper + 1]
-                      ].value,
+                      ].value
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4434,14 +4432,14 @@ SPDX-License-Identifier: Apache-2.0
                     val1 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper]
-                      ].attributes[att[helper]].value,
+                      ].attributes[att[helper]].value
                     );
                   } catch (err) {}
                   try {
                     val2 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper + 1]
-                      ].attributes[att[helper + 1]].value,
+                      ].attributes[att[helper + 1]].value
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4661,7 +4659,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "Diff(Status: Idle, Requested: Idle)",
-          "Client: User Idle",
+          "Client: User Idle"
         );
         colors = new Array(
           "#DCDCDC",
@@ -4673,7 +4671,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FAF0E6",
           "#FFDAB9",
           "#7D9EC0",
-          "#CDAF95",
+          "#CDAF95"
         );
         trColumnId = new Array(
           "entryLinks",
@@ -4685,7 +4683,7 @@ SPDX-License-Identifier: Apache-2.0
           "status",
           "requested",
           "difference",
-          "client",
+          "client"
         );
 
         /* FRONTEND VIEW */
@@ -4695,7 +4693,7 @@ SPDX-License-Identifier: Apache-2.0
             feCMChild,
             feStatChild,
             feReqChild,
-            feCMChild,
+            feCMChild
           );
         /* TOTAL VIEW */ else
           child = new Array(
@@ -4703,7 +4701,7 @@ SPDX-License-Identifier: Apache-2.0
             totCMChild,
             totStatChild,
             totReqChild,
-            totCMChild,
+            totCMChild
           );
 
         /* ARRAYS FOR INFO ACCESSING */
@@ -4715,7 +4713,7 @@ SPDX-License-Identifier: Apache-2.0
           totStatChild,
           totReqChild,
           0,
-          totCMChild,
+          totCMChild
         );
         trFEChildArry = new Array(
           feStatChild,
@@ -4724,19 +4722,19 @@ SPDX-License-Identifier: Apache-2.0
           feStatChild,
           feReqChild,
           0,
-          feCMChild,
+          feCMChild
         );
         // StatusRunningCores(Running cores) , ClientCoresTotal(Registered cores), StatusIdle(Idle), ReqIdle(Idle), ClientJobsIdle(User idle)
         // using columnArrayDesc, i starts w/ Entry_name, xmlAttTotalNumArry starts w/ DT (-1), xmlAttPeriodNumArry starts w/ Status (-columnArrayDesc.Status.offset)
         // In elements offset: 8, 5, -, 1, 1, -, 4
         trAttArry = new Array();
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8],
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8]
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.CM.offset - 1 + 5]);
         trAttArry.push(0);
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1],
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1]
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.Req.offset - 1 + 1]);
         trAttArry.push(0);
@@ -4747,20 +4745,20 @@ SPDX-License-Identifier: Apache-2.0
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 5
-          ],
+          ]
         );
         prAttArry.push(0);
         prAttArry.push(xmlAttPeriodNumArry[1]); // columnArrayDesc.Status.offset-columnArrayDesc.Status.offset+1
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.Req.offset - columnArrayDesc.Status.offset + 1
-          ],
+          ]
         );
         prAttArry.push(0);
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 4
-          ],
+          ]
         );
 
         rows = new Array();
@@ -4829,7 +4827,7 @@ SPDX-License-Identifier: Apache-2.0
                 cols[k].setAttribute("onmouseout", "hidePopUp()");
                 cols[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)",
+                  "showPopUpPeriod(this)"
                 );
                 cols[k - 1].setAttribute("id", c);
                 cols[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -4871,7 +4869,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y,
+              "factoryEntryStatusNow.html?entry=" + y
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             trpr_Table.rows[i].cells[0].appendChild(links[i]);
@@ -5168,7 +5166,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FFFAF0",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95",
+          "#CDAF95"
         );
         hArry2 = new Array(
           "",
@@ -5176,7 +5174,7 @@ SPDX-License-Identifier: Apache-2.0
           "Period:",
           "Status:",
           "Requested:",
-          "Client Monitor:",
+          "Client Monitor:"
         );
         // hArry3 = new Array(1, 1, 1,xmlAttStatNumArry.length, xmlAttReqNumArry.length, xmlAttCMNumArry.length);
         hArry3 = new Array(
@@ -5185,7 +5183,7 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length,
+          columnArrayDesc.CM.length
         );
 
         /*
@@ -5242,7 +5240,7 @@ SPDX-License-Identifier: Apache-2.0
                 cell[k].setAttribute("onmouseout", "hidePopUp()");
                 cell[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)",
+                  "showPopUpPeriod(this)"
                 );
                 cell[k - 1].setAttribute("id", c);
                 cell[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -5339,7 +5337,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y,
+              "factoryEntryStatusNow.html?entry=" + y
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             tableP.rows[i].cells[0].appendChild(links[i]);

--- a/creation/web_base/factory_support.js
+++ b/creation/web_base/factory_support.js
@@ -86,7 +86,7 @@ function getFactoryFrontends(factoryQStats) {
                                     var frontend_name =
                                         el3.attributes[0].value.toString();
                                     groups[entry_name.value].push(
-                                        frontend_name
+                                        frontend_name,
                                     );
                                 }
                             }
@@ -134,16 +134,16 @@ function getFactoryEntryGroups(factoryQStats) {
                                 ) {
                                     var group_name =
                                         grp.attributes.getNamedItem(
-                                            "group_name"
+                                            "group_name",
                                         );
                                     if (group_name.value in groups) {
                                         groups[group_name.value].push(
-                                            entry_name.value
+                                            entry_name.value,
                                         );
                                     } else {
                                         groups[group_name.value] = new Array();
                                         groups[group_name.value].push(
-                                            entry_name.value
+                                            entry_name.value,
                                         );
                                     }
                                 }
@@ -174,7 +174,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             factory_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "factory"
+                    "factory",
                 );
 
             for (var i = 0; i < factory_info[0].attributes.length; i++) {

--- a/creation/web_base/factory_support.js
+++ b/creation/web_base/factory_support.js
@@ -86,7 +86,7 @@ function getFactoryFrontends(factoryQStats) {
                                     var frontend_name =
                                         el3.attributes[0].value.toString();
                                     groups[entry_name.value].push(
-                                        frontend_name,
+                                        frontend_name
                                     );
                                 }
                             }
@@ -134,16 +134,16 @@ function getFactoryEntryGroups(factoryQStats) {
                                 ) {
                                     var group_name =
                                         grp.attributes.getNamedItem(
-                                            "group_name",
+                                            "group_name"
                                         );
                                     if (group_name.value in groups) {
                                         groups[group_name.value].push(
-                                            entry_name.value,
+                                            entry_name.value
                                         );
                                     } else {
                                         groups[group_name.value] = new Array();
                                         groups[group_name.value].push(
-                                            entry_name.value,
+                                            entry_name.value
                                         );
                                     }
                                 }
@@ -174,7 +174,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             factory_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "factory",
+                    "factory"
                 );
 
             for (var i = 0; i < factory_info[0].attributes.length; i++) {

--- a/creation/web_base/frontendGroupGraphStatusNow.html
+++ b/creation/web_base/frontendGroupGraphStatusNow.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: Apache-2.0
             chartData.push(
               simpleEncoding.charAt(
                 Math.round(
-                  ((simpleEncoding.length - 1) * currentValue) / maxValue,
-                ),
-              ),
+                  ((simpleEncoding.length - 1) * currentValue) / maxValue
+                )
+              )
             );
           } else {
             chartData.push("_");
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
           var numericVal = new Number(arrVals[i]);
           // Scale the value to maxVal.
           var scaledVal = Math.floor(
-            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal,
+            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal
           );
 
           if (scaledVal > EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH - 1) {
@@ -169,8 +169,8 @@ SPDX-License-Identifier: Apache-2.0
         return (
           decodeURIComponent(
             (new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(
-              location.search,
-            ) || [, ""])[1].replace(/\+/g, "%20"),
+              location.search
+            ) || [, ""])[1].replace(/\+/g, "%20")
           ) || null
         );
       }
@@ -263,7 +263,7 @@ SPDX-License-Identifier: Apache-2.0
           window.history.pushState(
             { group: selected_group },
             "",
-            addParameter(document.location.href, "group", selected_group),
+            addParameter(document.location.href, "group", selected_group)
           );
         } else {
           going_back = false;
@@ -321,7 +321,7 @@ SPDX-License-Identifier: Apache-2.0
                 group_name +
                 "'><i class='icon-chevron-right'></i>" +
                 group_name +
-                "</a>  </li>",
+                "</a>  </li>"
             );
 
             if (first_group == true) {
@@ -367,7 +367,7 @@ SPDX-License-Identifier: Apache-2.0
           .each(function () {
             if ($(this).attr("name") == "Local") {
               $("#updated_display").html(
-                "Snapshot last updated: " + $(this).attr("human"),
+                "Snapshot last updated: " + $(this).attr("human")
               );
             }
           });
@@ -400,7 +400,7 @@ SPDX-License-Identifier: Apache-2.0
         } else {
           $(input_array).each(function () {
             toReturn.push(
-              (parseFloat(this) / parseFloat(normalized_total)) * 100.0,
+              (parseFloat(this) / parseFloat(normalized_total)) * 100.0
             );
           });
         }
@@ -455,11 +455,11 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 0, entry_name);
 
             var matched_idle_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Idle"),
+              $(this).find("MatchedGlideins").attr("Idle")
             );
             matchedglideins_idle.push(matched_idle_glideins);
             var matched_running_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Running"),
+              $(this).find("MatchedGlideins").attr("Running")
             );
             matchedglideins_running.push(matched_running_glideins);
             data.setCell(counter, 3, matched_running_glideins);
@@ -482,29 +482,29 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 2, mji);
 
             matchedjobs_running.push(
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
             );
             data.setCell(
               counter,
               1,
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
             );
 
             requested_idle.push(
-              parseFloat($(this).find("Requested").attr("Idle")),
+              parseFloat($(this).find("Requested").attr("Idle"))
             );
             data.setCell(
               counter,
               7,
-              parseFloat($(this).find("Requested").attr("Idle")),
+              parseFloat($(this).find("Requested").attr("Idle"))
             );
             requested_max_running.push(
-              parseFloat($(this).find("Requested").attr("MaxGlideins")),
+              parseFloat($(this).find("Requested").attr("MaxGlideins"))
             );
             data.setCell(
               counter,
               6,
-              parseFloat($(this).find("Requested").attr("MaxGlideins")),
+              parseFloat($(this).find("Requested").attr("MaxGlideins"))
             );
 
             counter++;
@@ -518,7 +518,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Entry Points Detected",
             "No entry points were detected in the group: <strong>" +
               group_name +
-              "</strong>. <p>Please select another group from the menu on the left.</p>",
+              "</strong>. <p>Please select another group from the menu on the left.</p>"
           );
 
           // If no jobs are detected, idle or running
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Jobs Detected",
             "No jobs were detected, idle or running, in the group: <strong>" +
               group_name +
-              "</strong>.  <p>Please select another group from the menu on the left.</p>",
+              "</strong>.  <p>Please select another group from the menu on the left.</p>"
           );
         } else {
           $("#group_graphs").fadeTo(0, 1.0);
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
         data.setCell(
           counter,
           5,
-          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0,
+          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0
         );
         data.setCell(counter, 6, SumElements(requested_max_running));
         data.setCell(counter, 7, SumElements(requested_idle));
@@ -574,7 +574,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_idle,
           "Glideins not matched",
-          img,
+          img
         );
 
         img = CreateGraphImage();
@@ -586,7 +586,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_running,
           "Glideins claimed by jobs",
-          img,
+          img
         );
 
         img = CreateGraphImage();
@@ -599,7 +599,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedjobs_running,
           "Running jobs by Entry",
-          img,
+          img
         );
 
         img = CreateGraphImage();
@@ -612,11 +612,11 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           requested_max_running,
           "Requested Max Running",
-          img,
+          img
         );
 
         table = new google.visualization.Table(
-          document.getElementById("group_table"),
+          document.getElementById("group_table")
         );
         var dataview = new google.visualization.DataView(data);
         table.draw(dataview);
@@ -638,7 +638,7 @@ SPDX-License-Identifier: Apache-2.0
             .html(
               '<div id="image_load_fail" class="image_error">Unable to load image: ' +
                 img_title +
-                "<div>",
+                "<div>"
             );
         });
         $(img).click(function () {
@@ -699,7 +699,7 @@ SPDX-License-Identifier: Apache-2.0
             entry_data[i][0] +
               " (" +
               Math.round(entry_data[i][1] * 10) / 10.0 +
-              ")",
+              ")"
           );
         }
         baseurl += formatted_entry_points.join("|");
@@ -720,7 +720,7 @@ SPDX-License-Identifier: Apache-2.0
       function ShowDialog(tocenter_object, title, text) {
         HideDialog();
         $(tocenter_object).append(
-          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>",
+          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>"
         );
         $("#error_dialog")
           .dialog({

--- a/creation/web_base/frontendGroupGraphStatusNow.html
+++ b/creation/web_base/frontendGroupGraphStatusNow.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: Apache-2.0
             chartData.push(
               simpleEncoding.charAt(
                 Math.round(
-                  ((simpleEncoding.length - 1) * currentValue) / maxValue
-                )
-              )
+                  ((simpleEncoding.length - 1) * currentValue) / maxValue,
+                ),
+              ),
             );
           } else {
             chartData.push("_");
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
           var numericVal = new Number(arrVals[i]);
           // Scale the value to maxVal.
           var scaledVal = Math.floor(
-            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal
+            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal,
           );
 
           if (scaledVal > EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH - 1) {
@@ -169,8 +169,8 @@ SPDX-License-Identifier: Apache-2.0
         return (
           decodeURIComponent(
             (new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(
-              location.search
-            ) || [, ""])[1].replace(/\+/g, "%20")
+              location.search,
+            ) || [, ""])[1].replace(/\+/g, "%20"),
           ) || null
         );
       }
@@ -263,7 +263,7 @@ SPDX-License-Identifier: Apache-2.0
           window.history.pushState(
             { group: selected_group },
             "",
-            addParameter(document.location.href, "group", selected_group)
+            addParameter(document.location.href, "group", selected_group),
           );
         } else {
           going_back = false;
@@ -321,7 +321,7 @@ SPDX-License-Identifier: Apache-2.0
                 group_name +
                 "'><i class='icon-chevron-right'></i>" +
                 group_name +
-                "</a>  </li>"
+                "</a>  </li>",
             );
 
             if (first_group == true) {
@@ -367,7 +367,7 @@ SPDX-License-Identifier: Apache-2.0
           .each(function () {
             if ($(this).attr("name") == "Local") {
               $("#updated_display").html(
-                "Snapshot last updated: " + $(this).attr("human")
+                "Snapshot last updated: " + $(this).attr("human"),
               );
             }
           });
@@ -400,7 +400,7 @@ SPDX-License-Identifier: Apache-2.0
         } else {
           $(input_array).each(function () {
             toReturn.push(
-              (parseFloat(this) / parseFloat(normalized_total)) * 100.0
+              (parseFloat(this) / parseFloat(normalized_total)) * 100.0,
             );
           });
         }
@@ -455,11 +455,11 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 0, entry_name);
 
             var matched_idle_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Idle")
+              $(this).find("MatchedGlideins").attr("Idle"),
             );
             matchedglideins_idle.push(matched_idle_glideins);
             var matched_running_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Running")
+              $(this).find("MatchedGlideins").attr("Running"),
             );
             matchedglideins_running.push(matched_running_glideins);
             data.setCell(counter, 3, matched_running_glideins);
@@ -482,29 +482,29 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 2, mji);
 
             matchedjobs_running.push(
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
             );
             data.setCell(
               counter,
               1,
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
             );
 
             requested_idle.push(
-              parseFloat($(this).find("Requested").attr("Idle"))
+              parseFloat($(this).find("Requested").attr("Idle")),
             );
             data.setCell(
               counter,
               7,
-              parseFloat($(this).find("Requested").attr("Idle"))
+              parseFloat($(this).find("Requested").attr("Idle")),
             );
             requested_max_running.push(
-              parseFloat($(this).find("Requested").attr("MaxGlideins"))
+              parseFloat($(this).find("Requested").attr("MaxGlideins")),
             );
             data.setCell(
               counter,
               6,
-              parseFloat($(this).find("Requested").attr("MaxGlideins"))
+              parseFloat($(this).find("Requested").attr("MaxGlideins")),
             );
 
             counter++;
@@ -518,7 +518,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Entry Points Detected",
             "No entry points were detected in the group: <strong>" +
               group_name +
-              "</strong>. <p>Please select another group from the menu on the left.</p>"
+              "</strong>. <p>Please select another group from the menu on the left.</p>",
           );
 
           // If no jobs are detected, idle or running
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Jobs Detected",
             "No jobs were detected, idle or running, in the group: <strong>" +
               group_name +
-              "</strong>.  <p>Please select another group from the menu on the left.</p>"
+              "</strong>.  <p>Please select another group from the menu on the left.</p>",
           );
         } else {
           $("#group_graphs").fadeTo(0, 1.0);
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
         data.setCell(
           counter,
           5,
-          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0
+          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0,
         );
         data.setCell(counter, 6, SumElements(requested_max_running));
         data.setCell(counter, 7, SumElements(requested_idle));
@@ -574,7 +574,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_idle,
           "Glideins not matched",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -586,7 +586,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_running,
           "Glideins claimed by jobs",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -599,7 +599,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedjobs_running,
           "Running jobs by Entry",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -612,11 +612,11 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           requested_max_running,
           "Requested Max Running",
-          img
+          img,
         );
 
         table = new google.visualization.Table(
-          document.getElementById("group_table")
+          document.getElementById("group_table"),
         );
         var dataview = new google.visualization.DataView(data);
         table.draw(dataview);
@@ -638,7 +638,7 @@ SPDX-License-Identifier: Apache-2.0
             .html(
               '<div id="image_load_fail" class="image_error">Unable to load image: ' +
                 img_title +
-                "<div>"
+                "<div>",
             );
         });
         $(img).click(function () {
@@ -699,7 +699,7 @@ SPDX-License-Identifier: Apache-2.0
             entry_data[i][0] +
               " (" +
               Math.round(entry_data[i][1] * 10) / 10.0 +
-              ")"
+              ")",
           );
         }
         baseurl += formatted_entry_points.join("|");
@@ -720,7 +720,7 @@ SPDX-License-Identifier: Apache-2.0
       function ShowDialog(tocenter_object, title, text) {
         HideDialog();
         $(tocenter_object).append(
-          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>"
+          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>",
         );
         $("#error_dialog")
           .dialog({

--- a/creation/web_base/frontendRRDGroupMatrix.html
+++ b/creation/web_base/frontendRRDGroupMatrix.html
@@ -203,7 +203,7 @@ Description:
 
         for (var i in group_names) {
           fnames.push(
-            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd"
+            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd",
           );
           rrd_data.push(null);
         }

--- a/creation/web_base/frontendRRDGroupMatrix.html
+++ b/creation/web_base/frontendRRDGroupMatrix.html
@@ -203,7 +203,7 @@ Description:
 
         for (var i in group_names) {
           fnames.push(
-            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd",
+            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd"
           );
           rrd_data.push(null);
         }

--- a/creation/web_base/frontendStatus.html
+++ b/creation/web_base/frontendStatus.html
@@ -239,7 +239,7 @@ Description:
           "MatchCoreRunning",
           "MatchJobIdle",
           "ReqIdle",
-          "ReqMaxRun"
+          "ReqMaxRun",
         );
         //                                       'JobsRunning',    'GlideinTotal',     'GlideinRunning',     'GlideinIdle',     'JobsIdle');
         gtype_DSs["idle"] = new Array(
@@ -254,7 +254,7 @@ Description:
           "MatchCoreIdle",
           "MatchCoreRunning",
           "ReqIdle",
-          "ReqMaxRun"
+          "ReqMaxRun",
         );
 
         var gtype_formats = new Object();
@@ -501,7 +501,7 @@ Description:
             window_max: local_window_max,
             use_checked_DSs: true,
             use_element_buttons: true,
-          }
+          },
         );
       }
 
@@ -569,7 +569,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone"
+          "timezone",
         );
         var groupSpec;
         var infoGroupSpec;
@@ -610,11 +610,11 @@ Description:
                     //   as seen in the factory menu.
                     var state_list = getFrontendGroupStates(
                       loadFrontendStats(),
-                      groups[group]
+                      groups[group],
                     );
                     var fac_list = getFrontendGroupFactories(
                       loadFrontendStats(),
-                      groups[group]
+                      groups[group],
                     );
 
                     //states listed first in the Factory menu, so push factories onto state list

--- a/creation/web_base/frontendStatus.html
+++ b/creation/web_base/frontendStatus.html
@@ -239,7 +239,7 @@ Description:
           "MatchCoreRunning",
           "MatchJobIdle",
           "ReqIdle",
-          "ReqMaxRun",
+          "ReqMaxRun"
         );
         //                                       'JobsRunning',    'GlideinTotal',     'GlideinRunning',     'GlideinIdle',     'JobsIdle');
         gtype_DSs["idle"] = new Array(
@@ -254,7 +254,7 @@ Description:
           "MatchCoreIdle",
           "MatchCoreRunning",
           "ReqIdle",
-          "ReqMaxRun",
+          "ReqMaxRun"
         );
 
         var gtype_formats = new Object();
@@ -501,7 +501,7 @@ Description:
             window_max: local_window_max,
             use_checked_DSs: true,
             use_element_buttons: true,
-          },
+          }
         );
       }
 
@@ -569,7 +569,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone",
+          "timezone"
         );
         var groupSpec;
         var infoGroupSpec;
@@ -610,11 +610,11 @@ Description:
                     //   as seen in the factory menu.
                     var state_list = getFrontendGroupStates(
                       loadFrontendStats(),
-                      groups[group],
+                      groups[group]
                     );
                     var fac_list = getFrontendGroupFactories(
                       loadFrontendStats(),
-                      groups[group],
+                      groups[group]
                     );
 
                     //states listed first in the Factory menu, so push factories onto state list

--- a/creation/web_base/frontendStatusNow.html
+++ b/creation/web_base/frontendStatusNow.html
@@ -208,7 +208,9 @@ SPDX-License-Identifier: Apache-2.0
         text-align: left;
       }
       #button {
-        font-family: Lucida Console, monospace;
+        font-family:
+          Lucida Console,
+          monospace;
         font-weight: bold;
         color: #330000;
         width: 110px;

--- a/creation/web_base/frontendStatusNow.html
+++ b/creation/web_base/frontendStatusNow.html
@@ -208,9 +208,7 @@ SPDX-License-Identifier: Apache-2.0
         text-align: left;
       }
       #button {
-        font-family:
-          Lucida Console,
-          monospace;
+        font-family: Lucida Console, monospace;
         font-weight: bold;
         color: #330000;
         width: 110px;

--- a/creation/web_base/frontend_support.js
+++ b/creation/web_base/frontend_support.js
@@ -47,7 +47,7 @@ function getFrontendGroupFoS(
     frontendStats,
     group_name,
     fos_tag_top,
-    fos_tag_one
+    fos_tag_one,
 ) {
     factories = new Array();
 
@@ -88,7 +88,7 @@ function getFrontendGroupFoS(
                                     if (factory.nodeName == fos_tag_one) {
                                         factory_name =
                                             factory.attributes.getNamedItem(
-                                                "name"
+                                                "name",
                                             );
                                         factories.push(factory_name.value);
                                     }
@@ -109,7 +109,7 @@ function getFrontendGroupFactories(frontendStats, group_name) {
         frontendStats,
         group_name,
         "factories",
-        "factory"
+        "factory",
     );
 }
 
@@ -147,7 +147,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             frontend_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "frontend"
+                    "frontend",
                 );
             frontend_name = frontend_info[0].attributes[0].value;
             document.getElementById("pgtitle").innerHTML =
@@ -157,7 +157,7 @@ function set_title_and_footer(browser_title, page_title) {
 
             footer_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "monitor_footer"
+                    "monitor_footer",
                 );
             footer_text = footer_info[0].attributes[0].value;
             footer_link = footer_info[0].attributes[1].value;

--- a/creation/web_base/frontend_support.js
+++ b/creation/web_base/frontend_support.js
@@ -47,7 +47,7 @@ function getFrontendGroupFoS(
     frontendStats,
     group_name,
     fos_tag_top,
-    fos_tag_one,
+    fos_tag_one
 ) {
     factories = new Array();
 
@@ -88,7 +88,7 @@ function getFrontendGroupFoS(
                                     if (factory.nodeName == fos_tag_one) {
                                         factory_name =
                                             factory.attributes.getNamedItem(
-                                                "name",
+                                                "name"
                                             );
                                         factories.push(factory_name.value);
                                     }
@@ -109,7 +109,7 @@ function getFrontendGroupFactories(frontendStats, group_name) {
         frontendStats,
         group_name,
         "factories",
-        "factory",
+        "factory"
     );
 }
 
@@ -147,7 +147,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             frontend_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "frontend",
+                    "frontend"
                 );
             frontend_name = frontend_info[0].attributes[0].value;
             document.getElementById("pgtitle").innerHTML =
@@ -157,7 +157,7 @@ function set_title_and_footer(browser_title, page_title) {
 
             footer_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "monitor_footer",
+                    "monitor_footer"
                 );
             footer_text = footer_info[0].attributes[0].value;
             footer_link = footer_info[0].attributes[1].value;

--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -170,9 +170,9 @@ SPDX-License-Identifier: Apache-2.0
               <a href="#">&lt;process_logs &gt;</a><br />
               <blockquote>
                 <a href="#process_logs"
-                  >&lt;process_log extension="info" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="INFO"
-                  backup_count="5" compression="gz" /&gt;</a
+                  >&lt;process_log structured="True" extension="info"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="INFO" backup_count="5" compression="gz" /&gt;</a
                 ><br />
                 <a href="#process_logs"
                   >&lt;process_log extension="debug" max_days="7.0"
@@ -611,6 +611,12 @@ SPDX-License-Identifier: Apache-2.0
                 with other message types.
               </li>
             </ul>
+            If any of the logs has <i>structured=True</i>, then the logs are
+            written in structured format. It is actuallly a hybrid format, with
+            some initial field and a JSON dictionary. Since all logs share the
+            same logger, it is not possible to have some in structured and some
+            in classic format. In the future we plan for the structured format
+            to become the default. <br /><br />
             The extension is added to the log name to create separate logs.
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -159,14 +159,14 @@ SPDX-License-Identifier: Apache-2.0
               <a href="#">&lt;process_logs &gt;</a><br />
               <blockquote>
                 <a href="#process_logs"
-                  >&lt;process_log extension="info" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="INFO"
-                  backup_count="5" compression="gz" /&gt;</a
+                  >&lt;process_log structured="False" extension="info"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="INFO" backup_count="5" compression="gz" /&gt;</a
                 ><br />
                 <a href="#process_logs"
-                  >&lt;process_log extension="debug" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="DEBUG,ERR,WARN"
-                  backup_count="5" /&gt;</a
+                  >&lt;process_log structured="False" extension="debug"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="DEBUG,ERR,WARN" backup_count="5" /&gt;</a
                 ><br />
               </blockquote>
               <a href="#">&lt;/process_logs &gt;</a><br />
@@ -518,9 +518,10 @@ SPDX-License-Identifier: Apache-2.0
             <a name="process_logs" />
             <div class="xml">
               &lt;frontend&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
-              max_days=&quot;<i>max days</i>&quot; min_days=&quot;<i>min days</i
-              >&quot; max_bytes=&quot;<i>max bytes</i>&quot;
-              backup_count=&quot;<i>backup count</i>&quot;
+              structured="True" max_days=&quot;<i>max days</i>&quot;
+              min_days=&quot;<i>min days</i>&quot; max_bytes=&quot;<i
+                >max bytes</i
+              >&quot; backup_count=&quot;<i>backup count</i>&quot;
               type=&quot;<i>ALL</i>&quot; compression=&quot;<i>gz</i>&quot;/&gt;
             </div>
             <p>
@@ -541,6 +542,12 @@ SPDX-License-Identifier: Apache-2.0
                 that don't necessarily cause abnormal execution.
               </li>
             </ul>
+            If any of the logs has <i>structured=True</i>, then the logs are
+            written in structured format. It is actuallly a hybrid format, with
+            some initial field and a JSON dictionary. Since all logs share the
+            same logger, it is not possible to have some in structured and some
+            in classic format. In the future we plan for the structured format
+            to become the default. <br /><br />
             The extension is added to the log name to create separate logs.
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>

--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -873,7 +873,7 @@ def main(startup_dir):
                 int(float(plog["backup_count"])),
                 plog["compression"],
             )
-    logSupport.log = logging.getLogger("factory")
+    logSupport.log = logSupport.getLogger("factory")
     logSupport.log.info("Logging initialized")
 
     if glideinDescript.data["Entries"].strip() in ("", ","):

--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -847,33 +847,7 @@ def main(startup_dir):
     logSupport.log_dir = os.path.join(glideinDescript.data["LogDir"], "factory")
 
     # Configure factory process logging
-    process_logs = eval(glideinDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        if "ADMIN" in plog["msg_types"].upper():
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                "DEBUG,INFO,WARN,ERR",
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-        else:
-            logSupport.add_processlog_handler(
-                "factory",
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-    logSupport.log = logSupport.getLogger("factory")
+    logSupport.log = logSupport.get_logger_with_handlers("factory", logSupport.log_dir, glideinDescript.data)
     logSupport.log.info("Logging initialized")
 
     if glideinDescript.data["Entries"].strip() in ("", ","):

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -85,7 +85,7 @@ class Entry:
                 int(float(plog["backup_count"])),
                 plog["compression"],
             )
-        self.log = logging.getLogger(self.name)
+        self.log = logSupport.getLogger(self.name)
 
         cleaner = cleanupSupport.DirCleanupWSpace(
             self.logDir,

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -72,20 +72,7 @@ class Entry:
         self.scheddName = self.jobDescript.data["Schedd"]
 
         # glideFactoryLib.log_files
-        process_logs = eval(self.glideinDescript.data["ProcessLogs"])
-        for plog in process_logs:
-            logSupport.add_processlog_handler(
-                self.name,
-                self.logDir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-        self.log = logSupport.getLogger(self.name)
+        self.log = logSupport.get_logger_with_handlers(self.name, self.logDir, self.glideinDescript.data)
 
         cleaner = cleanupSupport.DirCleanupWSpace(
             self.logDir,

--- a/factory/glideFactoryEntryGroup.py
+++ b/factory/glideFactoryEntryGroup.py
@@ -646,7 +646,7 @@ def init_logs(name, log_dir, process_logs):
             int(float(plog["backup_count"])),
             plog["compression"],
         )
-        logSupport.log = logging.getLogger(name)
+        logSupport.log = logSupport.getLogger(name)
         logSupport.log.info("Logging initialized for %s" % name)
 
 

--- a/factory/tools/OSG_autoconf.py
+++ b/factory/tools/OSG_autoconf.py
@@ -30,6 +30,7 @@ from glideinwms.lib.config_util import (
     write_to_xml_file,
     write_to_yaml_file,
 )
+from glideinwms.lib.util import is_true
 
 
 def parse_opts():
@@ -291,19 +292,6 @@ def get_entries_configuration(data):
 #                    out[site][ce_hostname].setdefault(BEST_FIT_TAG, {})[qelem] = q_information
 #                    del out[site][ce_hostname][qelem]
 #
-
-
-def is_true(param):
-    """Determine if the parameter passed as argument is true or false
-
-    Args:
-        param: the parameter we need to determine if it is True or False. Can be any type.
-
-    Returns:
-        bool: True if the the string representation of param is "true"
-    """
-
-    return str(param).lower() == "true"
 
 
 def sanitize(whitelist_info):

--- a/factory/tools/manual_glidein_submit.py
+++ b/factory/tools/manual_glidein_submit.py
@@ -77,9 +77,9 @@ def parse_opts():
     # Initialize logging
     if options.debug:
         logging.basicConfig(format="%(levelname)s: %(message)s")
-        logging.getLogger().setLevel(logging.DEBUG)
+        logSupport.getLogger().setLevel(logging.DEBUG)
     else:
-        logging.getLogger().setLevel(logging.INFO)
+        logSupport.getLogger().setLevel(logging.INFO)
 
     return options
 
@@ -221,7 +221,7 @@ def main():
         params["Report_Failed"] = "NEVER"
 
         # Now that we have everything submit the pilot!
-        logging.getLogger().setLevel(logging.DEBUG)
+        logSupport.getLogger().setLevel(logging.DEBUG)
         submitGlideins(
             entry_name,
             "test.test",
@@ -232,7 +232,7 @@ def main():
             client_web,
             params,
             status_sf,
-            log=logging.getLogger(),
+            log=logSupport.getLogger(),
             factoryConfig=factory_config,
         )
 

--- a/factory/tools/manual_glidein_submit.py
+++ b/factory/tools/manual_glidein_submit.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import logging
+import logging  # This script is using straight logging instead of logSupport or structlog
 import os
 import pprint
 import socket
@@ -77,9 +77,9 @@ def parse_opts():
     # Initialize logging
     if options.debug:
         logging.basicConfig(format="%(levelname)s: %(message)s")
-        logSupport.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
     else:
-        logSupport.getLogger().setLevel(logging.INFO)
+        logging.getLogger().setLevel(logging.INFO)
 
     return options
 
@@ -221,7 +221,7 @@ def main():
         params["Report_Failed"] = "NEVER"
 
         # Now that we have everything submit the pilot!
-        logSupport.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
         submitGlideins(
             entry_name,
             "test.test",
@@ -232,7 +232,7 @@ def main():
             client_web,
             params,
             status_sf,
-            log=logSupport.getLogger(),
+            log=logging.getLogger(),
             factoryConfig=factory_config,
         )
 

--- a/frontend/glideinFrontend.py
+++ b/frontend/glideinFrontend.py
@@ -3,20 +3,11 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This is the main of the glideinFrontend
 #
 # Arguments:
 #   $1 = work_dir
-#
-# Author:
-#   Igor Sfiligoi
 #
 
 
@@ -529,20 +520,8 @@ def main(work_dir, action):
     logSupport.log_dir = os.path.join(frontendDescript.data["LogDir"], "frontend")
 
     # Configure frontend process logging
-    process_logs = eval(frontendDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        logSupport.add_processlog_handler(
-            "frontend",
-            logSupport.log_dir,
-            plog["msg_types"],
-            plog["extension"],
-            int(float(plog["max_days"])),
-            int(float(plog["min_days"])),
-            int(float(plog["max_mbytes"])),
-            int(float(plog["backup_count"])),
-            plog["compression"],
-        )
-    logSupport.log = logSupport.getLogger("frontend")
+    logSupport.log = logSupport.get_logger_with_handlers("frontend", logSupport.log_dir, frontendDescript.data)
+
     logSupport.log.info("Logging initialized")
     logSupport.log.debug("Frontend startup time: %s" % str(startup_time))
 

--- a/frontend/glideinFrontend.py
+++ b/frontend/glideinFrontend.py
@@ -542,7 +542,7 @@ def main(work_dir, action):
             int(float(plog["backup_count"])),
             plog["compression"],
         )
-    logSupport.log = logging.getLogger("frontend")
+    logSupport.log = logSupport.getLogger("frontend")
     logSupport.log.info("Logging initialized")
     logSupport.log.debug("Frontend startup time: %s" % str(startup_time))
 

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -210,21 +210,9 @@ class glideinFrontendElement:
         )
 
         # Configure frontend group process logging
-        process_logs = eval(self.elementDescript.frontend_data["ProcessLogs"])
-        for plog in process_logs:
-            logSupport.add_processlog_handler(
-                self.group_name,
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-
-        logSupport.log = logSupport.getLogger(self.group_name)
+        logSupport.log = logSupport.get_logger_with_handlers(
+            self.group_name, logSupport.log_dir, self.elementDescript.frontend_data
+        )
 
         # We will be starting often, so reduce the clutter
         # logSupport.log.info("Logging initialized")
@@ -244,8 +232,7 @@ class glideinFrontendElement:
             if not proxy_plugins.get(self.elementDescript.merged_data["ProxySelectionPlugin"]):
                 logSupport.log.warning(
                     "Invalid ProxySelectionPlugin '%s', supported plugins are %s"
-                    % (self.elementDescript.merged_data["ProxySelectionPlugin"]),
-                    list(proxy_plugins.keys()),
+                    % (self.elementDescript.merged_data["ProxySelectionPlugin"], list(proxy_plugins.keys()))
                 )
                 return 1
             self.x509_proxy_plugin = proxy_plugins[self.elementDescript.merged_data["ProxySelectionPlugin"]](

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -224,7 +224,7 @@ class glideinFrontendElement:
                 plog["compression"],
             )
 
-        logSupport.log = logging.getLogger(self.group_name)
+        logSupport.log = logSupport.getLogger(self.group_name)
 
         # We will be starting often, so reduce the clutter
         # logSupport.log.info("Logging initialized")

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -11,7 +11,6 @@
 #
 
 import codecs
-import structlog
 import logging
 import os
 import re
@@ -20,6 +19,8 @@ import sys  # for alternate_log
 import time
 
 from logging.handlers import BaseRotatingHandler
+
+import structlog
 
 # Compressions depend on the available module
 COMPRESSION_SUPPORTED = {}
@@ -361,6 +362,6 @@ def format_dict(unformated_dict, log_format="   %-25s : %s\n"):
 
     return formatted_string
 
+
 def getLogger(name):
     return structlog.getLogger(name)
-

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -64,7 +64,7 @@ def alternate_log(msg):
 
 class GlideinHandler(BaseRotatingHandler):
     """
-    Custom logging handler class for glideinWMS.  It combines the decision tree
+    Custom logging handler class for GlideinWMS.  It combines the decision tree
     for log rotation from the TimedRotatingFileHandler with the decision tree
     from the RotatingFileHandler.  This allows us to specify a lifetime AND
     file size to determine when to rotate the file.
@@ -173,8 +173,7 @@ class GlideinHandler(BaseRotatingHandler):
         return do_timed_rollover or do_size_rollover
 
     def getFilesToDelete(self):
-        """
-        Determine the files to delete when rolling over.
+        """Determine the files to delete when rolling over.
 
         More specific than the earlier method, which just used glob.glob().
         """
@@ -226,7 +225,7 @@ class GlideinHandler(BaseRotatingHandler):
 
         # Open a new log file
         self.mode = "w"
-        self.stream = self._open_new_log()
+        self.stream = self._open()
 
         # determine the next rollover time for the timed rollover check
         currentTime = int(time.time())
@@ -261,22 +260,24 @@ class GlideinHandler(BaseRotatingHandler):
             except OSError as e:
                 alternate_log("Log file gzip compression failed: %s" % e)
 
-    def _open_new_log(self):
-        """
-        This function is here to bridge the gap between the old (python 2.4) way
-        of opening new log files and the new (python 2.7) way.
-        """
-        new_stream = None
-        try:
-            # pylint: disable=E1101
-            new_stream = self._open()
-            # pylint: enable=E1101
-        except:
-            if self.encoding:
-                new_stream = codecs.open(self.baseFilename, self.mode, self.encoding)
-            else:
-                new_stream = open(self.baseFilename, self.mode)
-        return new_stream
+    # TODO: remove if all OK
+    # in python 3 _open() and ancoding are safe to use all the time
+    # def _open_new_log(self):
+    #     """
+    #     This function is here to bridge the gap between the old (python 2.4) way
+    #     of opening new log files and the new (python 2.7) way.
+    #     """
+    #     new_stream = None
+    #     try:
+    #         # pylint: disable=E1101
+    #         new_stream = self._open()
+    #         # pylint: enable=E1101
+    #     except:
+    #         if self.encoding:
+    #             new_stream = codecs.open(self.baseFilename, self.mode, self.encoding)
+    #         else:
+    #             new_stream = open(self.baseFilename, self.mode)
+    #     return new_stream
 
     def check_and_perform_rollover(self):
         if self.shouldRollover(None, empty_record=True):
@@ -347,20 +348,70 @@ class MsgFilter(logging.Filter):
 
 
 def format_dict(unformated_dict, log_format="   %-25s : %s\n"):
-    """
-    Convenience function used to format a dictionary for the logs to make it
-    human readable.
+    """Convenience function used to format a dictionary for the logs to make it  human-readable.
 
-    @type unformated_dict: dict
-    @param unformated_dict: The dictionary to be formatted for logging
-    @type log_format: string
-    @param log_format: format string for logging
+    Args:
+        unformated_dict (dict): The dictionary to be formatted for logging
+        log_format (str): format string for logging
+
+    Returns:
+        str: Formatted string
     """
     formatted_string = ""
     for key in unformated_dict:
         formatted_string += log_format % (key, unformated_dict[key])
 
     return formatted_string
+
+
+###############################
+# structlog
+
+# From structlog's suggested configurations - separate rendering, using same output
+structlog.configure(
+    processors=[
+        # If log level is too low, abort pipeline and throw away log entry.
+        structlog.stdlib.filter_by_level,
+        # Add the name of the logger to event dict.
+        structlog.stdlib.add_logger_name,
+        # Add log level to event dict.
+        structlog.stdlib.add_log_level,
+        # Perform %-style formatting.
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        # Add a timestamp in ISO 8601 format.
+        structlog.processors.TimeStamper(fmt="iso"),
+        # If the "stack_info" key in the event dict is true, remove it and
+        # render the current stack trace in the "stack" key.
+        structlog.processors.StackInfoRenderer(),
+        # If the "exc_info" key in the event dict is either true or a
+        # sys.exc_info() tuple, remove "exc_info" and render the exception
+        # with traceback into the "exception" key.
+        structlog.processors.format_exc_info,
+        # If some value is in bytes, decode it to a unicode str.
+        structlog.processors.UnicodeDecoder(),
+        # Add callsite parameters.
+        structlog.processors.CallsiteParameterAdder(
+            {
+                structlog.processors.CallsiteParameter.FILENAME,
+                structlog.processors.CallsiteParameter.FUNC_NAME,
+                structlog.processors.CallsiteParameter.LINENO,
+            }
+        ),
+        # Render the final event dict as JSON.
+        structlog.processors.JSONRenderer(),
+    ],
+    # `wrapper_class` is the bound logger that you get back from
+    # get_logger(). This one imitates the API of `logging.Logger`.
+    wrapper_class=structlog.stdlib.BoundLogger,
+    # `logger_factory` is used to create wrapped loggers that are used for
+    # OUTPUT. This one returns a `logging.Logger`. The final value (a JSON
+    # string) from the final processor (`JSONRenderer`) will be passed to
+    # the method of the same name as that you've called on the bound logger.
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    # Effectively freeze configuration after creating the first bound
+    # logger.
+    cache_logger_on_first_use=True,
+)
 
 
 def getLogger(name):

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -11,6 +11,7 @@
 #
 
 import codecs
+import structlog
 import logging
 import os
 import re
@@ -359,3 +360,7 @@ def format_dict(unformated_dict, log_format="   %-25s : %s\n"):
         formatted_string += log_format % (key, unformated_dict[key])
 
     return formatted_string
+
+def getLogger(name):
+    return structlog.getLogger(name)
+

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -297,7 +297,7 @@ def add_processlog_handler(
 
     logfile = os.path.expandvars(f"{log_dir}/{logger_name}.{extension.lower()}.log")
 
-    mylog = logging.getLogger(logger_name)
+    mylog = structlog.getLogger(logger_name)
     mylog.setLevel(logging.DEBUG)
 
     handler = GlideinHandler(logfile, maxDays, minDays, maxMBytes, backupCount, compression)

--- a/lib/util.py
+++ b/lib/util.py
@@ -402,6 +402,22 @@ def safe_boolcomp(value, expected):
     return str(value).lower() == str(expected).lower()
 
 
+# DEV NOTE: merging of creation.lib.CWParamDict.is_true() and factory.tools.OSG_autoconf.is_true()
+#   the first one required the argument to be a string. OK to drop that
+def is_true(value):
+    """Case-insensitive "True" string parsing helper.
+    Return True for true (case-insensitive string representation matching), False otherwise.
+
+    Args:
+        value: argument to evaluate as True or False. Can be any type.
+
+    Returns:
+        bool: True if the string representation of value is "true"
+    """
+
+    return str(value).lower() == "true"
+
+
 def str2bool(val):
     """Convert u"True" or u"False" to boolean or raise ValueError"""
     if val not in ["True", "False"]:

--- a/lib/xmlParse.py
+++ b/lib/xmlParse.py
@@ -1,17 +1,7 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description: general purpose XML decoder
-#
-# Author:
-#  Igor Sfiligoi (Mar 27th, 2007)
-#
 
 import xml.dom.minidom
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ htcondor
 # classad  # pure python 3rd party classad implementation
 m2crypto
 requests
+structlog
 pyyaml
 pyjwt
 

--- a/tools/gwms-logparser.py
+++ b/tools/gwms-logparser.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import fileinput
+import json
+import os
+
+
+def arg_parser():
+    epilog_text = """examples:
+   %(prog)s -f 0,1,2 -k msg mylog.txt
+   %(prog)s -f 3 mylog.txt"""
+    parser = argparse.ArgumentParser(
+        description="Simple log file parser to filter the records and print only part of them.",
+        epilog=epilog_text,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # need to use the default group, otherwise --help is in a separate group by itself
+    parser.add_argument(
+        "-f",
+        "--fields",
+        metavar="<fields>",
+        default="",
+        help="comma separated list of field numbers to select in the structured log message. Start from 0",
+    )
+    parser.add_argument(
+        "-k",
+        "--keys",
+        metavar="<keys>",
+        default="",
+        help="comma separated list of keys to select in the structured log message",
+    )
+    parser.add_argument(
+        "-i",
+        "--input_separator",
+        metavar="<input separator>",
+        default=" - ",
+        help="input separator (string). Defaults to ' - '.",
+    )
+    parser.add_argument(
+        "-s",
+        "--separator",
+        metavar="<separator>",
+        default=",",
+        help="output separator (string). Defaults to comma, ','",
+    )
+    parser.add_argument(
+        "-c",
+        "--constraint",
+        metavar="<constraint>",
+        action="append",
+        help="line selection constraint. Repeat the option for multiple constraints. Format: '(field # | key) value'."
+        " Integers are always considered field numbers.",
+    )
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        metavar="<loglevel>",
+        action="store",
+        help="add constraint for log level. Same as '-c 3 <loglevel>'",
+    )
+    parser.add_argument(
+        "-e",
+        "--logdirectory",
+        metavar="<logdirectory>",
+        action="store",
+        default="/var/log/gwms",
+        help="log files directory. Default is '/var/log/gwms'",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Include exception messages")
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug, e.g. to use for unit test")
+    positional = parser.add_argument_group("positional arguments")
+    positional.add_argument(
+        "logfile",
+        metavar="<logfile>",
+        nargs="?",
+        help="log file to parse. File names without directory are searched also in the default log files directory."
+        " Using stdin if '-' or if none is provided",
+    )
+    return parser
+
+
+def parse_constraints(constraints, loglevel=None):
+    """Parse and combine the constraints
+
+    Args:
+        constraints (list|None): List of constraints
+        loglevel (str): Logging level, e.g. DEBUG, INFO, ...
+
+    Returns:
+        dict: combined constraint dictionary
+
+    """
+    if not constraints and not loglevel:
+        return None
+    constraint = {"fields": [], "keys": []}
+    if loglevel:
+        # The log level is the 4th field in each log line
+        constraint["fields"].append((3, loglevel))
+    if constraints:
+        for c in constraints:
+            i, v = c.split(maxsplit=1)
+            try:
+                constraint["fields"].append((int(i), v))
+            except ValueError:
+                # TODO: add also time constraints: before, after, ...
+                constraint["keys"].append((i, v))
+    return constraint
+
+
+def matches_constraint(constraint, linelist, linedict):
+    """Return True if all constraints are marched
+
+    Args:
+        constraint (dict|None): combined constraints
+        linelist (list): List of line fields
+        linedict (dict): Dictionary with structured elements
+
+    Returns:
+        bool: True is all constraints are matched, False otherwise
+
+    """
+    if constraint is None:
+        return True
+    # if constraint is not None, it will always have "fields" and "keys"
+    if constraint["fields"]:
+        try:
+            if not all(linelist[i] == v for i, v in constraint["fields"]):
+                return False
+        except IndexError:
+            # In case records have variable number of fields (change in the log format)
+            return False
+    if constraint["keys"]:
+        try:
+            if not all(linedict[k] == v for k, v in constraint["keys"]):
+                return False
+        except KeyError:
+            # Some records may have keys not present in others. Only positive matches are True
+            return False
+    return True
+
+
+def execute_command_from_args(argsparsed, logfile=None, constraint=None):
+    """Parse the log file as requested.
+
+    Args:
+        argsparsed (Namespace): Parsed arguments from arg_parser in this file.
+        logfile (path): Log file path.
+        constraint (dict): Combined constraints dictionary
+
+    Returns:
+        str: Output of the command.
+    """
+
+    outlines = []
+    fields = []
+    keys = []
+    if argsparsed.fields:
+        fields = [int(i) for i in argsparsed.fields.split(",")]
+    if argsparsed.keys:
+        keys = argsparsed.keys.split(",")
+    if not fields and not keys:
+        raise ValueError("No field or key specified")
+    possible_dict_split = False
+    if argsparsed.input_separator == ": " or argsparsed.input_separator == ", ":
+        possible_dict_split = True
+    # If you would call fileinput.input() without files it would try to process all arguments.
+    # We pass '-' as only file when argparse got no files which will cause fileinput to read from stdin
+    with fileinput.input(files=(logfile,) if logfile else ("-",)) as f:
+        for full_line in f:
+            line = full_line.strip()
+            if not line:
+                # Skip empty lines
+                continue
+            linelist = line.split(argsparsed.input_separator)
+            if possible_dict_split and linelist[-1][-1] == "}":  # The line is stripped, no rstrip needed in last
+                i = 0
+                while i < len(linelist):
+                    if linelist[i].lstrip()[0] == "{":
+                        break
+                    i += 1
+                if i < len(linelist):
+                    # found split dictionary, trying to remediate
+                    linelist[i] = argsparsed.input_separator.join(linelist[i:])
+                    linelist = linelist[: i + 1]
+            if linelist[-1][0] == "{":
+                linedict = json.loads(linelist[-1])
+            else:
+                linedict = {}
+            if not matches_constraint(constraint, linelist, linedict):
+                continue
+            outline = ""
+            # Guaranteed to have at least one field or key
+            # IndexError and KeyError needed to cover irregular lines
+            for i in fields:
+                try:
+                    outline += f"{argsparsed.separator}{linelist[i]}"
+                except IndexError:
+                    outline += f"{argsparsed.separator}NOT_AVAILABLE"
+            for k in keys:
+                try:
+                    outline += f"{argsparsed.separator}{linedict[k]}"
+                except KeyError:
+                    outline += f"{argsparsed.separator}NOT_AVAILABLE"
+            print(outline[len(argsparsed.separator) :])
+            if argsparsed.debug:
+                outlines.append(outline[len(argsparsed.separator) :])
+    return "\n".join(outlines)
+
+
+def main(args_to_parse=None):
+    """Main function for logparser
+
+    Args:
+        args_to_parse (list, optional): If you pass a list of args, they will be used instead of sys.argv.
+        Defaults to None.
+
+    Returns:
+        str: Parsing result
+    """
+    parser = arg_parser()
+    args = parser.parse_args(args_to_parse)
+    if args.verbose:
+        if args.input_separator == ": " or args.input_separator == ", ":
+            print(f"Input separator '{args.input_separator}' could split the JSON dictionary failing the parsing.")
+    logfile = args.logfile
+    if (
+        logfile
+        and logfile != "-"
+        and not os.path.exists(logfile)
+        and logfile == os.path.basename(logfile)
+        and os.path.exists(os.path.join(args.logdirectory, logfile))
+    ):
+        logfile = os.path.join(args.logdirectory, logfile)
+        if args.verbose:
+            print(f"Found log file in the default log directory: '{logfile}'")
+    constraint = parse_constraints(args.constraint, args.loglevel)
+    try:
+        return execute_command_from_args(args, logfile, constraint)
+    except KeyboardInterrupt:  # pragma: no cover
+        # When working in a pipe from stdin must be interrupted w/ a signal
+        return ""
+    except ValueError as e:
+        msg = (
+            f"An error occurred while trying to parse '{logfile}'\n"
+            + "Please ensure that you requested some fields or keys."
+        )
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+    except FileNotFoundError as e:
+        msg = (
+            f"An error occurred while trying to parse '{logfile}'\n"
+            + "Please ensure that the log file name is correct."
+        )
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+    except Exception as e:  # pragma: no cover
+        msg = f"An error occurred while trying to parse '{logfile}'."
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+
+
+def console_scripts_main(args_to_parse=None):
+    """
+    This is the entry point for the setuptools auto generated scripts.
+    Setuptools thinks a return from this function is an error message.
+    """
+    msg = main(args_to_parse)
+    if "An error occurred while trying to parse" in msg:
+        return msg
+    # Regular output already printed line by line.
+    # Returned here only for test purposes when bebug is enabled
+
+
+if __name__ == "__main__":
+    mmsg = console_scripts_main()
+    # Checking the return value to emulate the behavior of the setuptools invoker
+    if mmsg:
+        if mmsg[0] == " ":
+            print(mmsg[1:])
+        exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ changedir = doc/api
 # A better practice is to specify a specific version of sphinx.
 deps =
     sphinx
+    structlog
     m2crypto
 # Everything must be in the dependency or whitelist (* is allowed here)
 whitelist_externals =

--- a/unittests/test_lib_logSupport.py
+++ b/unittests/test_lib_logSupport.py
@@ -4,12 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Project:
-    glideinwms
 Purpose:
     test glideinwms/lib/logSupport.py
-Author:
-    Anthony Tiradani, tiradani@fnal.gov
 """
 
 
@@ -63,9 +59,9 @@ class TestLogSupport(unittest.TestCase):
         log_name = str(self.config[section]["log_name"])
         extension = str(self.config[section]["extension"])
         msg_types = str(self.config[section]["msg_types"])
-        max_days = float(self.config[section]["max_days"])
-        min_days = float(self.config[section]["min_days"])
-        max_mbytes = float(self.config[section]["max_mbytes"])
+        max_days = int(float(self.config[section]["max_days"]))
+        min_days = int(float(self.config[section]["min_days"]))
+        max_mbytes = int(float(self.config[section]["max_mbytes"]))
 
         backupCount = 5
         try:
@@ -82,7 +78,7 @@ class TestLogSupport(unittest.TestCase):
         log_dir = f"{self.log_base_dir}/{log_name}"
         os.makedirs(log_dir)
 
-        logSupport.add_processlog_handler(
+        handler = logSupport.get_processlog_handler(
             log_name,
             log_dir,
             msg_types,
@@ -93,8 +89,9 @@ class TestLogSupport(unittest.TestCase):
             backupCount=backupCount,
             compression=compression,
         )
-
-        return logSupport.getLogger(log_name), log_dir
+        log = logSupport.get_logging_logger(log_name)
+        log.addHandler(handler)
+        return log, log_dir
 
     def rotated_log_tests(self, section, log_dir):
         log_file_name = "{}.{}.log".format(

--- a/unittests/test_logSupport.py
+++ b/unittests/test_logSupport.py
@@ -94,7 +94,7 @@ class TestLogSupport(unittest.TestCase):
             compression=compression,
         )
 
-        return logging.getLogger(log_name), log_dir
+        return logSupport.getLogger(log_name), log_dir
 
     def rotated_log_tests(self, section, log_dir):
         log_file_name = "{}.{}.log".format(

--- a/unittests/worker_scripts/log_writer.py
+++ b/unittests/worker_scripts/log_writer.py
@@ -51,7 +51,7 @@ def main():
             compression=compression,
         )
 
-        log = logging.getLogger(log_name)
+        log = logSupport.getLogger(log_name)
         log.info("%s\n" % create_random_string(length=2048))
 
         return 0

--- a/unittests/worker_scripts/log_writer.py
+++ b/unittests/worker_scripts/log_writer.py
@@ -31,15 +31,16 @@ def main():
         log_name = str(config[section]["log_name"])
         extension = str(config[section]["extension"])
         msg_types = str(config[section]["msg_types"])
-        max_days = float(config[section]["max_days"])
-        min_days = float(config[section]["min_days"])
-        max_mbytes = float(config[section]["max_mbytes"])
+        max_days = int(float(config[section]["max_days"]))
+        min_days = int(float(config[section]["min_days"]))
+        max_mbytes = int(float(config[section]["max_mbytes"]))
         backupCount = 5
         compression = ""
+        structured = False
 
         log_dir = "/tmp/%s" % log_name
 
-        logSupport.add_processlog_handler(
+        handler = logSupport.get_processlog_handler(
             log_name,
             log_dir,
             msg_types,
@@ -50,8 +51,12 @@ def main():
             backupCount=backupCount,
             compression=compression,
         )
+        if structured:
+            log = logSupport.get_structlog_logger(log_name)
+        else:
+            log = logSupport.get_logging_logger(log_name)
+        log.addHandler(handler)
 
-        log = logSupport.getLogger(log_name)
         log.info("%s\n" % create_random_string(length=2048))
 
         return 0


### PR DESCRIPTION
Added changes to support structured logs:
- using structlog https://www.structlog.org/en/stable/
- added supporting functions and structlog configuration in `logSupport`
- consolidated log and handlers configuration and set up
- updated all files using the framework loggers
- added configuration knobs
- added documentation

Structured logs are disabled by default to ease the transition. They can be enabled by adding `structured="True"` to the configuration of the logs (`process_log` sections in the Factory and Frontend configurations)

Added also some general improvements: cleanup of comments and docstrings, consolidation of `util.is_true()`, and fixed a couple of small bugs.

The first commits are by @MissAnita2
This PR replaces Anita's PR #325 because I reverted once the automatic unrelated changes to all HTML files and was unable to force-update when they were re-applied