### PR TITLE
Fix for rrdtool bindings crash when file is missing in EL9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes since the last release
 -   Populate missing Entry parameters for ARC CEs submissions (PR #304)
 -   Modified the usage of subprocess module, for building/rebuilding cvmfsexec distributions, only when necessary (PR #309)
 -   manual_glidein_submit now correctly sets idtokens in the EncryptedInputFiles (issue #283, PR #284)
+-   Fixed fetch_rrd crash in EL9 causing missing monitoring and glidefactoryclient classad information (Issue #338, PR #339)
 
 ### Testing / Development
 
@@ -38,8 +39,6 @@ Changes since the last release
 
 -   When generating cvmfsexec distribution for el9 machine type on an el7 machine, the factory reconfig and/or upgrade fails as a result of an error in `create_cvmfsexec_distros.sh`. This is possibly due to the tools for el7 being unable to handle el9 files (as per Dave Dykstra). Please exercise caution if using `rhel9-x86_64` in the `mtypes` list for the `cvmfsexec_distro` tag in factory configuration.
     -   Our workaround: the el9 machine type has been removed from the default list of machine types supported by the custom distros creation script (PR #312)
--   Installing the factory on Alma9 results in missing monitoring and glidefactoryclient classad. As a consequence of this, the Factory continued to submit pilots since it was not aware of the submitted pilots. See Issue #338 for the technical details.
-    -   Our workaround: added a check to test if the rrd file under question exists. If the file is non-existent, fetching the rrd file will be skipped.
 
 ## v3.10.2 \[2023-5-10\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Changes since the last release
 
 -   When generating cvmfsexec distribution for el9 machine type on an el7 machine, the factory reconfig and/or upgrade fails as a result of an error in `create_cvmfsexec_distros.sh`. This is possibly due to the tools for el7 being unable to handle el9 files (as per Dave Dykstra). Please exercise caution if using `rhel9-x86_64` in the `mtypes` list for the `cvmfsexec_distro` tag in factory configuration.
     -   Our workaround: the el9 machine type has been removed from the default list of machine types supported by the custom distros creation script (PR #312)
+-   Installing the factory on Alma9 results in missing monitoring and glidefactoryclient classad. As a consequence of this, the Factory continued to submit pilots since it was not aware of the submitted pilots. See Issue #338 for the technical details.
+    -   Our workaround: added a check to test if the rrd file under question exists. If the file is non-existent, fetching the rrd file will be skipped.
 
 ## v3.10.2 \[2023-5-10\]
 

--- a/lib/rrdSupport.py
+++ b/lib/rrdSupport.py
@@ -465,9 +465,12 @@ class BaseRRDSupport:
             args.append(str(daemon))
 
         if os.path.exists(filename):
-            return self.rrd_obj.fetch(*args)
+            try:
+                return self.rrd_obj.fetch(filename)
+            except Exception as e:
+                raise RuntimeError(f"Error when running rrdtool.fetch") from e
         else:
-            raise FileNotFoundError(f"File {filename} does not exist. Skipping...")
+            raise RuntimeError(f"RRD file '{filename}' does not exist. Failing fetch_rrd.")
 
     def verify_rrd(self, filename, expected_dict):
         """

--- a/lib/rrdSupport.py
+++ b/lib/rrdSupport.py
@@ -464,7 +464,10 @@ class BaseRRDSupport:
             args.append("--daemon")
             args.append(str(daemon))
 
-        return self.rrd_obj.fetch(*args)
+        if os.path.exists(filename):
+            return self.rrd_obj.fetch(*args)
+        else:
+            raise FileNotFoundError(f"File {filename} does not exist. Skipping...")
 
     def verify_rrd(self, filename, expected_dict):
         """


### PR DESCRIPTION
**Partially** fixes issue #338.

Title was: "Workaround for the existing handling of rrdtool bindings", but this code fixes the problem.
A workaround would have been to disable the bindings.