### PR TITLE
Web pages security and code fixes plus pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_language_version:
   node: 17.9.0
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: black
   - repo: "https://github.com/pre-commit/mirrors-prettier"
-    rev: v2.6.2
+    rev: v3.0.1
     hooks:
       - id: prettier
         exclude_types:
@@ -54,7 +54,7 @@ repos:
         args:
           - "--py36-plus"
   - repo: "https://github.com/fsfe/reuse-tool"
-    rev: v0.14.0
+    rev: v2.1.0
     hooks:
       - id: reuse
         additional_dependencies:

--- a/creation/web_base/factoryCompletedStats.html
+++ b/creation/web_base/factoryCompletedStats.html
@@ -179,7 +179,7 @@ Description:
         "aggwsum",
         "aggavgf",
         "affwsumf",
-        "fail"
+        "fail",
       );
       var ENTRY;
 
@@ -224,7 +224,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -254,7 +254,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -831,7 +831,7 @@ Description:
           for (var i = 0; i < gtype_filtered_list.length; i++) {
             rrd_filtered_data = new RRDFilterDS(
               rrd_data1,
-              gtype_DSs[gtype_filtered_list[i]]
+              gtype_DSs[gtype_filtered_list[i]],
             );
             var DS_list = [];
             for (var j = 0; j < rrd_filtered_data.getNrDSs(); j++) {
@@ -849,7 +849,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null
+            null,
           );
         } else if (gtype_id == "fail") {
           var DS_list = [];
@@ -872,8 +872,8 @@ Description:
           op_list.push(
             new FractionDS(
               rrd_data1.getDS(failed_idx).getName(),
-              rrd_data1.getDS(glidein_idx).getName()
-            )
+              rrd_data1.getDS(glidein_idx).getName(),
+            ),
           );
           rrd_data1 = new RRDFilterOp(rrd_data1, op_list);
           var f = new rrdFlot(
@@ -881,7 +881,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            null
+            null,
           );
         }
         //Non-Aggregated InfoGroups
@@ -903,12 +903,12 @@ Description:
               continue;
             }
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i)
+              new RelativeDS(DS_list, rrd_data1.getDS(i).getName(), i),
             );
           }
           if (flag == 1) {
             op_list.push(
-              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0)
+              new RelativeDS(DS_list, rrd_data1.getDS(0).getName(), 0),
             );
           }
 
@@ -950,7 +950,7 @@ Description:
             rrd_data1,
             null,
             gtype_formats[gtype_id],
-            { num_cb_rows: x }
+            { num_cb_rows: x },
           );
         }
 

--- a/creation/web_base/factoryEntryStatusNow.html
+++ b/creation/web_base/factoryEntryStatusNow.html
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientJobsIdle",
         "ClientGlideTotal",
         "ClientCoresTotal",
-        "ClientInfoAge"
+        "ClientInfoAge",
       );
 
       var xmlAttStatusArry = new Array(
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageIn",
         "StageOut",
         "IdleOther",
-        "Held"
+        "Held",
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       var xmlAttCMArry = new Array(
@@ -96,7 +96,7 @@ SPDX-License-Identifier: Apache-2.0
         "JobsIdle",
         "GlideTotal",
         "CoresTotal",
-        "InfoAge"
+        "InfoAge",
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -123,7 +123,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmGlideinIdle",
         "cmGlideinJobsIdle",
         "cmGlideinTotal",
-        "cmGlideinInfoAge"
+        "cmGlideinInfoAge",
       );
 
       var exactCols = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Registered",
         "Info age",
         "Diff(Status: Running - CM: Registered)",
-        "Diff(Status: Idle - Requested: Idle)"
+        "Diff(Status: Idle - Requested: Idle)",
       );
       var prTxtArry = new Array("Now", "2 hours", "24 hours", "7 days");
 
@@ -171,7 +171,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Stage out",
         "Status: Unknown",
         "Status: Held",
-        "Client Monitor: Info age"
+        "Client Monitor: Info age",
       );
       var indivTableAttColors = new Array(
         0,
@@ -192,7 +192,7 @@ SPDX-License-Identifier: Apache-2.0
         0,
         0,
         0,
-        2
+        2,
       );
 
       var indivAtts = new Array(
@@ -214,7 +214,7 @@ SPDX-License-Identifier: Apache-2.0
         5,
         6,
         7,
-        16
+        16,
       );
 
       var indivChild;
@@ -315,10 +315,10 @@ SPDX-License-Identifier: Apache-2.0
                 .attributes[0].value
             ) {
               feArryMaster.push(
-                totalEntries[optionIndex].childNodes[feChild].childNodes[x]
+                totalEntries[optionIndex].childNodes[feChild].childNodes[x],
               );
               feArryPMaster.push(
-                totalEntriesP[optionIndex].childNodes[3].childNodes[x]
+                totalEntriesP[optionIndex].childNodes[3].childNodes[x],
               );
             }
           }
@@ -342,7 +342,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -446,8 +446,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .name
-                )
+                    .name,
+                ),
               );
               cellsD[count].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsD[count]);
@@ -456,8 +456,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsD[count].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[1].attributes[i - 1]
-                    .value
-                )
+                    .value,
+                ),
               );
               rowsD[i].appendChild(cellsD[count]);
               count++;
@@ -483,8 +483,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .name
-                )
+                    .name,
+                ),
               );
               cellsT[count2].style.fontWeight = "bold";
               rowsD[i].appendChild(cellsT[count2]);
@@ -493,8 +493,8 @@ SPDX-License-Identifier: Apache-2.0
               cellsT[count2].appendChild(
                 document.createTextNode(
                   entryAttDescript[optionIndex].childNodes[3].attributes[i - 1]
-                    .value
-                )
+                    .value,
+                ),
               );
               rowsD[i].appendChild(cellsT[count2]);
               count2++;
@@ -528,7 +528,7 @@ SPDX-License-Identifier: Apache-2.0
           if (xmlhttp.readyState == 4) {
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated"
+                "updated",
               );
             totalEntriesMaster =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -760,7 +760,7 @@ SPDX-License-Identifier: Apache-2.0
                   totStatChild,
                   totStatChild,
                   totStatChild,
-                  totCMChild
+                  totCMChild,
                 );
 
                 indivChildFE = new Array(
@@ -782,7 +782,7 @@ SPDX-License-Identifier: Apache-2.0
                   feStatChild,
                   feStatChild,
                   feStatChild,
-                  feCMChild
+                  feCMChild,
                 );
                 break;
               }
@@ -815,7 +815,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "makeTotTable(document.getElementById('choose').value)"
+          "makeTotTable(document.getElementById('choose').value)",
         );
         head = document.createElement("option");
         txt0 = document.createTextNode("No Entry Selected");
@@ -885,7 +885,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild
+                  document.getElementsByTagName("div")[index].firstChild,
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -895,7 +895,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild
+                  document.getElementsByTagName("div")[index + 1].firstChild,
                 );
             }
             index++;
@@ -928,7 +928,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index].removeChild(
-                  document.getElementsByTagName("div")[index].firstChild
+                  document.getElementsByTagName("div")[index].firstChild,
                 );
             }
             /* REMOVE ALL CHILDNODES (PARAM TABLE) */
@@ -938,7 +938,7 @@ SPDX-License-Identifier: Apache-2.0
               document
                 .getElementsByTagName("div")
                 [index + 1].removeChild(
-                  document.getElementsByTagName("div")[index + 1].firstChild
+                  document.getElementsByTagName("div")[index + 1].firstChild,
                 );
             }
             index++;
@@ -982,7 +982,7 @@ SPDX-License-Identifier: Apache-2.0
           cell_num - 1,
           cell_num - 1,
           cell_num,
-          cell_num - 1
+          cell_num - 1,
         );
 
         table = document.createElement("table");
@@ -1081,7 +1081,7 @@ SPDX-License-Identifier: Apache-2.0
               k != 2 - (cell_num - cell_numArry[c])
             ) {
               cont = document.createTextNode(
-                feArryMaster[k - 3].attributes[0].value
+                feArryMaster[k - 3].attributes[0].value,
               );
             } else if (c == 0 && k == 2 - (cell_num - cell_numArry[c])) {
               cont = document.createTextNode("Total");
@@ -1145,7 +1145,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days"
+            "7 Days",
           );
           rowLength = rowsTwoTxt.length;
         } else {
@@ -1198,7 +1198,7 @@ SPDX-License-Identifier: Apache-2.0
           if (j % (rowLength / 2) == 0) {
             cols[j].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1234,7 +1234,7 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k) % (rowLength / 2) == 0) {
             cols[j + k].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k] = document.createTextNode(indivTableAtts[attribute]);
             attribute++;
@@ -1268,10 +1268,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l) % (rowLength / 2) == 0) {
             cols[j + k + l].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1304,10 +1304,10 @@ SPDX-License-Identifier: Apache-2.0
           if ((j + k + l + m) % (rowLength / 2) == 0) {
             cols[j + k + l + m].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l + m] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1341,10 +1341,10 @@ SPDX-License-Identifier: Apache-2.0
           ) {
             cols[j + k + l + m + n].setAttribute(
               "bgColor",
-              colorArry[indivTableAttColors[attribute]]
+              colorArry[indivTableAttColors[attribute]],
             );
             colsTxt[j + k + l + m + n] = document.createTextNode(
-              indivTableAtts[attribute]
+              indivTableAtts[attribute],
             );
             attribute++;
           } else {
@@ -1724,7 +1724,7 @@ SPDX-License-Identifier: Apache-2.0
             "Now",
             "2 Hours",
             "24 Hours",
-            "7 Days"
+            "7 Days",
           );
         else feRowTwoTxt = new Array("", "Now", "", "Now");
         index = 0;
@@ -1803,7 +1803,7 @@ SPDX-License-Identifier: Apache-2.0
             if (j % (feRowTwoTxt.length / 2) == 0) {
               feCell[j].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j] = document.createTextNode(indivTableAtts[attribute]);
               attribute++;
@@ -1841,10 +1841,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1882,10 +1882,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1921,10 +1921,10 @@ SPDX-License-Identifier: Apache-2.0
             if ((j + k + l + m) % (feRowTwoTxt.length / 2) == 0) {
               feCell[j + k + l + m].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l + m] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -1963,10 +1963,10 @@ SPDX-License-Identifier: Apache-2.0
             ) {
               feCell[j + k + l + m + n].setAttribute(
                 "bgColor",
-                colorArry[indivTableAttColors[attribute]]
+                colorArry[indivTableAttColors[attribute]],
               );
               feCellTxt[j + k + l + m + n] = document.createTextNode(
-                indivTableAtts[attribute]
+                indivTableAtts[attribute],
               );
               attribute++;
             } else {
@@ -2002,7 +2002,7 @@ SPDX-License-Identifier: Apache-2.0
 
           paramRow[0] =
             document.createElement(
-              "tr"
+              "tr",
             ); /* Will hold parameter table header. */
           paramCell = document.createElement("td");
 
@@ -2011,7 +2011,7 @@ SPDX-License-Identifier: Apache-2.0
               .length <= 1
           ) {
             paramTxtHead = document.createTextNode(
-              "(" + feArryMaster[i].attributes[0].value + ") No Parameters "
+              "(" + feArryMaster[i].attributes[0].value + ") No Parameters ",
             );
           } else paramTxtHead = document.createTextNode("Parameters: ");
           paramCell.appendChild(paramTxtHead);
@@ -2034,11 +2034,11 @@ SPDX-License-Identifier: Apache-2.0
             paramCell[j] = document.createElement("td");
             paramCellTxt[j - 1] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[0].value
+                .attributes[0].value,
             );
             paramCellTxt[j] = document.createTextNode(
               feArryMaster[i].childNodes[feReqChild].childNodes[1].childNodes[j]
-                .attributes[1].value
+                .attributes[1].value,
             );
             paramCell[j - 1].appendChild(paramCellTxt[j - 1]);
             paramCell[j].appendChild(paramCellTxt[j]);
@@ -2490,7 +2490,7 @@ SPDX-License-Identifier: Apache-2.0
         font-size: 40px;
         color: #000;
         font-weight: bold;
-        font-family: 'Times New Roman', Times;
+        font-family: &quot;Times New Roman&quot;, Times;
         text-decoration: none;
         left: 50%;
       "

--- a/creation/web_base/factoryLogStatus.html
+++ b/creation/web_base/factoryLogStatus.html
@@ -185,7 +185,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -240,7 +240,7 @@ Description:
           "EnteredRunning",
           "ExitedRunning",
           "EnteredCompleted",
-          "EnteredHeld"
+          "EnteredHeld",
         );
         gtype_DSs["idle"] = new Array(
           "StatusIdle",
@@ -250,7 +250,7 @@ Description:
           "EnteredWait",
           "ExitedWait",
           "EnteredRunning",
-          "EnteredHeld"
+          "EnteredHeld",
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
@@ -258,7 +258,7 @@ Description:
           "ExitedHeld",
           "EnteredRemoved",
           "EnteredIdle",
-          "EnteredRunning"
+          "EnteredRunning",
         );
         gtype_DSs["completed"] = new Array(
           "Lasted",
@@ -268,7 +268,7 @@ Description:
           "JobsGoodput",
           "Glideins",
           "FailedNr",
-          "JobsNr"
+          "JobsNr",
         );
 
         var gtype_formats = new Object();
@@ -471,7 +471,7 @@ Description:
           "mygraph",
           rrd_data1,
           null,
-          gtype_formats[gtype_id]
+          gtype_formats[gtype_id],
         );
 
         // Finally, update the files loaded so far

--- a/creation/web_base/factoryRRDBrowse.html
+++ b/creation/web_base/factoryRRDBrowse.html
@@ -151,7 +151,7 @@ Description:
         "Log_Counts",
         "Log_Completed",
         "Log_Completed_Stats",
-        "Log_Completed_WasteTime"
+        "Log_Completed_WasteTime",
       );
       var ENTRY;
 
@@ -196,7 +196,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -226,7 +226,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }

--- a/creation/web_base/factoryRRDEntryMatrix.html
+++ b/creation/web_base/factoryRRDEntryMatrix.html
@@ -224,7 +224,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", true)'
+              '", true)',
           );
 
           var but_el2 = document.createElement("input");
@@ -235,7 +235,7 @@ Description:
             "onclick",
             'setGroupEntriesValue("' +
               entrylist2groupname(entries[entry]) +
-              '", false)'
+              '", false)',
           );
 
           var form_el = document.getElementById("selector");
@@ -390,7 +390,7 @@ Description:
           var fn_array = new Array();
           for (var j = 0; j < ent_list.length; j++) {
             fn_array.push(
-              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd"
+              "entry_" + ent_list[j] + "/total/" + rrd_name + ".rrd",
             );
           }
           fnames.push(fn_array.join(","));
@@ -413,7 +413,7 @@ Description:
                 FetchBinaryURLAsync(
                   fn_array[j],
                   update_grouped_fname_handler,
-                  i
+                  i,
                 );
                 rrds_to_load++;
               }

--- a/creation/web_base/factoryStatus.html
+++ b/creation/web_base/factoryStatus.html
@@ -201,7 +201,7 @@ Description:
       for (var entry in entries) {
         if (ec_added < groups_starting_idx) {
           entries_select.appendChild(
-            new Option(entries[entry], entries[entry])
+            new Option(entries[entry], entries[entry]),
           );
           ec_added++;
         } else {
@@ -227,7 +227,7 @@ Description:
         fes.appendChild(new Option("total", "total"));
         for (var frontend in frontend_list[entry]) {
           frontends_select.appendChild(
-            new Option(frontend_list[entry][frontend])
+            new Option(frontend_list[entry][frontend]),
           );
         }
       }
@@ -261,7 +261,7 @@ Description:
           "ClientJobsIdle",
           "ReqIdle",
           "StatusIdle",
-          "ClientInfoAge"
+          "ClientInfoAge",
         );
         gtype_DSs["idle"] = new Array(
           "ReqIdle",
@@ -269,14 +269,14 @@ Description:
           "StatusWait",
           "StatusPending",
           "ClientJobsIdle",
-          "ClientInfoAge"
+          "ClientInfoAge",
         );
         gtype_DSs["other"] = new Array(
           "StatusHeld",
           "StatusStageIn",
           "StatusStageOut",
           "StatusIdleOther",
-          "StatusIdle"
+          "StatusIdle",
         );
 
         gtype_formats = new Object();
@@ -519,7 +519,7 @@ Description:
             use_element_buttons: false,
           },
           gtype_DSs[gtype_id],
-          rra_ops
+          rra_ops,
         );
 
         // Finally, update the files loaded so far
@@ -636,7 +636,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone"
+          "timezone",
         );
         group = 0;
         var entrySpec;

--- a/creation/web_base/factoryStatusNow.html
+++ b/creation/web_base/factoryStatusNow.html
@@ -110,7 +110,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age"
+        "Info age",
       );
 
       var headColArryPR = new Array(
@@ -133,7 +133,7 @@ SPDX-License-Identifier: Apache-2.0
         "Unmatched cores",
         "User idle",
         "Registered cores",
-        "Info age"
+        "Info age",
       );
 
       var headColArryTR = new Array(
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle"
+        "Client: User Idle",
       );
 
       var headColArryTRPR = new Array(
@@ -157,7 +157,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client: User Idle"
+        "Client: User Idle",
       );
 
       var columnArray = new Array(
@@ -181,7 +181,7 @@ SPDX-License-Identifier: Apache-2.0
         "cmCoresIdle",
         "cmGlideinJobsIdle",
         "cmCoresTotal",
-        "cmGlideinInfoAge"
+        "cmGlideinInfoAge",
       );
       /* columnArrayStruct describes columnArray: total length (length) and length and offset of its component: DT, Status, Req, CM
    it is used to display the table w/ the values
@@ -217,7 +217,7 @@ SPDX-License-Identifier: Apache-2.0
         "Client Monitor: Unmatched cores",
         "Client Monitor: User idle",
         "Client Monitor: Registered cores",
-        "Client Monitor: Info age"
+        "Client Monitor: Info age",
       );
 
       var exactColumnsTR = new Array(
@@ -229,7 +229,7 @@ SPDX-License-Identifier: Apache-2.0
         "Status: Idle",
         "Requested: Idle",
         "Diff(Status: Idle, Requested: Idle)",
-        "Client Monitor: User Idle"
+        "Client Monitor: User Idle",
       );
 
       var xmlAttPeriodArry = new Array(
@@ -252,7 +252,7 @@ SPDX-License-Identifier: Apache-2.0
         "ClientCoresIdle",
         "ClientJobsIdle",
         "ClientCoresTotal",
-        "ClientInfoAge"
+        "ClientInfoAge",
       ); /* ONE LESS ATT THAN DEFAULT, no Downtime */
 
       var xmlAttDTArry = new Array("Status");
@@ -265,7 +265,7 @@ SPDX-License-Identifier: Apache-2.0
         "StageOut",
         "IdleOther",
         "Held",
-        "RunningCores"
+        "RunningCores",
       );
       var xmlAttReqArry = new Array("MaxGlideins", "Idle");
       // var xmlAttCMArry = new Array("GlideRunning", "CoresRunning", "JobsRunHere", "JobsRunning", "GlideIdle", "CoresIdle", "JobsIdle", "GlideTotal", "CoresTotal", "InfoAge");
@@ -276,7 +276,7 @@ SPDX-License-Identifier: Apache-2.0
         "CoresIdle",
         "JobsIdle",
         "CoresTotal",
-        "InfoAge"
+        "InfoAge",
       );
       var xmlAttStatNumArry = new Array();
       var xmlAttReqNumArry = new Array();
@@ -394,7 +394,7 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            totalEntries[row - 1].getAttribute("name")
+            totalEntries[row - 1].getAttribute("name"),
           );
           if (troubleshoot)
             attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -443,7 +443,7 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         nameTxtNode = document.createTextNode(
-          totalEntries[row - 1].getAttribute("name")
+          totalEntries[row - 1].getAttribute("name"),
         );
         if (troubleshoot)
           attTxtNode = document.createTextNode(exactColumnsTR[column]);
@@ -520,7 +520,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":"
+              sortedFE[i].attributes[0].value + ":",
             );
             td2 = document.createElement("td");
 
@@ -546,12 +546,12 @@ SPDX-License-Identifier: Apache-2.0
               diff = 0;
               try {
                 val1 = parseInt(
-                  sortedFE[i].childNodes[child1].attributes[att1].value
+                  sortedFE[i].childNodes[child1].attributes[att1].value,
                 );
               } catch (err) {}
               try {
                 val2 = parseInt(
-                  sortedFE[i].childNodes[child2].attributes[att2].value
+                  sortedFE[i].childNodes[child2].attributes[att2].value,
                 );
               } catch (err) {}
               diff = val1 - val2;
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feStatChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -576,7 +576,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feReqChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -587,7 +587,7 @@ SPDX-License-Identifier: Apache-2.0
                 txt2 = document.createTextNode(
                   sortedFE[i].childNodes[feCMChild].attributes[
                     xmlAttTotalNumArry[column - 1]
-                  ].value
+                  ].value,
                 );
               } catch (err) {
                 txt2 = document.createTextNode(0);
@@ -754,21 +754,21 @@ SPDX-License-Identifier: Apache-2.0
         if (entry.childNodes[totChild].childNodes.length == 0) {
           /* POP UP TEXT CONTENTS */
           nameTxtNode = document.createTextNode(
-            tempTotalEntries[row].getAttribute("name")
+            tempTotalEntries[row].getAttribute("name"),
           );
 
           if (!diffCol)
             attTxtNode = document.createTextNode(
-              exactColumns[column + 1] + timeFrame
+              exactColumns[column + 1] + timeFrame,
             );
           else if (diffCol == 1)
             attTxtNode = document.createTextNode(
               "Diff(Status: Running cores, Client: Registered cores) " +
-                timeFrame
+                timeFrame,
             );
           else
             attTxtNode = document.createTextNode(
-              "Diff(Status: Idle, Requested: Idle) " + timeFrame
+              "Diff(Status: Idle, Requested: Idle) " + timeFrame,
             );
 
           NFE = document.createTextNode("No Frontends Exist");
@@ -815,18 +815,19 @@ SPDX-License-Identifier: Apache-2.0
         td3 = document.createElement("td");
         td4 = document.createElement("td");
         cont = document.createTextNode(
-          tempTotalEntries[row].getAttribute("name")
+          tempTotalEntries[row].getAttribute("name"),
         );
 
         if (!diffCol)
           cont2 = document.createTextNode(exactColumns[column + 1] + timeFrame);
         else if (diffCol == 1)
           cont2 = document.createTextNode(
-            "Diff(Status: Running cores, Client: Registered cores) " + timeFrame
+            "Diff(Status: Running cores, Client: Registered cores) " +
+              timeFrame,
           );
         else
           cont2 = document.createTextNode(
-            "Diff(Status: Idle, Requested: Idle) " + timeFrame
+            "Diff(Status: Idle, Requested: Idle) " + timeFrame,
           );
 
         td1.appendChild(cont);
@@ -894,7 +895,7 @@ SPDX-License-Identifier: Apache-2.0
             tr = document.createElement("tr");
             td = document.createElement("td");
             txt = document.createTextNode(
-              sortedFE[i].attributes[0].value + ":"
+              sortedFE[i].attributes[0].value + ":",
             );
             td2 = document.createElement("td");
 
@@ -936,7 +937,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[1]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value
+                      ].value,
                   );
                 } else {
                   /* 2ND DIFF COL */
@@ -946,7 +947,7 @@ SPDX-License-Identifier: Apache-2.0
                     ].value -
                       sortedFE[i].childNodes[trFEChildArry[4]].attributes[
                         xmlAttTotalNumArry[dCol2]
-                      ].value
+                      ].value,
                   );
                 }
               } else {
@@ -960,8 +961,8 @@ SPDX-License-Identifier: Apache-2.0
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[dCol2 - 1]
                       ].value) *
-                      100
-                  ) / 100
+                      100,
+                  ) / 100,
                 );
               }
             } else if (column < columnArrayDesc.Req.offset - 1) {
@@ -971,7 +972,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feStatChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -979,8 +980,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -994,7 +995,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feReqChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1002,8 +1003,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1014,7 +1015,7 @@ SPDX-License-Identifier: Apache-2.0
                   txt2 = document.createTextNode(
                     sortedFE[i].childNodes[feCMChild].attributes[
                       xmlAttTotalNumArry[column]
-                    ].value
+                    ].value,
                   );
                 } else {
                   txt2 = document.createTextNode(
@@ -1022,8 +1023,8 @@ SPDX-License-Identifier: Apache-2.0
                       tempTotalEntriesP[row].childNodes[3].childNodes[prFEChild]
                         .childNodes[1].childNodes[pr].attributes[
                         xmlAttPeriodNumArry[column - 1]
-                      ].value * 100
-                    ) / 100
+                      ].value * 100,
+                    ) / 100,
                   );
                 }
               } else txt2 = document.createTextNode(0);
@@ -1229,7 +1230,7 @@ SPDX-License-Identifier: Apache-2.0
         select.setAttribute("id", "choose");
         select.setAttribute(
           "onchange",
-          "loadFrontEnd(document.getElementById('choose').value)"
+          "loadFrontEnd(document.getElementById('choose').value)",
         );
         def = document.createElement("option");
         defTxt = document.createTextNode("Total (Default)");
@@ -1655,7 +1656,7 @@ SPDX-License-Identifier: Apache-2.0
                     childView = j;
                     feEntries.push(totalEntries[i]);
                     feTotal.push(
-                      totalEntries[i].childNodes[feChild].childNodes[j]
+                      totalEntries[i].childNodes[feChild].childNodes[j],
                     );
                     feEntriesP.push(totalEntriesP[i]);
                     feTotalP.push(totalEntriesP[i].childNodes[3].childNodes[j]);
@@ -1894,12 +1895,12 @@ SPDX-License-Identifier: Apache-2.0
           links[i].setAttribute("onbrowseover", "hideEntryName()");
           links[i].setAttribute(
             "onmouseover",
-            "showPopUpSubEntries(this, '" + y + "')"
+            "showPopUpSubEntries(this, '" + y + "')",
           );
           links[i].setAttribute("onmouseout", "hidePopUpSubEntries()");
           links[i].setAttribute(
             "href",
-            "factoryEntryStatusNow.html?entry=" + y
+            "factoryEntryStatusNow.html?entry=" + y,
           );
           links[i].setAttribute("onclick", "entryClick(this)");
           table.rows[i].cells[0].appendChild(links[i]);
@@ -2084,7 +2085,7 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEndsP =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntriesP =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
@@ -2132,19 +2133,19 @@ SPDX-License-Identifier: Apache-2.0
         xmlhttp.onreadystatechange = function () {
           if (!active)
             document.getElementById(
-              "active"
+              "active",
             ).checked = false; /* Reset active check box. */
           if (!updating && !period && !prTr)
             document.getElementById(
-              "period"
+              "period",
             ).checked = false; /* Reset troubleshoot box. */
           if (!updating && !troubleshoot && !prTr)
             document.getElementById(
-              "troubleshoot"
+              "troubleshoot",
             ).checked = false; /* Reset troubleshoot box. */
           if (!periodV && !prTr)
             document.getElementById(
-              "period"
+              "period",
             ).checked = false; /* Reset active check box. */
 
           if (xmlhttp.readyState == 4) {
@@ -2157,7 +2158,7 @@ SPDX-License-Identifier: Apache-2.0
             /* GET ALL NECESSARY INFO FROM THE XML */
             updated =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "updated"
+                "updated",
               );
             showTime();
             totalEntriesMaster =
@@ -2166,13 +2167,13 @@ SPDX-License-Identifier: Apache-2.0
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
             frontEnds =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "frontend"
+                "frontend",
               );
             totalEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName("entry");
             statusEntries =
               xmlhttp.responseXML.documentElement.getElementsByTagName(
-                "StatusEntries"
+                "StatusEntries",
               );
             total =
               xmlhttp.responseXML.documentElement.getElementsByTagName("total");
@@ -2761,28 +2762,28 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length
+          columnArrayDesc.CM.length,
         );
         headTxt = new Array(
           "",
           "",
           "Status: ",
           "Requested: ",
-          "Client Monitor: "
+          "Client Monitor: ",
         );
         headId = new Array(
           "empty",
           "downtime",
           "status",
           "requested",
-          "client"
+          "client",
         );
         headClr = new Array(
           "#DCDCDC",
           "#DCDCDC",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95"
+          "#CDAF95",
         );
 
         /* HEADER */
@@ -3006,7 +3007,7 @@ SPDX-License-Identifier: Apache-2.0
           3,
           3,
           3,
-          3
+          3,
         ); /* 1 DT + 9 STAT + 4 REQ + 10 CM  = 24 */
         trSortColNumArry = new Array(
           0,
@@ -3026,7 +3027,7 @@ SPDX-License-Identifier: Apache-2.0
           0,
           0,
           8,
-          3
+          3,
         );
         feChildArry = new Array(feStatChild, feReqChild, feCMChild);
         totChildArry = new Array(totStatChild, totReqChild, totCMChild);
@@ -3878,7 +3879,7 @@ SPDX-License-Identifier: Apache-2.0
             "Status: Idle",
             "Requested: Idle",
             "Diff(Status: Idle, Requested: Idle)",
-            "Client: User Idle"
+            "Client: User Idle",
           );
           trColumnId = new Array(
             "entryLinks",
@@ -3889,7 +3890,7 @@ SPDX-License-Identifier: Apache-2.0
             "status",
             "requested",
             "difference",
-            "client"
+            "client",
           );
           colors = new Array(
             "#DCDCDC",
@@ -3900,7 +3901,7 @@ SPDX-License-Identifier: Apache-2.0
             "#FAF0E6",
             "#FFDAB9",
             "#7D9EC0",
-            "#CDAF95"
+            "#CDAF95",
           );
 
           /* SET CHILD ARRAY */
@@ -3910,7 +3911,7 @@ SPDX-License-Identifier: Apache-2.0
               feCMChild,
               feStatChild,
               feReqChild,
-              feCMChild
+              feCMChild,
             );
           else
             child = new Array(
@@ -3918,7 +3919,7 @@ SPDX-License-Identifier: Apache-2.0
               totCMChild,
               totStatChild,
               totReqChild,
-              totCMChild
+              totCMChild,
             );
 
           count = 0;
@@ -3982,7 +3983,7 @@ SPDX-License-Identifier: Apache-2.0
                   hrefs[i - 1].innerHTML = y;
                   hrefs[i - 1].setAttribute(
                     "href",
-                    "factoryEntryStatusNow.html?entry=" + y
+                    "factoryEntryStatusNow.html?entry=" + y,
                   );
                   hrefs[i - 1].setAttribute("onclick", "entryClick(this)");
                   cols[j].appendChild(hrefs[i - 1]);
@@ -4027,7 +4028,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 2]].attributes[
                             att[count - 2]
-                          ].value
+                          ].value,
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4037,7 +4038,7 @@ SPDX-License-Identifier: Apache-2.0
                           tempTotalEntries[i - 1].childNodes[totChild]
                             .childNodes[child[count - 1]].attributes[
                             att[count - 1]
-                          ].value
+                          ].value,
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4047,7 +4048,7 @@ SPDX-License-Identifier: Apache-2.0
                         val1 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 2]]
-                            .attributes[att[count - 2]].value
+                            .attributes[att[count - 2]].value,
                         );
                       } catch (err) {
                         val1 = 0;
@@ -4056,7 +4057,7 @@ SPDX-License-Identifier: Apache-2.0
                         val2 = parseInt(
                           tempTotalEntries[i - 1].childNodes[feChild]
                             .childNodes[childView].childNodes[child[count - 1]]
-                            .attributes[att[count - 1]].value
+                            .attributes[att[count - 1]].value,
                         );
                       } catch (err) {
                         val2 = 0;
@@ -4191,7 +4192,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "diff",
-          "Client: User Idle"
+          "Client: User Idle",
         );
         sortColNum = new Array(
           "statusRunning",
@@ -4200,11 +4201,11 @@ SPDX-License-Identifier: Apache-2.0
           "statusIdle",
           "requestIdle",
           "diff",
-          "cmGlideinJobsIdle"
+          "cmGlideinJobsIdle",
         );
         diffCol = new Array(
           "Diff(Status: Running cores, Client: Registered cores)",
-          "Diff(Status: Idle, Requested: Idle)"
+          "Diff(Status: Idle, Requested: Idle)",
         );
 
         if (!prTr) diffCell = new Array(4, 7);
@@ -4219,7 +4220,7 @@ SPDX-License-Identifier: Apache-2.0
             totStatChild,
             totCMChild,
             totStatChild,
-            totReqChild
+            totReqChild,
           );
 
         att = new Array(5, 2, 1, 0); // child and att are used only for the diff values
@@ -4255,7 +4256,7 @@ SPDX-License-Identifier: Apache-2.0
               sorted = temp;
             }
             trSortSignal(
-              tempHold + 2
+              tempHold + 2,
             ); /* ENTRY NAME COL + DOWNTIME STATUS COL = 2 */
             return;
           }
@@ -4281,14 +4282,14 @@ SPDX-License-Identifier: Apache-2.0
             if (!prTr) {
               for (k = 0; k < trTable.rows.length; k++) {
                 diffArry.push(
-                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML)
+                  parseInt(trTable.rows[k].cells[diffCell[j]].innerHTML),
                 );
               }
             } else {
               for (k = 0; k < trpr_Table.rows.length; k++) {
                 if (k % 4 == 0) {
                   diffArry.push(
-                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML)
+                    parseInt(trpr_Table.rows[k].cells[diffCell[j]].innerHTML),
                   );
                 }
               }
@@ -4387,7 +4388,8 @@ SPDX-License-Identifier: Apache-2.0
                   try {
                     val1 = parseInt(
                       totalEntries[k].childNodes[feChild].childNodes[childView]
-                        .childNodes[child[helper]].attributes[att[helper]].value
+                        .childNodes[child[helper]].attributes[att[helper]]
+                        .value,
                     );
                   } catch (err) {}
                   try {
@@ -4395,7 +4397,7 @@ SPDX-License-Identifier: Apache-2.0
                       totalEntries[k].childNodes[feChild].childNodes[childView]
                         .childNodes[child[helper + 1]].attributes[
                         att[helper + 1]
-                      ].value
+                      ].value,
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4432,14 +4434,14 @@ SPDX-License-Identifier: Apache-2.0
                     val1 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper]
-                      ].attributes[att[helper]].value
+                      ].attributes[att[helper]].value,
                     );
                   } catch (err) {}
                   try {
                     val2 = parseInt(
                       totalEntries[k].childNodes[totChild].childNodes[
                         child[helper + 1]
-                      ].attributes[att[helper + 1]].value
+                      ].attributes[att[helper + 1]].value,
                     );
                   } catch (err) {}
                   diff = val1 - val2;
@@ -4659,7 +4661,7 @@ SPDX-License-Identifier: Apache-2.0
           "Status: Idle",
           "Requested: Idle",
           "Diff(Status: Idle, Requested: Idle)",
-          "Client: User Idle"
+          "Client: User Idle",
         );
         colors = new Array(
           "#DCDCDC",
@@ -4671,7 +4673,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FAF0E6",
           "#FFDAB9",
           "#7D9EC0",
-          "#CDAF95"
+          "#CDAF95",
         );
         trColumnId = new Array(
           "entryLinks",
@@ -4683,7 +4685,7 @@ SPDX-License-Identifier: Apache-2.0
           "status",
           "requested",
           "difference",
-          "client"
+          "client",
         );
 
         /* FRONTEND VIEW */
@@ -4693,7 +4695,7 @@ SPDX-License-Identifier: Apache-2.0
             feCMChild,
             feStatChild,
             feReqChild,
-            feCMChild
+            feCMChild,
           );
         /* TOTAL VIEW */ else
           child = new Array(
@@ -4701,7 +4703,7 @@ SPDX-License-Identifier: Apache-2.0
             totCMChild,
             totStatChild,
             totReqChild,
-            totCMChild
+            totCMChild,
           );
 
         /* ARRAYS FOR INFO ACCESSING */
@@ -4713,7 +4715,7 @@ SPDX-License-Identifier: Apache-2.0
           totStatChild,
           totReqChild,
           0,
-          totCMChild
+          totCMChild,
         );
         trFEChildArry = new Array(
           feStatChild,
@@ -4722,19 +4724,19 @@ SPDX-License-Identifier: Apache-2.0
           feStatChild,
           feReqChild,
           0,
-          feCMChild
+          feCMChild,
         );
         // StatusRunningCores(Running cores) , ClientCoresTotal(Registered cores), StatusIdle(Idle), ReqIdle(Idle), ClientJobsIdle(User idle)
         // using columnArrayDesc, i starts w/ Entry_name, xmlAttTotalNumArry starts w/ DT (-1), xmlAttPeriodNumArry starts w/ Status (-columnArrayDesc.Status.offset)
         // In elements offset: 8, 5, -, 1, 1, -, 4
         trAttArry = new Array();
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8]
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 8],
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.CM.offset - 1 + 5]);
         trAttArry.push(0);
         trAttArry.push(
-          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1]
+          xmlAttTotalNumArry[columnArrayDesc.Status.offset - 1 + 1],
         );
         trAttArry.push(xmlAttTotalNumArry[columnArrayDesc.Req.offset - 1 + 1]);
         trAttArry.push(0);
@@ -4745,20 +4747,20 @@ SPDX-License-Identifier: Apache-2.0
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 5
-          ]
+          ],
         );
         prAttArry.push(0);
         prAttArry.push(xmlAttPeriodNumArry[1]); // columnArrayDesc.Status.offset-columnArrayDesc.Status.offset+1
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.Req.offset - columnArrayDesc.Status.offset + 1
-          ]
+          ],
         );
         prAttArry.push(0);
         prAttArry.push(
           xmlAttPeriodNumArry[
             columnArrayDesc.CM.offset - columnArrayDesc.Status.offset + 4
-          ]
+          ],
         );
 
         rows = new Array();
@@ -4827,7 +4829,7 @@ SPDX-License-Identifier: Apache-2.0
                 cols[k].setAttribute("onmouseout", "hidePopUp()");
                 cols[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)"
+                  "showPopUpPeriod(this)",
                 );
                 cols[k - 1].setAttribute("id", c);
                 cols[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -4869,7 +4871,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y
+              "factoryEntryStatusNow.html?entry=" + y,
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             trpr_Table.rows[i].cells[0].appendChild(links[i]);
@@ -5166,7 +5168,7 @@ SPDX-License-Identifier: Apache-2.0
           "#FFFAF0",
           "#FAF0E6",
           "#FFDAB9",
-          "#CDAF95"
+          "#CDAF95",
         );
         hArry2 = new Array(
           "",
@@ -5174,7 +5176,7 @@ SPDX-License-Identifier: Apache-2.0
           "Period:",
           "Status:",
           "Requested:",
-          "Client Monitor:"
+          "Client Monitor:",
         );
         // hArry3 = new Array(1, 1, 1,xmlAttStatNumArry.length, xmlAttReqNumArry.length, xmlAttCMNumArry.length);
         hArry3 = new Array(
@@ -5183,7 +5185,7 @@ SPDX-License-Identifier: Apache-2.0
           1,
           columnArrayDesc.Status.length,
           columnArrayDesc.Req.length,
-          columnArrayDesc.CM.length
+          columnArrayDesc.CM.length,
         );
 
         /*
@@ -5240,7 +5242,7 @@ SPDX-License-Identifier: Apache-2.0
                 cell[k].setAttribute("onmouseout", "hidePopUp()");
                 cell[k - 1].setAttribute(
                   "onmouseover",
-                  "showPopUpPeriod(this)"
+                  "showPopUpPeriod(this)",
                 );
                 cell[k - 1].setAttribute("id", c);
                 cell[k - 1].setAttribute("onmouseout", "hidePopUp()");
@@ -5337,7 +5339,7 @@ SPDX-License-Identifier: Apache-2.0
             links[i].innerHTML = y;
             links[i].setAttribute(
               "href",
-              "factoryEntryStatusNow.html?entry=" + y
+              "factoryEntryStatusNow.html?entry=" + y,
             );
             links[i].setAttribute("onclick", "entryClick(this)");
             tableP.rows[i].cells[0].appendChild(links[i]);

--- a/creation/web_base/factory_support.js
+++ b/creation/web_base/factory_support.js
@@ -86,7 +86,7 @@ function getFactoryFrontends(factoryQStats) {
                                     var frontend_name =
                                         el3.attributes[0].value.toString();
                                     groups[entry_name.value].push(
-                                        frontend_name
+                                        frontend_name,
                                     );
                                 }
                             }
@@ -134,16 +134,16 @@ function getFactoryEntryGroups(factoryQStats) {
                                 ) {
                                     var group_name =
                                         grp.attributes.getNamedItem(
-                                            "group_name"
+                                            "group_name",
                                         );
                                     if (group_name.value in groups) {
                                         groups[group_name.value].push(
-                                            entry_name.value
+                                            entry_name.value,
                                         );
                                     } else {
                                         groups[group_name.value] = new Array();
                                         groups[group_name.value].push(
-                                            entry_name.value
+                                            entry_name.value,
                                         );
                                     }
                                 }
@@ -174,7 +174,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             factory_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "factory"
+                    "factory",
                 );
 
             for (var i = 0; i < factory_info[0].attributes.length; i++) {

--- a/creation/web_base/frontendGroupGraphStatusNow.html
+++ b/creation/web_base/frontendGroupGraphStatusNow.html
@@ -719,7 +719,7 @@ SPDX-License-Identifier: Apache-2.0
       // text: Text inside the dialog box
       function ShowDialog(tocenter_object, title, text) {
         HideDialog();
-        $(tocenter_object).append(
+        $.find(tocenter_object).append(
           "<div id='error_dialog' title=\"" + title + '">' + text + "</div>"
         );
         $("#error_dialog")

--- a/creation/web_base/frontendGroupGraphStatusNow.html
+++ b/creation/web_base/frontendGroupGraphStatusNow.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: Apache-2.0
             chartData.push(
               simpleEncoding.charAt(
                 Math.round(
-                  ((simpleEncoding.length - 1) * currentValue) / maxValue
-                )
-              )
+                  ((simpleEncoding.length - 1) * currentValue) / maxValue,
+                ),
+              ),
             );
           } else {
             chartData.push("_");
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
           var numericVal = new Number(arrVals[i]);
           // Scale the value to maxVal.
           var scaledVal = Math.floor(
-            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal
+            (EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH * numericVal) / maxVal,
           );
 
           if (scaledVal > EXTENDED_MAP_LENGTH * EXTENDED_MAP_LENGTH - 1) {
@@ -169,8 +169,8 @@ SPDX-License-Identifier: Apache-2.0
         return (
           decodeURIComponent(
             (new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(
-              location.search
-            ) || [, ""])[1].replace(/\+/g, "%20")
+              location.search,
+            ) || [, ""])[1].replace(/\+/g, "%20"),
           ) || null
         );
       }
@@ -263,7 +263,7 @@ SPDX-License-Identifier: Apache-2.0
           window.history.pushState(
             { group: selected_group },
             "",
-            addParameter(document.location.href, "group", selected_group)
+            addParameter(document.location.href, "group", selected_group),
           );
         } else {
           going_back = false;
@@ -321,7 +321,7 @@ SPDX-License-Identifier: Apache-2.0
                 group_name +
                 "'><i class='icon-chevron-right'></i>" +
                 group_name +
-                "</a>  </li>"
+                "</a>  </li>",
             );
 
             if (first_group == true) {
@@ -367,7 +367,7 @@ SPDX-License-Identifier: Apache-2.0
           .each(function () {
             if ($(this).attr("name") == "Local") {
               $("#updated_display").html(
-                "Snapshot last updated: " + $(this).attr("human")
+                "Snapshot last updated: " + $(this).attr("human"),
               );
             }
           });
@@ -400,7 +400,7 @@ SPDX-License-Identifier: Apache-2.0
         } else {
           $(input_array).each(function () {
             toReturn.push(
-              (parseFloat(this) / parseFloat(normalized_total)) * 100.0
+              (parseFloat(this) / parseFloat(normalized_total)) * 100.0,
             );
           });
         }
@@ -455,11 +455,11 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 0, entry_name);
 
             var matched_idle_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Idle")
+              $(this).find("MatchedGlideins").attr("Idle"),
             );
             matchedglideins_idle.push(matched_idle_glideins);
             var matched_running_glideins = parseFloat(
-              $(this).find("MatchedGlideins").attr("Running")
+              $(this).find("MatchedGlideins").attr("Running"),
             );
             matchedglideins_running.push(matched_running_glideins);
             data.setCell(counter, 3, matched_running_glideins);
@@ -482,29 +482,29 @@ SPDX-License-Identifier: Apache-2.0
             data.setCell(counter, 2, mji);
 
             matchedjobs_running.push(
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
             );
             data.setCell(
               counter,
               1,
-              parseFloat($(this).find("MatchedJobs").attr("RunningHere"))
+              parseFloat($(this).find("MatchedJobs").attr("RunningHere")),
             );
 
             requested_idle.push(
-              parseFloat($(this).find("Requested").attr("Idle"))
+              parseFloat($(this).find("Requested").attr("Idle")),
             );
             data.setCell(
               counter,
               7,
-              parseFloat($(this).find("Requested").attr("Idle"))
+              parseFloat($(this).find("Requested").attr("Idle")),
             );
             requested_max_running.push(
-              parseFloat($(this).find("Requested").attr("MaxGlideins"))
+              parseFloat($(this).find("Requested").attr("MaxGlideins")),
             );
             data.setCell(
               counter,
               6,
-              parseFloat($(this).find("Requested").attr("MaxGlideins"))
+              parseFloat($(this).find("Requested").attr("MaxGlideins")),
             );
 
             counter++;
@@ -518,7 +518,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Entry Points Detected",
             "No entry points were detected in the group: <strong>" +
               group_name +
-              "</strong>. <p>Please select another group from the menu on the left.</p>"
+              "</strong>. <p>Please select another group from the menu on the left.</p>",
           );
 
           // If no jobs are detected, idle or running
@@ -536,7 +536,7 @@ SPDX-License-Identifier: Apache-2.0
             "No Jobs Detected",
             "No jobs were detected, idle or running, in the group: <strong>" +
               group_name +
-              "</strong>.  <p>Please select another group from the menu on the left.</p>"
+              "</strong>.  <p>Please select another group from the menu on the left.</p>",
           );
         } else {
           $("#group_graphs").fadeTo(0, 1.0);
@@ -562,7 +562,7 @@ SPDX-License-Identifier: Apache-2.0
         data.setCell(
           counter,
           5,
-          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0
+          Math.round(SumElements(matchedglideins_idlefra) * 100) / 100.0,
         );
         data.setCell(counter, 6, SumElements(requested_max_running));
         data.setCell(counter, 7, SumElements(requested_idle));
@@ -574,7 +574,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_idle,
           "Glideins not matched",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -586,7 +586,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedglideins_running,
           "Glideins claimed by jobs",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -599,7 +599,7 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           matchedjobs_running,
           "Running jobs by Entry",
-          img
+          img,
         );
 
         img = CreateGraphImage();
@@ -612,11 +612,11 @@ SPDX-License-Identifier: Apache-2.0
           factories.slice(),
           requested_max_running,
           "Requested Max Running",
-          img
+          img,
         );
 
         table = new google.visualization.Table(
-          document.getElementById("group_table")
+          document.getElementById("group_table"),
         );
         var dataview = new google.visualization.DataView(data);
         table.draw(dataview);
@@ -638,7 +638,7 @@ SPDX-License-Identifier: Apache-2.0
             .html(
               '<div id="image_load_fail" class="image_error">Unable to load image: ' +
                 img_title +
-                "<div>"
+                "<div>",
             );
         });
         $(img).click(function () {
@@ -699,7 +699,7 @@ SPDX-License-Identifier: Apache-2.0
             entry_data[i][0] +
               " (" +
               Math.round(entry_data[i][1] * 10) / 10.0 +
-              ")"
+              ")",
           );
         }
         baseurl += formatted_entry_points.join("|");
@@ -720,7 +720,7 @@ SPDX-License-Identifier: Apache-2.0
       function ShowDialog(tocenter_object, title, text) {
         HideDialog();
         $.find(tocenter_object).append(
-          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>"
+          "<div id='error_dialog' title=\"" + title + '">' + text + "</div>",
         );
         $("#error_dialog")
           .dialog({

--- a/creation/web_base/frontendRRDGroupMatrix.html
+++ b/creation/web_base/frontendRRDGroupMatrix.html
@@ -203,7 +203,7 @@ Description:
 
         for (var i in group_names) {
           fnames.push(
-            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd"
+            "group_" + group_names[i] + "/total/" + rrd_name + ".rrd",
           );
           rrd_data.push(null);
         }

--- a/creation/web_base/frontendStatus.html
+++ b/creation/web_base/frontendStatus.html
@@ -239,7 +239,7 @@ Description:
           "MatchCoreRunning",
           "MatchJobIdle",
           "ReqIdle",
-          "ReqMaxRun"
+          "ReqMaxRun",
         );
         //                                       'JobsRunning',    'GlideinTotal',     'GlideinRunning',     'GlideinIdle',     'JobsIdle');
         gtype_DSs["idle"] = new Array(
@@ -254,7 +254,7 @@ Description:
           "MatchCoreIdle",
           "MatchCoreRunning",
           "ReqIdle",
-          "ReqMaxRun"
+          "ReqMaxRun",
         );
 
         var gtype_formats = new Object();
@@ -501,7 +501,7 @@ Description:
             window_max: local_window_max,
             use_checked_DSs: true,
             use_element_buttons: true,
-          }
+          },
         );
       }
 
@@ -569,7 +569,7 @@ Description:
           "rra",
           "window_min",
           "window_max",
-          "timezone"
+          "timezone",
         );
         var groupSpec;
         var infoGroupSpec;
@@ -610,11 +610,11 @@ Description:
                     //   as seen in the factory menu.
                     var state_list = getFrontendGroupStates(
                       loadFrontendStats(),
-                      groups[group]
+                      groups[group],
                     );
                     var fac_list = getFrontendGroupFactories(
                       loadFrontendStats(),
-                      groups[group]
+                      groups[group],
                     );
 
                     //states listed first in the Factory menu, so push factories onto state list

--- a/creation/web_base/frontendStatusNow.html
+++ b/creation/web_base/frontendStatusNow.html
@@ -208,7 +208,9 @@ SPDX-License-Identifier: Apache-2.0
         text-align: left;
       }
       #button {
-        font-family: Lucida Console, monospace;
+        font-family:
+          Lucida Console,
+          monospace;
         font-weight: bold;
         color: #330000;
         width: 110px;

--- a/creation/web_base/frontend_support.js
+++ b/creation/web_base/frontend_support.js
@@ -47,7 +47,7 @@ function getFrontendGroupFoS(
     frontendStats,
     group_name,
     fos_tag_top,
-    fos_tag_one
+    fos_tag_one,
 ) {
     factories = new Array();
 
@@ -88,7 +88,7 @@ function getFrontendGroupFoS(
                                     if (factory.nodeName == fos_tag_one) {
                                         factory_name =
                                             factory.attributes.getNamedItem(
-                                                "name"
+                                                "name",
                                             );
                                         factories.push(factory_name.value);
                                     }
@@ -109,7 +109,7 @@ function getFrontendGroupFactories(frontendStats, group_name) {
         frontendStats,
         group_name,
         "factories",
-        "factory"
+        "factory",
     );
 }
 
@@ -147,7 +147,7 @@ function set_title_and_footer(browser_title, page_title) {
             //4 == READY
             frontend_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "frontend"
+                    "frontend",
                 );
             frontend_name = frontend_info[0].attributes[0].value;
             document.getElementById("pgtitle").innerHTML =
@@ -157,7 +157,7 @@ function set_title_and_footer(browser_title, page_title) {
 
             footer_info =
                 xmlhttp_descript.responseXML.documentElement.getElementsByTagName(
-                    "monitor_footer"
+                    "monitor_footer",
                 );
             footer_text = footer_info[0].attributes[0].value;
             footer_link = footer_info[0].attributes[1].value;


### PR DESCRIPTION
Web page fix for "DOM text reinterpreted as HTML" flagged by GH. In reality, the function mentioned is invoked only w/ constant parameters, so it should not be vulnerable. Anyway, I applied the suggested fix.

The other changes come from the new version of Prettier.

Updated some pre-commit hooks. We cannot auto-update pre-commit, it would break Python 3.6 compatibility