### PR TITLE
Added support for structured logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since the last release
 ### New features / functionalities
 
 -   Added support for Debian 11 and Ubuntu 22 worker nodes (PR #320)
+-   Added structured logging. It is a hybrid format with some fields followed by a JSON dictionary. The exact format of the messages may change in the future, and we plan for it to become the default. Now it is disabled by default. Add `structured="True"` to all `<process_log>` elements (PR #333)
 -   Add option to set xml output directory in OSG_autoconf (PR #319)
 -   Allow OSG_autoconf to skip sites or CEs that are not present in the OSG collector (PR #315)
 

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -185,11 +185,13 @@ Requires: python3-pyyaml
 Requires: python3-jwt
 Requires: python3-cryptography
 Requires: python3-m2crypto
+#Requires: python3-structlog
 %else
 Requires: PyYAML
 Requires: python36-jwt
 Requires: python36-cryptography
 Requires: python36-m2crypto
+Requires: python36-structlog
 %endif
 Requires: python3-rrdtool
 %description libs

--- a/creation/lib/cWParamDict.py
+++ b/creation/lib/cWParamDict.py
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Frontend creation module
 #   Classes and functions needed to handle dictionary files
@@ -17,12 +11,9 @@
 
 import os.path
 
+from glideinwms.lib.util import is_true
+
 from . import cWConsts, cWDictFile
-
-
-def is_true(s):
-    """Case insensitive string parsing helper. Return True for true (case insensitive matching), False otherwise."""
-    return type(s) == str and s.lower() == "true"
 
 
 def has_file_wrapper(dicts):

--- a/creation/lib/cWParams.py
+++ b/creation/lib/cWParams.py
@@ -1,21 +1,8 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This module contains the generic params classes
-#
-# Extracted from:
-#   cgWParams.py
-#
-# Author:
-#   Igor Sfiligoi
-#
 
 import copy
 import os
@@ -95,6 +82,7 @@ class SubParams(Mapping):
 
         """
         for k in self.data:
+            # TODO: MMBFIX is the next line doing anything? should it be removed? check history?
             self.data
             if k not in base:
                 # element not in base, report
@@ -663,7 +651,7 @@ def shorten_text(text, width):
 
 
 def defdict2string(defaults, indent, width=80):
-    """Convert defualts to a string
+    """Convert defaults to a string
 
     Args:
         defaults:

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -1,11 +1,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Glidein creation module
 #   Classes and functions needed to handle dictionary files

--- a/creation/lib/cgWParams.py
+++ b/creation/lib/cgWParams.py
@@ -1,18 +1,8 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Desscription:
 #   This module contains the create_glidein params class
-#
-# Author:
-#   Igor Sfiligoi
-#
 
 import copy
 import os
@@ -28,10 +18,6 @@ from glideinwms.lib.util import safe_boolcomp
 from glideinwms.lib.xmlParse import OrderedDict
 
 from . import cWParams
-
-# import types
-# import traceback
-# from collections import OrderedDict
 
 
 ######################################################
@@ -297,6 +283,7 @@ class GlideinParams(cWParams.CommonParams):
         self.defaults["monitor_footer"] = monitor_footer_defaults
 
         process_log_defaults = copy.deepcopy(one_log_retention_defaults)
+        process_log_defaults["structured"] = ["False", "Bool", "True to use structured logs", None]
         process_log_defaults["extension"] = ["all", "string", "name of the log extention", None]
         process_log_defaults["msg_types"] = ["INFO, WARN, ERR", "string", "types of log messages", None]
         process_log_defaults["backup_count"] = ["5", "string", "Number of backup logs to keep", None]

--- a/creation/lib/cvWParams.py
+++ b/creation/lib/cvWParams.py
@@ -406,6 +406,7 @@ class VOFrontendParams(cWParams.CommonParams):
         self.defaults["work"] = work_defaults
 
         process_log_defaults = cWParams.CommentedOrderedDict()
+        process_log_defaults["structured"] = ["False", "Bool", "True to use structured logs", None]
         process_log_defaults["min_days"] = [
             "3.0",
             "days",

--- a/creation/lib/factory_defaults.xml
+++ b/creation/lib/factory_defaults.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
       <job_logs max_days="7.0" max_mbytes="100.0" min_days="2.0"/>
       <summary_logs max_days="31.0" max_mbytes="100.0" min_days="3.0"/>
       <process_logs>
-         <process_log max_days="7.0" max_mbytes="100.0" min_days="3.0" backup_count="5" compression="" extension="all" msg_types="INFO, WARN, ERR"/>
+         <process_log structured="False" max_days="7.0" max_mbytes="100.0" min_days="3.0" backup_count="5" compression="" extension="all" msg_types="INFO, WARN, ERR"/>
       </process_logs>
    </log_retention>
    <!-- hard coding rpm paths for now -->

--- a/creation/reconfig_glidein
+++ b/creation/reconfig_glidein
@@ -61,31 +61,7 @@ def logReconfig(msg):
     # Set the Log directory
     logSupport.log_dir = os.path.join(glideinDescript.data["LogDir"], "factory")
     # Configure factory process logging
-    process_logs = eval(glideinDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        if "ADMIN" in plog["msg_types"]:
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                "DEBUG,INFO,WARN,ERR",
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                plog["compression"],
-            )
-        else:
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                plog["compression"],
-            )
-    logSupport.log = logSupport.getLogger("factoryadmin")
+    logSupport.log = logSupport.get_logger_with_handlers("factoryadmin", logSupport.log_dir, glideinDescript.data)
     logSupport.log.info("Reconfiguring factory: %s" % msg)
 
 

--- a/creation/reconfig_glidein
+++ b/creation/reconfig_glidein
@@ -85,7 +85,7 @@ def logReconfig(msg):
                 int(float(plog["max_mbytes"])),
                 plog["compression"],
             )
-    logSupport.log = logging.getLogger("factoryadmin")
+    logSupport.log = logSupport.getLogger("factoryadmin")
     logSupport.log.info("Reconfiguring factory: %s" % msg)
 
 

--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -170,9 +170,9 @@ SPDX-License-Identifier: Apache-2.0
               <a href="#">&lt;process_logs &gt;</a><br />
               <blockquote>
                 <a href="#process_logs"
-                  >&lt;process_log extension="info" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="INFO"
-                  backup_count="5" compression="gz" /&gt;</a
+                  >&lt;process_log structured="True" extension="info"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="INFO" backup_count="5" compression="gz" /&gt;</a
                 ><br />
                 <a href="#process_logs"
                   >&lt;process_log extension="debug" max_days="7.0"
@@ -611,6 +611,12 @@ SPDX-License-Identifier: Apache-2.0
                 with other message types.
               </li>
             </ul>
+            If any of the logs has <i>structured=True</i>, then the logs are
+            written in structured format. It is actuallly a hybrid format, with
+            some initial field and a JSON dictionary. Since all logs share the
+            same logger, it is not possible to have some in structured and some
+            in classic format. In the future we plan for the structured format
+            to become the default. <br /><br />
             The extension is added to the log name to create separate logs.
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -159,14 +159,14 @@ SPDX-License-Identifier: Apache-2.0
               <a href="#">&lt;process_logs &gt;</a><br />
               <blockquote>
                 <a href="#process_logs"
-                  >&lt;process_log extension="info" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="INFO"
-                  backup_count="5" compression="gz" /&gt;</a
+                  >&lt;process_log structured="False" extension="info"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="INFO" backup_count="5" compression="gz" /&gt;</a
                 ><br />
                 <a href="#process_logs"
-                  >&lt;process_log extension="debug" max_days="7.0"
-                  max_mbytes="100.0" min_days="3.0" msg_types="DEBUG,ERR,WARN"
-                  backup_count="5" /&gt;</a
+                  >&lt;process_log structured="False" extension="debug"
+                  max_days="7.0" max_mbytes="100.0" min_days="3.0"
+                  msg_types="DEBUG,ERR,WARN" backup_count="5" /&gt;</a
                 ><br />
               </blockquote>
               <a href="#">&lt;/process_logs &gt;</a><br />
@@ -518,9 +518,10 @@ SPDX-License-Identifier: Apache-2.0
             <a name="process_logs" />
             <div class="xml">
               &lt;frontend&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
-              max_days=&quot;<i>max days</i>&quot; min_days=&quot;<i>min days</i
-              >&quot; max_bytes=&quot;<i>max bytes</i>&quot;
-              backup_count=&quot;<i>backup count</i>&quot;
+              structured="True" max_days=&quot;<i>max days</i>&quot;
+              min_days=&quot;<i>min days</i>&quot; max_bytes=&quot;<i
+                >max bytes</i
+              >&quot; backup_count=&quot;<i>backup count</i>&quot;
               type=&quot;<i>ALL</i>&quot; compression=&quot;<i>gz</i>&quot;/&gt;
             </div>
             <p>
@@ -541,6 +542,12 @@ SPDX-License-Identifier: Apache-2.0
                 that don't necessarily cause abnormal execution.
               </li>
             </ul>
+            If any of the logs has <i>structured=True</i>, then the logs are
+            written in structured format. It is actuallly a hybrid format, with
+            some initial field and a JSON dictionary. Since all logs share the
+            same logger, it is not possible to have some in structured and some
+            in classic format. In the future we plan for the structured format
+            to become the default. <br /><br />
             The extension is added to the log name to create separate logs.
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>

--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -835,33 +835,7 @@ def main(startup_dir):
     logSupport.log_dir = os.path.join(glideinDescript.data["LogDir"], "factory")
 
     # Configure factory process logging
-    process_logs = eval(glideinDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        if "ADMIN" in plog["msg_types"].upper():
-            logSupport.add_processlog_handler(
-                "factoryadmin",
-                logSupport.log_dir,
-                "DEBUG,INFO,WARN,ERR",
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-        else:
-            logSupport.add_processlog_handler(
-                "factory",
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-    logSupport.log = logSupport.getLogger("factory")
+    logSupport.log = logSupport.get_logger_with_handlers("factory", logSupport.log_dir, glideinDescript.data)
     logSupport.log.info("Logging initialized")
 
     if glideinDescript.data["Entries"].strip() in ("", ","):

--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -861,7 +861,7 @@ def main(startup_dir):
                 int(float(plog["backup_count"])),
                 plog["compression"],
             )
-    logSupport.log = logging.getLogger("factory")
+    logSupport.log = logSupport.getLogger("factory")
     logSupport.log.info("Logging initialized")
 
     if glideinDescript.data["Entries"].strip() in ("", ","):

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -78,7 +78,7 @@ class Entry:
                 int(float(plog["backup_count"])),
                 plog["compression"],
             )
-        self.log = logging.getLogger(self.name)
+        self.log = logSupport.getLogger(self.name)
 
         cleaner = cleanupSupport.DirCleanupWSpace(
             self.logDir,

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -65,20 +65,7 @@ class Entry:
         self.scheddName = self.jobDescript.data["Schedd"]
 
         # glideFactoryLib.log_files
-        process_logs = eval(self.glideinDescript.data["ProcessLogs"])
-        for plog in process_logs:
-            logSupport.add_processlog_handler(
-                self.name,
-                self.logDir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-        self.log = logSupport.getLogger(self.name)
+        self.log = logSupport.get_logger_with_handlers(self.name, self.logDir, self.glideinDescript.data)
 
         cleaner = cleanupSupport.DirCleanupWSpace(
             self.logDir,

--- a/factory/glideFactoryEntryGroup.py
+++ b/factory/glideFactoryEntryGroup.py
@@ -646,7 +646,7 @@ def init_logs(name, log_dir, process_logs):
             int(float(plog["backup_count"])),
             plog["compression"],
         )
-        logSupport.log = logging.getLogger(name)
+        logSupport.log = logSupport.getLogger(name)
         logSupport.log.info("Logging initialized for %s" % name)
 
 

--- a/factory/glideFactoryEntryGroup.py
+++ b/factory/glideFactoryEntryGroup.py
@@ -3,25 +3,18 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This is the glideinFactoryEntryGroup. Common Tasks like querying collector
 #   and advertizing the work done by group are done here
 #
 # Arguments:
-#   $1 = poll period (in seconds)
-#   $2 = advertize rate (every $2 loops)
-#   $3 = glidein submit_dir
-#   $4 = entry name
-#
-# Author:
-#   Parag Mhashilkar (October 2012)
-#
+#   $1 = parent_pid (int): The pid for the Factory daemon
+#   $2 = sleep_time (int): The number of seconds to sleep between iterations
+#   $3 = advertize_rate (int): The rate at which advertising should occur (every $3 loops)
+#   $4 = startup_dir (str|Path): The "home" directory for the entry.
+#   $5 = entry_names (str): Colon separated list with the names of the entries this process should work on
+#   $6 = group_id (str): Group id, normally a number (with the "group_" prefix formes the group name),
+#             It can change between Factory reconfigurations
 
 import logging
 import os
@@ -578,17 +571,18 @@ def iterate(parent_pid, sleep_time, advertize_rate, glideinDescript, frontendDes
                                 entry.writeStats()
                                 return_dict[entry.name] = entry.getState()
                             except:
-                                entry.log.warning("Error writing stats for entry '%s'" % (entry.name))
-                                entry.log.exception("Error writing stats for entry '%s': " % (entry.name))
+                                entry.log.warning(f"Error writing stats for entry '{entry.name}'")
+                                entry.log.exception(f"Error writing stats for entry '{entry.name}': ")
 
                         try:
                             os.write(w, pickle.dumps(return_dict))
                         except:
                             # Catch and log exceptions if any to avoid
                             # runaway processes.
-                            entry.log.exception("Error writing pickled state for entry '%s': " % (entry.name))
+                            logSupport.log.exception(f"Error writing pickled state for entries '{entrylists[cpu]}': ")
                         os.close(w)
                         # Exit without triggering SystemExit exception
+                        # Note that this is skippihg also all the cleanup (files closing, finally clauses)
                         os._exit(0)
 
                 try:
@@ -630,65 +624,34 @@ def iterate(parent_pid, sleep_time, advertize_rate, glideinDescript, frontendDes
 
 
 ############################################################
-# Initialize log_files for entries and groups
-
-
-def init_logs(name, log_dir, process_logs):
-    for plog in process_logs:
-        logSupport.add_processlog_handler(
-            name,
-            log_dir,
-            plog["msg_types"],
-            plog["extension"],
-            int(float(plog["max_days"])),
-            int(float(plog["min_days"])),
-            int(float(plog["max_mbytes"])),
-            int(float(plog["backup_count"])),
-            plog["compression"],
-        )
-        logSupport.log = logSupport.getLogger(name)
-        logSupport.log.info("Logging initialized for %s" % name)
-
-
-############################################################
 
 
 def main(parent_pid, sleep_time, advertize_rate, startup_dir, entry_names, group_id):
-    """
-    GlideinFactoryEntryGroup main function
+    """GlideinFactoryEntryGroup main function
 
     Setup logging, monitoring, and configuration information. Starts the Entry
     group main loop and handles cleanup at shutdown.
 
-    @type parent_pid: int
-    @param parent_pid: The pid for the Factory daemon
+    Args:
+        parent_pid (int): The pid for the Factory daemon
+        sleep_time (int): The number of seconds to sleep between iterations
+        advertize_rate (int): The rate at which advertising should occur
+        startup_dir (str|Path): The "home" directory for the entry.
+        entry_names (str): Colon separated list with the names of the entries this process should work on
+        group_id (str): Group id, normally a number (with the "group_" prefix formes the group name),
+            It can change between Factory reconfigurations
 
-    @type sleep_time: int
-    @param sleep_time: The number of seconds to sleep between iterations
-
-    @type advertize_rate: int
-    @param advertize_rate: The rate at which advertising should occur
-
-    @type startup_dir: string
-    @param startup_dir: The "home" directory for the entry.
-
-    @type entry_names: string
-    @param entry_names: The CVS name of the entries this process should work on
-
-    @type group_id: string
-    @param group_id: Group id
     """
 
     # Assume name to be group_[0,1,2] etc. Only required to create log_dir
     # where tasks common to the group will be stored. There is no other
     # significance to the group_name and number of entries supported by a group
     # can change between factory reconfigs
-
     group_name = "group_%s" % group_id
 
     os.chdir(startup_dir)
 
-    # Setup the lock_dir
+    # Set up the lock_dir
     gfi.factoryConfig.lock_dir = os.path.join(startup_dir, "lock")
 
     # Read information about the glidein and frontends
@@ -706,10 +669,10 @@ def main(parent_pid, sleep_time, advertize_rate, startup_dir, entry_names, group
     my_entries = {}
     glidein_entries = glideinDescript.data["Entries"]
 
-    # Initiate the logs
+    # Initialize log files for entry groups
     logSupport.log_dir = os.path.join(glideinDescript.data["LogDir"], "factory")
-    process_logs = eval(glideinDescript.data["ProcessLogs"])
-    init_logs(group_name, logSupport.log_dir, process_logs)
+    logSupport.log = logSupport.get_logger_with_handlers(group_name, logSupport.log_dir, glideinDescript.data)
+    logSupport.log.info(f"Logging initialized for {group_name}")
 
     logSupport.log.info("Starting up")
     logSupport.log.info(f"Entries processed by {group_name}: {entry_names} ")
@@ -752,19 +715,17 @@ def main(parent_pid, sleep_time, advertize_rate, startup_dir, entry_names, group
 
 
 def compile_pickle_data(entry, work_done):
+    """Extract the state of the entry after doing work
+
+    Args:
+        entry (Entry): Entry object
+        work_done (int): Work done info
+
+    Returns:
+        dict: pickle-friendly version of the Entry (state of the Entry)
     """
-    Extract the state of the entry after doing work
-
-    @type entry: Entry
-    @param entry: Entry object
-
-    @type work_done: int
-    @param work_done: Work done info
-    """
-
     return_dict = entry.getState()
     return_dict["work_done"] = work_done
-
     return return_dict
 
 
@@ -780,4 +741,4 @@ if __name__ == "__main__":
     # Force integrity checks on all condor operations
     gfl.set_condor_integrity_checks()
 
-    main(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), sys.argv[4], sys.argv[5], sys.argv[6])
+    main(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), sys.argv[4], sys.argv[5], sys.argv[6])

--- a/factory/tools/OSG_autoconf.py
+++ b/factory/tools/OSG_autoconf.py
@@ -30,6 +30,7 @@ from glideinwms.lib.config_util import (
     write_to_xml_file,
     write_to_yaml_file,
 )
+from glideinwms.lib.util import is_true
 
 
 def parse_opts():
@@ -291,19 +292,6 @@ def get_entries_configuration(data):
 #                    out[site][ce_hostname].setdefault(BEST_FIT_TAG, {})[qelem] = q_information
 #                    del out[site][ce_hostname][qelem]
 #
-
-
-def is_true(param):
-    """Determine if the parameter passed as argument is true or false
-
-    Args:
-        param: the parameter we need to determine if it is True or False. Can be any type.
-
-    Returns:
-        bool: True if the the string representation of param is "true"
-    """
-
-    return str(param).lower() == "true"
 
 
 def sanitize(whitelist_info):

--- a/factory/tools/manual_glidein_submit.py
+++ b/factory/tools/manual_glidein_submit.py
@@ -77,9 +77,9 @@ def parse_opts():
     # Initialize logging
     if options.debug:
         logging.basicConfig(format="%(levelname)s: %(message)s")
-        logging.getLogger().setLevel(logging.DEBUG)
+        logSupport.getLogger().setLevel(logging.DEBUG)
     else:
-        logging.getLogger().setLevel(logging.INFO)
+        logSupport.getLogger().setLevel(logging.INFO)
 
     return options
 
@@ -231,7 +231,7 @@ def main():
         params["Report_Failed"] = "NEVER"
 
         # Now that we have everything submit the pilot!
-        logging.getLogger().setLevel(logging.DEBUG)
+        logSupport.getLogger().setLevel(logging.DEBUG)
         submitGlideins(
             entry_name,
             "test.test",
@@ -242,7 +242,7 @@ def main():
             client_web,
             params,
             status_sf,
-            log=logging.getLogger(),
+            log=logSupport.getLogger(),
             factoryConfig=factory_config,
         )
 

--- a/factory/tools/manual_glidein_submit.py
+++ b/factory/tools/manual_glidein_submit.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import logging
+import logging  # This script is using straight logging instead of logSupport or structlog
 import os
 import pprint
 import socket
@@ -77,9 +77,9 @@ def parse_opts():
     # Initialize logging
     if options.debug:
         logging.basicConfig(format="%(levelname)s: %(message)s")
-        logSupport.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
     else:
-        logSupport.getLogger().setLevel(logging.INFO)
+        logging.getLogger().setLevel(logging.INFO)
 
     return options
 
@@ -231,7 +231,7 @@ def main():
         params["Report_Failed"] = "NEVER"
 
         # Now that we have everything submit the pilot!
-        logSupport.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
         submitGlideins(
             entry_name,
             "test.test",
@@ -242,7 +242,7 @@ def main():
             client_web,
             params,
             status_sf,
-            log=logSupport.getLogger(),
+            log=logging.getLogger(),
             factoryConfig=factory_config,
         )
 

--- a/frontend/glideinFrontend.py
+++ b/frontend/glideinFrontend.py
@@ -3,20 +3,11 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This is the main of the glideinFrontend
 #
 # Arguments:
 #   $1 = work_dir
-#
-# Author:
-#   Igor Sfiligoi
 #
 
 
@@ -529,20 +520,8 @@ def main(work_dir, action):
     logSupport.log_dir = os.path.join(frontendDescript.data["LogDir"], "frontend")
 
     # Configure frontend process logging
-    process_logs = eval(frontendDescript.data["ProcessLogs"])
-    for plog in process_logs:
-        logSupport.add_processlog_handler(
-            "frontend",
-            logSupport.log_dir,
-            plog["msg_types"],
-            plog["extension"],
-            int(float(plog["max_days"])),
-            int(float(plog["min_days"])),
-            int(float(plog["max_mbytes"])),
-            int(float(plog["backup_count"])),
-            plog["compression"],
-        )
-    logSupport.log = logSupport.getLogger("frontend")
+    logSupport.log = logSupport.get_logger_with_handlers("frontend", logSupport.log_dir, frontendDescript.data)
+
     logSupport.log.info("Logging initialized")
     logSupport.log.debug("Frontend startup time: %s" % str(startup_time))
 

--- a/frontend/glideinFrontend.py
+++ b/frontend/glideinFrontend.py
@@ -542,7 +542,7 @@ def main(work_dir, action):
             int(float(plog["backup_count"])),
             plog["compression"],
         )
-    logSupport.log = logging.getLogger("frontend")
+    logSupport.log = logSupport.getLogger("frontend")
     logSupport.log.info("Logging initialized")
     logSupport.log.debug("Frontend startup time: %s" % str(startup_time))
 

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -224,7 +224,7 @@ class glideinFrontendElement:
                 plog["compression"],
             )
 
-        logSupport.log = logging.getLogger(self.group_name)
+        logSupport.log = logSupport.getLogger(self.group_name)
 
         # We will be starting often, so reduce the clutter
         # logSupport.log.info("Logging initialized")

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -3,12 +3,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This is the main of the glideinFrontend
 #
@@ -18,15 +12,10 @@
 #   $3 = group_name
 #   $4 = operation type (optional, defaults to "run")
 #
-# Author:
-#   Igor Sfiligoi (was glideinFrontend.py until Nov 21, 2008)
-#
 
 import copy
-import logging
 import os
 import re
-import shutil
 import socket
 import sys
 import tempfile
@@ -181,7 +170,7 @@ class glideinFrontendElement:
         self.removal_requests_tracking = self.elementDescript.element_data["RemovalRequestsTracking"]
         self.removal_margin = int(self.elementDescript.element_data["RemovalMargin"])
 
-        # Default bahavior: Use factory proxies unless configure overrides it
+        # Default behavior: Use factory proxies unless configure overrides it
         self.x509_proxy_plugin = None
 
         # If not None, this is a request for removal of glideins only (i.e. do not ask for more)
@@ -210,21 +199,9 @@ class glideinFrontendElement:
         )
 
         # Configure frontend group process logging
-        process_logs = eval(self.elementDescript.frontend_data["ProcessLogs"])
-        for plog in process_logs:
-            logSupport.add_processlog_handler(
-                self.group_name,
-                logSupport.log_dir,
-                plog["msg_types"],
-                plog["extension"],
-                int(float(plog["max_days"])),
-                int(float(plog["min_days"])),
-                int(float(plog["max_mbytes"])),
-                int(float(plog["backup_count"])),
-                plog["compression"],
-            )
-
-        logSupport.log = logSupport.getLogger(self.group_name)
+        logSupport.log = logSupport.get_logger_with_handlers(
+            self.group_name, logSupport.log_dir, self.elementDescript.frontend_data
+        )
 
         # We will be starting often, so reduce the clutter
         # logSupport.log.info("Logging initialized")
@@ -244,8 +221,7 @@ class glideinFrontendElement:
             if not proxy_plugins.get(self.elementDescript.merged_data["ProxySelectionPlugin"]):
                 logSupport.log.warning(
                     "Invalid ProxySelectionPlugin '%s', supported plugins are %s"
-                    % (self.elementDescript.merged_data["ProxySelectionPlugin"]),
-                    list(proxy_plugins.keys()),
+                    % (self.elementDescript.merged_data["ProxySelectionPlugin"], list(proxy_plugins.keys()))
                 )
                 return 1
             self.x509_proxy_plugin = proxy_plugins[self.elementDescript.merged_data["ProxySelectionPlugin"]](

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -296,7 +296,7 @@ def add_processlog_handler(
 
     logfile = os.path.expandvars(f"{log_dir}/{logger_name}.{extension.lower()}.log")
 
-    mylog = logging.getLogger(logger_name)
+    mylog = structlog.getLogger(logger_name)
     mylog.setLevel(logging.DEBUG)
 
     handler = GlideinHandler(logfile, maxDays, minDays, maxMBytes, backupCount, compression)

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -11,6 +11,7 @@
 #
 
 import codecs
+import structlog
 import logging
 import os
 import re
@@ -359,3 +360,7 @@ def format_dict(unformated_dict, log_format="   %-25s : %s\n"):
         formatted_string += log_format % (key, unformated_dict[key])
 
     return formatted_string
+
+def getLogger(name):
+    return structlog.getLogger(name)
+

--- a/lib/util.py
+++ b/lib/util.py
@@ -409,6 +409,22 @@ def safe_boolcomp(value, expected):
     return str(value).lower() == str(expected).lower()
 
 
+# DEV NOTE: merging of creation.lib.CWParamDict.is_true() and factory.tools.OSG_autoconf.is_true()
+#   the first one required the argument to be a string. OK to drop that
+def is_true(value):
+    """Case-insensitive "True" string parsing helper.
+    Return True for true (case-insensitive string representation matching), False otherwise.
+
+    Args:
+        value: argument to evaluate as True or False. Can be any type.
+
+    Returns:
+        bool: True if the string representation of value is "true"
+    """
+
+    return str(value).lower() == "true"
+
+
 def str2bool(val):
     """Convert u"True" or u"False" to boolean or raise ValueError"""
     if val not in ["True", "False"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ htcondor
 # classad  # pure python 3rd party classad implementation
 m2crypto
 requests
+structlog
 pyyaml
 pyjwt
 

--- a/tools/gwms-logparser.py
+++ b/tools/gwms-logparser.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import fileinput
+import json
+import os
+
+
+def arg_parser():
+    epilog_text = """examples:
+   %(prog)s -f 0,1,2 -k msg mylog.txt
+   %(prog)s -f 3 mylog.txt"""
+    parser = argparse.ArgumentParser(
+        description="Simple log file parser to filter the records and print only part of them.",
+        epilog=epilog_text,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # need to use the default group, otherwise --help is in a separate group by itself
+    parser.add_argument(
+        "-f",
+        "--fields",
+        metavar="<fields>",
+        default="",
+        help="comma separated list of field numbers to select in the structured log message. Start from 0",
+    )
+    parser.add_argument(
+        "-k",
+        "--keys",
+        metavar="<keys>",
+        default="",
+        help="comma separated list of keys to select in the structured log message",
+    )
+    parser.add_argument(
+        "-i",
+        "--input_separator",
+        metavar="<input separator>",
+        default=" - ",
+        help="input separator (string). Defaults to ' - '.",
+    )
+    parser.add_argument(
+        "-s",
+        "--separator",
+        metavar="<separator>",
+        default=",",
+        help="output separator (string). Defaults to comma, ','",
+    )
+    parser.add_argument(
+        "-c",
+        "--constraint",
+        metavar="<constraint>",
+        action="append",
+        help="line selection constraint. Repeat the option for multiple constraints. Format: '(field # | key) value'."
+        " Integers are always considered field numbers.",
+    )
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        metavar="<loglevel>",
+        action="store",
+        help="add constraint for log level. Same as '-c 3 <loglevel>'",
+    )
+    parser.add_argument(
+        "-e",
+        "--logdirectory",
+        metavar="<logdirectory>",
+        action="store",
+        default="/var/log/gwms",
+        help="log files directory. Default is '/var/log/gwms'",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Include exception messages")
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug, e.g. to use for unit test")
+    positional = parser.add_argument_group("positional arguments")
+    positional.add_argument(
+        "logfile",
+        metavar="<logfile>",
+        nargs="?",
+        help="log file to parse. File names without directory are searched also in the default log files directory."
+        " Using stdin if '-' or if none is provided",
+    )
+    return parser
+
+
+def parse_constraints(constraints, loglevel=None):
+    """Parse and combine the constraints
+
+    Args:
+        constraints (list|None): List of constraints
+        loglevel (str): Logging level, e.g. DEBUG, INFO, ...
+
+    Returns:
+        dict: combined constraint dictionary
+
+    """
+    if not constraints and not loglevel:
+        return None
+    constraint = {"fields": [], "keys": []}
+    if loglevel:
+        # The log level is the 4th field in each log line
+        constraint["fields"].append((3, loglevel))
+    if constraints:
+        for c in constraints:
+            i, v = c.split(maxsplit=1)
+            try:
+                constraint["fields"].append((int(i), v))
+            except ValueError:
+                # TODO: add also time constraints: before, after, ...
+                constraint["keys"].append((i, v))
+    return constraint
+
+
+def matches_constraint(constraint, linelist, linedict):
+    """Return True if all constraints are marched
+
+    Args:
+        constraint (dict|None): combined constraints
+        linelist (list): List of line fields
+        linedict (dict): Dictionary with structured elements
+
+    Returns:
+        bool: True is all constraints are matched, False otherwise
+
+    """
+    if constraint is None:
+        return True
+    # if constraint is not None, it will always have "fields" and "keys"
+    if constraint["fields"]:
+        try:
+            if not all(linelist[i] == v for i, v in constraint["fields"]):
+                return False
+        except IndexError:
+            # In case records have variable number of fields (change in the log format)
+            return False
+    if constraint["keys"]:
+        try:
+            if not all(linedict[k] == v for k, v in constraint["keys"]):
+                return False
+        except KeyError:
+            # Some records may have keys not present in others. Only positive matches are True
+            return False
+    return True
+
+
+def execute_command_from_args(argsparsed, logfile=None, constraint=None):
+    """Parse the log file as requested.
+
+    Args:
+        argsparsed (Namespace): Parsed arguments from arg_parser in this file.
+        logfile (path): Log file path.
+        constraint (dict): Combined constraints dictionary
+
+    Returns:
+        str: Output of the command.
+    """
+
+    outlines = []
+    fields = []
+    keys = []
+    if argsparsed.fields:
+        fields = [int(i) for i in argsparsed.fields.split(",")]
+    if argsparsed.keys:
+        keys = argsparsed.keys.split(",")
+    if not fields and not keys:
+        raise ValueError("No field or key specified")
+    possible_dict_split = False
+    if argsparsed.input_separator == ": " or argsparsed.input_separator == ", ":
+        possible_dict_split = True
+    # If you would call fileinput.input() without files it would try to process all arguments.
+    # We pass '-' as only file when argparse got no files which will cause fileinput to read from stdin
+    with fileinput.input(files=(logfile,) if logfile else ("-",)) as f:
+        for full_line in f:
+            line = full_line.strip()
+            if not line:
+                # Skip empty lines
+                continue
+            linelist = line.split(argsparsed.input_separator)
+            if possible_dict_split and linelist[-1][-1] == "}":  # The line is stripped, no rstrip needed in last
+                i = 0
+                while i < len(linelist):
+                    if linelist[i].lstrip()[0] == "{":
+                        break
+                    i += 1
+                if i < len(linelist):
+                    # found split dictionary, trying to remediate
+                    linelist[i] = argsparsed.input_separator.join(linelist[i:])
+                    linelist = linelist[: i + 1]
+            if linelist[-1][0] == "{":
+                linedict = json.loads(linelist[-1])
+            else:
+                linedict = {}
+            if not matches_constraint(constraint, linelist, linedict):
+                continue
+            outline = ""
+            # Guaranteed to have at least one field or key
+            # IndexError and KeyError needed to cover irregular lines
+            for i in fields:
+                try:
+                    outline += f"{argsparsed.separator}{linelist[i]}"
+                except IndexError:
+                    outline += f"{argsparsed.separator}NOT_AVAILABLE"
+            for k in keys:
+                try:
+                    outline += f"{argsparsed.separator}{linedict[k]}"
+                except KeyError:
+                    outline += f"{argsparsed.separator}NOT_AVAILABLE"
+            print(outline[len(argsparsed.separator) :])
+            if argsparsed.debug:
+                outlines.append(outline[len(argsparsed.separator) :])
+    return "\n".join(outlines)
+
+
+def main(args_to_parse=None):
+    """Main function for logparser
+
+    Args:
+        args_to_parse (list, optional): If you pass a list of args, they will be used instead of sys.argv.
+        Defaults to None.
+
+    Returns:
+        str: Parsing result
+    """
+    parser = arg_parser()
+    args = parser.parse_args(args_to_parse)
+    if args.verbose:
+        if args.input_separator == ": " or args.input_separator == ", ":
+            print(f"Input separator '{args.input_separator}' could split the JSON dictionary failing the parsing.")
+    logfile = args.logfile
+    if (
+        logfile
+        and logfile != "-"
+        and not os.path.exists(logfile)
+        and logfile == os.path.basename(logfile)
+        and os.path.exists(os.path.join(args.logdirectory, logfile))
+    ):
+        logfile = os.path.join(args.logdirectory, logfile)
+        if args.verbose:
+            print(f"Found log file in the default log directory: '{logfile}'")
+    constraint = parse_constraints(args.constraint, args.loglevel)
+    try:
+        return execute_command_from_args(args, logfile, constraint)
+    except KeyboardInterrupt:  # pragma: no cover
+        # When working in a pipe from stdin must be interrupted w/ a signal
+        return ""
+    except ValueError as e:
+        msg = (
+            f"An error occurred while trying to parse '{logfile}'\n"
+            + "Please ensure that you requested some fields or keys."
+        )
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+    except FileNotFoundError as e:
+        msg = (
+            f"An error occurred while trying to parse '{logfile}'\n"
+            + "Please ensure that the log file name is correct."
+        )
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+    except Exception as e:  # pragma: no cover
+        msg = f"An error occurred while trying to parse '{logfile}'."
+        if args.verbose:
+            msg = f" {msg}\n{e}"
+        return msg
+
+
+def console_scripts_main(args_to_parse=None):
+    """
+    This is the entry point for the setuptools auto generated scripts.
+    Setuptools thinks a return from this function is an error message.
+    """
+    msg = main(args_to_parse)
+    if "An error occurred while trying to parse" in msg:
+        return msg
+    # Regular output already printed line by line.
+    # Returned here only for test purposes when bebug is enabled
+
+
+if __name__ == "__main__":
+    mmsg = console_scripts_main()
+    # Checking the return value to emulate the behavior of the setuptools invoker
+    if mmsg:
+        if mmsg[0] == " ":
+            print(mmsg[1:])
+        exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ changedir = doc/api
 # A better practice is to specify a specific version of sphinx.
 deps =
     sphinx
+    structlog
     m2crypto
 # Everything must be in the dependency or whitelist (* is allowed here)
 whitelist_externals =

--- a/unittests/fixtures/factory/work-dir/glidein.descript
+++ b/unittests/fixtures/factory/work-dir/glidein.descript
@@ -34,4 +34,4 @@ SummaryLogRetentionMaxMBs 	100.0
 CondorLogRetentionMaxDays 	14.0
 CondorLogRetentionMinDays 	3.0
 CondorLogRetentionMaxMBs 	100.0
-ProcessLogs 	[{u'compression': u'', u'extension': u'info', u'min_days': u'3.0', u'msg_types': u'INFO', u'max_days': u'7.0', u'max_mbytes': u'100.0', u'backup_count': u'5'}, {u'compression': u'', u'extension': u'err', u'min_days': u'3.0', u'msg_types': u'DEBUG,ERR,WARN,EXCEPTION', u'max_days': u'7.0', u'max_mbytes': u'100.0', u'backup_count': u'5'}]
+ProcessLogs     [{'backup_count': '5', 'compression': '', 'extension': 'info', 'max_days': '7.0', 'max_mbytes': '100.0', 'min_days': '3.0', 'msg_types': 'INFO', 'comment': None, 'structured': 'False'}, {'backup_count': '5', 'compression': '', 'extension': 'err', 'max_days': '7.0', 'max_mbytes': '100.0', 'min_days': '3.0', 'msg_types': 'DEBUG,ERR,WARN,EXCEPTION', 'comment': None, 'structured': 'False'}]

--- a/unittests/fixtures/frontend/frontend.descript
+++ b/unittests/fixtures/frontend/frontend.descript
@@ -17,7 +17,7 @@ MonitorDisplayText
 MonitorLink
 CondorConfig 	/var/lib/gwms-frontend/vofrontend/frontend.condor_config
 LogDir 	fixtures/frontend/log/gwms-frontend
-ProcessLogs 	[{'comment': None, 'extension': 'all', u'min_days': u'3.0', u'msg_types': u'ALL', u'max_days': u'7.0', u'max_mbytes': u'100.0', 'backup_count': '5', u'compression': u''}, {'comment': None, 'extension': 'all', u'min_days': u'3.0', u'msg_types': u'INFO,ERR,WARN', u'max_days': u'7.0', u'max_mbytes': u'100.0', 'backup_count': '5', u'compression': u''}, {'comment': None, 'extension': 'all', u'min_days': u'3.0', u'msg_types': u'DEBUG', u'max_days': u'7.0', u'max_mbytes': u'100.0', 'backup_count': '5', u'compression': u''}]
+ProcessLogs     [{'backup_count': '5', 'compression': '', 'extension': 'all', 'max_days': '7.0', 'max_mbytes': '100.0', 'min_days': '3.0', 'msg_types': 'ALL', 'comment': None, 'structured': 'False'}, {'backup_count': '5', 'compression': '', 'extension': 'all', 'max_days': '7.0', 'max_mbytes': '100.0', 'min_days': '3.0', 'msg_types': 'INFO,ERR,WARN', 'comment': None, 'structured': 'False'}, {'backup_count': '5', 'compression': '', 'extension': 'all', 'max_days': '7.0', 'max_mbytes': '100.0', 'min_days': '3.0', 'msg_types': 'DEBUG', 'comment': None, 'structured': 'False'}]
 MaxIdleVMsTotal 	1000
 CurbIdleVMsTotal 	200
 MaxIdleVMsTotalGlobal 	1000

--- a/unittests/test_configurations/test_logSupport.yaml
+++ b/unittests/test_configurations/test_logSupport.yaml
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+test_level:
+  log_name: level
+  msg_types: INFO,DEBUG,ERR,WARN
+  extension: level
+  max_days: 1
+  min_days: 0
+  max_mbytes: 1
+
 test_size_rotate:
   log_name: sizeRotate
   msg_types: INFO,DEBUG,ERR,WARN

--- a/unittests/test_logSupport.py
+++ b/unittests/test_logSupport.py
@@ -94,7 +94,7 @@ class TestLogSupport(unittest.TestCase):
             compression=compression,
         )
 
-        return logging.getLogger(log_name), log_dir
+        return logSupport.getLogger(log_name), log_dir
 
     def rotated_log_tests(self, section, log_dir):
         log_file_name = "{}.{}.log".format(

--- a/unittests/worker_scripts/log_writer.py
+++ b/unittests/worker_scripts/log_writer.py
@@ -51,7 +51,7 @@ def main():
             compression=compression,
         )
 
-        log = logging.getLogger(log_name)
+        log = logSupport.getLogger(log_name)
         log.info("%s\n" % create_random_string(length=2048))
 
         return 0

--- a/unittests/worker_scripts/log_writer.py
+++ b/unittests/worker_scripts/log_writer.py
@@ -3,13 +3,12 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import os
 import sys
 
 import yaml
 
-# this shoud be not needed #was-pylint: disable=import-error
+# this should be not needed #was-pylint: disable=import-error
 import glideinwms.lib.logSupport as logSupport
 
 from glideinwms.unittests.unittest_utils import create_random_string
@@ -31,15 +30,16 @@ def main():
         log_name = str(config[section]["log_name"])
         extension = str(config[section]["extension"])
         msg_types = str(config[section]["msg_types"])
-        max_days = float(config[section]["max_days"])
-        min_days = float(config[section]["min_days"])
-        max_mbytes = float(config[section]["max_mbytes"])
+        max_days = int(float(config[section]["max_days"]))
+        min_days = int(float(config[section]["min_days"]))
+        max_mbytes = int(float(config[section]["max_mbytes"]))
         backupCount = 5
         compression = ""
+        structured = False
 
-        log_dir = "/tmp/%s" % log_name
+        log_dir = os.path.join("/tmp", log_name)
 
-        logSupport.add_processlog_handler(
+        handler = logSupport.get_processlog_handler(
             log_name,
             log_dir,
             msg_types,
@@ -50,9 +50,13 @@ def main():
             backupCount=backupCount,
             compression=compression,
         )
+        if structured:
+            log = logSupport.get_structlog_logger(log_name)
+        else:
+            log = logSupport.get_logging_logger(log_name)
+        log.addHandler(handler)
 
-        log = logSupport.getLogger(log_name)
-        log.info("%s\n" % create_random_string(length=2048))
+        log.info(f"{create_random_string(length=2048)}\n")
 
         return 0
     except:


### PR DESCRIPTION
Added changes to support structured logs:
- using structlog https://www.structlog.org/en/stable/
- added supporting functions and structlog configuration in `logSupport`
- consolidated log and handlers configuration and set up
- updated all files using the framework loggers
- added configuration knobs
- added documentation

Structured logs are disabled by default to ease the transition. They can be enabled by adding `structured="True"` to the configuration of the logs (`process_log` sections in the Factory and Frontend configurations)

Added also some general improvements: cleanup of comments and docstrings, consolidation of `util.is_true()`, and fixed a couple of small bugs.

The first commits are by @MissAnita2

This PR replaces PR #327 because GitHub got confused from the rebase eliminating the HTML files changes.
And that PR replaced Anita's PR #325 because I reverted once the automatic unrelated changes to all HTML files and was unable to force-update when they were re-applied

Suggestions from @namrathaurs review of PR #327 have been applied