### PR TITLE
Updated CI to use requirements.txt and fix flagged issues

### DIFF
--- a/build/ci/utils.sh
+++ b/build/ci/utils.sh
@@ -210,7 +210,13 @@ setup_python3_venv() {
         pip_packages="$pip_packages ${HYPOTHESIS} ${AUTOPEP8} ${TESTFIXTURES}"
         pip_packages="$pip_packages ${HTCONDOR} ${JSONPICKLE} ${M2CRYPTO}"
 
-        # TODO: load the list from requirements.txt
+        # TODO: clean above here and the variables above once load from requirements.txt is tested and reliable
+
+        pip_packages=""
+        while read -r line; do
+            [[ "$line" = "#"* ]] && continue
+            pip_packages="$pip_packages ${line}"
+        done < "${GLIDEINWMS_SRC}/requirements.txt"
 
         # Uncomment to troubleshoot setup:  loginfo "$(log_python)"
 

--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -665,7 +665,7 @@ def spawn(
                     logSupport.log.exception("Error occurred processing the globals classads: ")
 
             logSupport.log.info("Checking EntryGroups %s" % list(childs.keys()))
-            for group in childs:
+            for group in list(childs):  # making a copy of the keys because the dict is being modified in the loop
                 entry_names = ":".join(entry_groups[group])
                 child = childs[group]
 

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -482,12 +482,13 @@ def update_x509_proxy_file(entry_name, username, client_id, proxy_data, factoryC
     #  Since dn and voms are extracted, should they be used in a log message or the file name?
     dn = ""
     voms = ""
+    tempfilename = ""
     try:
         (f, tempfilename) = tempfile.mkstemp()
         os.write(f, proxy_data)
         os.close(f)
     except:
-        logSupport.log.error("Unable to create tempfile %s!" % tempfilename)
+        logSupport.log.error(f"Unable to create tempfile '{tempfilename}'!")
 
     try:
         dn = x509Support.extract_DN(tempfilename)  # not really used

--- a/factory/glideFactoryMonitorAggregator.py
+++ b/factory/glideFactoryMonitorAggregator.py
@@ -166,7 +166,7 @@ def aggregateStatus(in_downtime):
 
     # initialize the RRD dictionary, so it gets created properly
     val_dict = {}
-    for tp in list(global_total.keys()):
+    for tp in global_total:
         # values (RRD type) - Status or Requested
         if not (tp in list(status_attributes.keys())):
             continue
@@ -216,26 +216,27 @@ def aggregateStatus(in_downtime):
             nr_entries += 1
             status["entries"][entry]["total"] = entry_data["total"]
 
-            for w in global_total:
+            for w in list(global_total):  # making a copy of the keys because the dict is being modified (keys are not!)
                 tel = global_total[w]
                 if w not in entry_data["total"]:
                     continue
                 el = entry_data["total"][w]
                 if tel is None:
                     # new one, just copy over
-                    global_total[w] = {}
-                    tel = global_total[w]
+                    tel = {}
                     for a in el:
-                        tel[a] = int(el[a])  # coming from XML, everything is a string
+                        # coming from XML, everything is a string
+                        tel[a] = int(el[a])
+                    global_total[w] = tel
                 else:
                     # successive, sum
                     for a in el:
-                        if a in tel:
-                            tel[a] += int(el[a])
+                        if a in tel:  # pylint: disable=unsupported-membership-test
+                            tel[a] += int(el[a])  # pylint: disable=unsupported-assignment-operation
                     # if any attribute from prev. frontends is not in the current one, remove from total
                     for a in list(tel):  # making a copy of the keys because the dict is being modified
                         if a not in el:
-                            del tel[a]
+                            del tel[a]  # pylint: disable=unsupported-delete-operation
                             tmp_list_removed.append(a)
                     if tmp_list_removed:
                         logSupport.log.debug(
@@ -309,7 +310,9 @@ def aggregateStatus(in_downtime):
             for a in tel:  # pylint: disable=not-an-iterable
                 if a in avgEntries:
                     # since all entries must have this attr to be here, just divide by nr of entries
-                    tel[a] = tel[a] // nr_entries
+                    tel[a] = (
+                        tel[a] // nr_entries
+                    )  # pylint: disable=unsupported-assignment-operation,unsubscriptable-object
 
     # do average for per-fe stat--'InfoAge' only
     for fe in list(status_fe["frontends"].keys()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,10 @@ pyjwt
 
 #for verifications
 pylint
-pycodestyle
+#pylint==2.7.1  # TODO: Remove this lock when https://github.com/PyCQA/pylint/issues/3624 is solved
 astroid
+#astroid==2.5.0  # Required by pylint 2.7.1 TODO: Remove this lock along with the above lock
+pycodestyle
 hypothesis
 autopep8
 testfixtures
@@ -20,6 +22,7 @@ future
 # std in p3 argparse
 pyyaml
 PyJWT
+toml
 
 # for tests
 jsonpickle

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,13 @@ toxworkdir = {toxinidir}/.tox/build
 # Do not build the package
 skipsdist=True
 
+[pycodestyle]
+count = False
+#ignore = E226,E302,E71
+max-line-length = 120
+statistics = True
+
+
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 basepython = python3

--- a/unittests/test_lib_fork.py
+++ b/unittests/test_lib_fork.py
@@ -84,12 +84,12 @@ def sleep_fn(sleep_tm=None):
 
 class TestForkResultError(unittest.TestCase):
     def test___init__(self):
+        fork_result_error = "FAILED"
         try:
             fork_result_error = ForkResultError(nr_errors=1, good_results=None, failed=1)
         except ForkResultError as err:
             self.assertEqual("", str(err))
             self.assertEqual("", str(fork_result_error))
-
         return
 
 


### PR DESCRIPTION
GWMS CI (runtest.sh and util.sh) was not using requirements.txt and had outdated requirements.
Updated to use that file and fixed new errors flagged by pycodestyle.
A couple are about a dictionary being changed in a loop, which are strange because the keys are not changed. Probably the assignment `d[key] = val` cannot be evaluated to know that key is an existing one.

Urgent PR. then rebase the remaining ones to avoid linting errors