### PR TITLE
Fixed node validation and added case insensitive gconfig_get

### DIFF
--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -36,6 +36,7 @@ PSPID="$(command -v ps) -q"
 # Return the value stored in glidein_config
 #  1: id (key) of the value to retrieve;
 #  2(opt): path of the config file ("$glidein_config" by default)
+#  3(opt): options for grep (e.g. -i for case insensitive)
 # Counting on $glidein_config if $2 not provided
 # compatible w/: grep "^$1 " "$glidein_config" | cut -d ' ' -f 2-
 # different form previous: grep "^$1 " "$glidein_config" | awk '{print $2}' (was trimming and returning 1st word, not rest of line)
@@ -43,9 +44,10 @@ PSPID="$(command -v ps) -q"
 gconfig_get() {
     local config_file=${2:-$glidein_config}
     [[ -z "${config_file}" ]] && { warn "Error: glidein_config not provided and glidein_config variable not defined. Forcing exit."; exit 1; }
+    [[ -n "$3" && ! "$3" = \-* ]] && { warn "Error: gconfig_get 3rd parameter must start with '-' Forcing exit."; exit 1; }
     [[ -r "$config_file" ]] || { true; return; }
     # Leave the extra space in the grep, to parse correctly strings w/ the same beginning
-    $TAC "$config_file" | grep -m1 "^$1 " | cut -d ' ' -f 2-
+    $TAC "$config_file" | grep -m1 $3 "^$1 " | cut -d ' ' -f 2-
 }
 
 gconfig_log_name() {

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -3,12 +3,9 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
+# Description:
+#   Base script of the Glidein (pilot job)
+#   This scripts runs all the others
 
 # default IFS, to protect against unusual environment, better than "unset IFS" because works with restoring old one
 IFS=$' \t\n'
@@ -479,16 +476,16 @@ glidein_exit() {
   final_result_long=$(simplexml2longxml "${final_result_simple}" "${global_result}")
 
   if [ "$1" -ne 0 ]; then
-      report_failed=$(grep -i "^GLIDEIN_Report_Failed " "${glidein_config}" | cut -d ' ' -f 2-)
+      report_failed=$(gconfig_get GLIDEIN_Report_Failed "${glidein_config}" "-i")
 
       if [ -z "${report_failed}" ]; then
           report_failed="NEVER"
       fi
 
-      factory_report_failed=$(grep -i "^GLIDEIN_Factory_Report_Failed " "${glidein_config}" | cut -d ' ' -f 2-)
+      factory_report_failed=$(gconfig_get GLIDEIN_Factory_Report_Failed "${glidein_config}" "-i")
 
       if [ -z "${factory_report_failed}" ]; then
-          factory_collector=$(grep -i "^GLIDEIN_Factory_Collector " "${glidein_config}" | cut -d ' ' -f 2-)
+          factory_collector=$(gconfig_get GLIDEIN_Factory_Collector "${glidein_config}" "-i")
           if [ -z "${factory_collector}" ]; then
               # no point in enabling it if there are no collectors
               factory_report_failed="NEVER"
@@ -516,7 +513,7 @@ glidein_exit() {
 
       add_config_line "GLIDEIN_FAILURE_REASON" "Glidein failed while running ${ge_last_script_name}. Keeping node busy until ${dl} (${dlf})."
 
-      condor_vars_file="$(grep -i "^CONDOR_VARS_FILE " "${glidein_config}" | cut -d ' ' -f 2-)"
+      condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "${glidein_config}" "-i")
       if [ -n "${condor_vars_file}" ]; then
          # if we are to advertise, this should be available... else, it does not matter anyhow
          add_condor_vars_line "GLIDEIN_ADVERTISE_ONLY" "C" "True" "+" "Y" "Y" "-"
@@ -1450,7 +1447,7 @@ fetch_file_try() {
     if [[ "${fft_config_check}" != "TRUE" ]]; then
         # TRUE is a special case, always downloaded and processed
         local fft_get_ss
-        fft_get_ss=$(grep -i "^${fft_config_check} " glidein_config | cut -d ' ' -f 2-)
+        fft_get_ss=$(gconfig_get "${fft_config_check}" glidein_config "-i")
         # Stop download and processing if the cond_attr variable is not defined or has a value different from 1
         [[ "${fft_get_ss}" != "1" ]] && return 0
         # TODO: what if fft_get_ss is not 1? nothing, still skip the file?
@@ -1461,7 +1458,7 @@ fetch_file_try() {
     if [[ "${fft_base_name}" = gconditional_* ]]; then
         fft_condition_attr="${fft_base_name#gconditional_}"
         fft_condition_attr="GLIDEIN_USE_${fft_condition_attr%%_*}"
-        fft_condition_attr_val=$(grep -i "^${fft_condition_attr} " glidein_config | cut -d ' ' -f 2-)
+        fft_condition_attr_val=$(gconfig_get "${fft_condition_attr}" glidein_config "-i")
         # if the variable fft_condition_attr is not defined or empty, do not download
         [[ -z "${fft_condition_attr_val}" ]] && return 0
     fi

--- a/creation/web_base/script_wrapper.sh
+++ b/creation/web_base/script_wrapper.sh
@@ -3,10 +3,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
 # Description:
 #   Helper script to wrap periodically executed scripts
 #   This script will allow periodic script to be similar to the

--- a/creation/web_base/validate_node.sh
+++ b/creation/web_base/validate_node.sh
@@ -3,12 +3,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This script checks that the node is in good shape
 #
@@ -20,15 +14,15 @@ function check_df {
     chdf_reqmbs=$2
     chdf_id=$3
 
-    free=`df -kP $chdf_dir | awk '{if (NR==2) print $4}'`
-    let "chdf_reqkbs=$chdf_reqmbs * 1024"
-    if [ $free -lt $chdf_reqkbs ]; then
+    free=$(df -kP "$chdf_dir" | awk '{if (NR==2) print $4}')
+    ((chdf_reqkbs=chdf_reqmbs * 1024)) || true
+    if [[ $free -lt $chdf_reqkbs ]]; then
         #echo "Space on '$chdf_dir' not enough." 1>&2
         #echo "At least $chdf_reqmbs MBs required, found $free KBs" 1>&2
         STR="Space on '$chdf_dir' not enough.\n"
         STR+="At least $chdf_reqmbs MBs required, found $free KBs"
-	STR1=`echo -e "$STR"`
-        "$error_gen" -error "validate_node.sh" "WN_Resource" "$STR1" ${chdf_id}FreeKb $free  ${chdf_id}MinKb ${chdf_reqkbs}
+        STR1=$(echo -e "$STR")
+        "$error_gen" -error "validate_node.sh" "WN_Resource" "$STR1" "${chdf_id}FreeKb" "$free"  "${chdf_id}MinKb" "${chdf_reqkbs}"
         exit 1
     fi
 
@@ -41,23 +35,23 @@ function check_quotas {
     chq_reqmbs=$2
     chq_id=$3
 
-    fs=`df -kP $chq_dir | awk '{if (NR==2) print $1}'`
-    myquotastr=`quota 2>/dev/null | awk '{if (NR>2) {if (NF==1) {n=$1; getline; print n " " $2-$1} else {print $1 " " $3-$2}}}' |grep $fs`
-    if [ $? -eq 0 ]; then
-	# check only if there are any quotas, else ignore
-	myquota=`echo $myquotastr|awk '{print $2}'`
-	let "blocks=$chdf_reqmbs * 1024 * 2"
-	if [ $myquota -lt $blocks ]; then
+    fs=$(df -kP "$chq_dir" | awk '{if (NR==2) print $1}')
+    myquotastr=$(quota 2>/dev/null | awk '{if (NR>2) {if (NF==1) {n=$1; getline; print n " " $2-$1} else {print $1 " " $3-$2}}}' |grep $fs)
+    if [[ $? -eq 0 ]]; then
+        # check only if there are any quotas, else ignore
+        myquota=$(echo $myquotastr|awk '{print $2}')
+        ((blocks=chdf_reqmbs * 1024 * 2))  || true
+        if [[ $myquota -lt $blocks ]]; then
             #echo "Quota on '$chdf_dir' too small." 1>&2
             #echo "At least $chdf_reqmbs MBs required, found $myquota blocks" 1>&2
             STR="Quota on '$chdf_dir' too small.\n"
             STR+="At least $chdf_reqmbs MBs required, found $myquota blocks"
-	    STR1=`echo -e "$STR"`
-            "$error_gen" -error "validate_node.sh" "WN_Resource" "$STR1" ${chq_id}FreeBlocks $blocks ${chq_id}QuotaBlocks $myquota
-	    exit 1
-	fi
-	let "myquotakb=$myquota / 2"
-	metrics+=" ${chq_id}QuotaKb $myquotakb"
+            STR1=$(echo -e "$STR")
+            "$error_gen" -error "validate_node.sh" "WN_Resource" "$STR1" "${chq_id}FreeBlocks" "$blocks" "${chq_id}QuotaBlocks" "$myquota"
+            exit 1
+        fi
+        ((myquotakb=myquota / 2)) || true
+        metrics+=" ${chq_id}QuotaKb $myquotakb"
     fi
 
     return 0
@@ -73,7 +67,7 @@ function check_quotas {
 config_file="$1"
 
 # import add_config_line and add_condor_vars_line functions
-add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$config_file" | cut -d ' ' -f 2-)
 # shellcheck source=./add_config_line.source
 . "$add_config_line_source"
 
@@ -82,37 +76,36 @@ error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 #
 # Check space on current directory
 #
-reqgbs=`grep -i "^MIN_DISK_GBS " "$config_file" | cut -d ' ' -f 2-`
-if [ -n "$reqgbs" ]; then
- # can only check if defined
- let "reqmbs=$reqgbs * 1024"
+reqgbs=$(gconfig_get MIN_DISK_GBS "$config_file" "-i")
+if [[ -n "$reqgbs" ]]; then
+    # can only check if defined
+    ((reqmbs=reqgbs * 1024)) || true
 
- check_df . $reqmbs "Cwd"
+    check_df . "$reqmbs" "Cwd"
 
- reqquotas=`grep -i "^CHECK_QUOTA " "$config_file" | cut -d ' ' -f 2-`
- if [ "$reqquotas" == "1" ]; then
-    check_quotas . $reqmbs "Cwd"
- fi
+    reqquotas=$(gconfig_get CHECK_QUOTA "$config_file" "-i")
+    if [[ "$reqquotas" == "1" ]]; then
+        check_quotas . "$reqmbs" "Cwd"
+    fi
 fi
 
 #
-# Check availablity of /tmp
+# Check availability of /tmp
 #
 
 # check there is at least a few megs of space free
 check_df /tmp 10 "Tmp"
 
 # and that I can create a temo dir in it
-tmp_dir=`mktemp -d "/tmp/wmsglide_XXXXXX"`
-if [ $? -ne 0 ]; then
+if ! tmp_dir=$(mktemp -d "/tmp/wmsglide_XXXXXX"); then
     #echo "Cannot create a dir in /tmp" 1>&2
     STR="Cannot create a dir in /tmp"
     "$error_gen" -error "validate_node.sh" "WN_Resource" "$STR" "TmpWritable" "False"
     exit 1
 fi
 
-rmdir $tmp_dir
+rmdir "$tmp_dir"
 metrics+=" TmpWritable True"
 
-"$error_gen"  -ok "validate_node.sh" $metrics
+"$error_gen"  -ok "validate_node.sh" "$metrics"
 exit 0


### PR DESCRIPTION
Fixed node validation, was not reading the glidein_config due to a wrong variable name
This was noted by @namrathaurs in PR #245. Moving it here because is a bug that needs to be fixed in the main branch

Added also a case-insensitive option for gconfig_get()
gconfig_get VAR FILE GREP_OPTIONS
e.g. `gconfig_get GLIDEIN_Report_Failed "${glidein_config}" "-i"`
And I fixed some files that were still using grep+cut because of case-insensitivity