### PR TITLE
Add an option to clear conflicting variables in containers environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release provides full functionality in EL9 and Python 3.9. Changes since th
 -   Add option to set xml output directory in OSG_autoconf (PR #319)
 -   Allow OSG_autoconf to skip sites or CEs that are not present in the OSG collector (PR #315)
 -   Add option to set num_factories in OSG_autoconf (Issue #344, PR #345)
--   Added the ability to clear a list of variables from the environment via GLIDEIN_CONTAINER_ENV_CLEARLIST before starting a container (PR #342)
+-   Added the ability to clear a list of variables from the environment via GLIDEIN_CONTAINER_ENV_CLEARLIST before starting a container (Issue #341, PR #342)
 
 ### Changed defaults / behaviours
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ## v3.10.3 \[2023-6-15\]
 
-Changes since the last release
+This release provides full functionality in EL9 and Python 3.9. Changes since the last release
 
 ### New features / functionalities
 
@@ -13,7 +13,8 @@ Changes since the last release
 -   Added structured logging. It is a hybrid format with some fields followed by a JSON dictionary. The exact format of the messages may change in the future, and we plan for it to become the default. Now it is disabled by default. Add `structured="True"` to all `<process_log>` elements (PR #333)
 -   Add option to set xml output directory in OSG_autoconf (PR #319)
 -   Allow OSG_autoconf to skip sites or CEs that are not present in the OSG collector (PR #315)
--   Add option to set num_factories in OSG_autoconf (PR #345)
+-   Add option to set num_factories in OSG_autoconf (Issue #344, PR #345)
+-   Added the ability to clear a list of variables from the environment via GLIDEIN_CONTAINER_ENV_CLEARLIST before starting a container (PR #342)
 
 ### Changed defaults / behaviours
 

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -744,13 +744,16 @@ env_clear() {
             env_clear_one ${i}
         done
     fi
+    echo "${singularity_opts}"
+}
+
+env_clearlist() {
     if [[ -n "$GLIDEIN_CONTAINER_ENV_CLEARLIST" ]]; then
         #local IFS=,  # Default "\t\t\"", changed from here to end of function
         for i in ${GLIDEIN_CONTAINER_ENV_CLEARLIST//,/ } ; do
             env_clear_one "${i}"
         done
     fi
-    echo "${singularity_opts}"
 }
 
 
@@ -925,6 +928,9 @@ env_restore() {
             export ${i}="${!varname}"
         done
     fi
+}
+
+env_restorelist() {
     if [[ -n "$GLIDEIN_CONTAINER_ENV_CLEARLIST"  ]]; then
         #local IFS=,  # Default "\t\t\"", changed from here to end of function
         for i in ${GLIDEIN_CONTAINER_ENV_CLEARLIST//,/ } ; do
@@ -2044,6 +2050,7 @@ ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
 
     # Add --clearenv if requested
     GWMS_SINGULARITY_EXTRA_OPTS=$(env_clear "${GLIDEIN_CONTAINER_ENV}" "${GWMS_SINGULARITY_EXTRA_OPTS}")
+    env_clearlist
 
     # If there is clearenv protect the variables (it may also have been added by the custom Singularity options)
     if env_gets_cleared "${GWMS_SINGULARITY_EXTRA_OPTS}"; then
@@ -2065,6 +2072,8 @@ ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
     # Continuing here only if exec of singularity failed
     GWMS_SINGULARITY_REEXEC=0
     env_restore "${GLIDEIN_CONTAINER_ENV}"
+    env_restorelist
+
     # Restoring paths that are always cleared before invoking Singularity,
     # may contain something used for error communication
     [[ -n "$old_path" ]] && PATH=$old_path

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2557,6 +2557,18 @@ MAX_STARTD_LOG          I       10000000        +                               
               </p>
             </td>
           </tr>
+          <tr>
+            <td><b>GLIDEIN_CONTAINER_ENV_CLEARLIST</b></td>
+            <td>String</td>
+            <td></td>
+            <td>Frontend Factory</td>
+            <td>
+              <p>
+                Comma separated list of environment variable names that should
+                be cleared before starting the container
+              </p>
+            </td>
+          </tr>
         </table>
       </div>
 

--- a/test/bats/creation_web_base_singularity_lib.bats
+++ b/test/bats/creation_web_base_singularity_lib.bats
@@ -162,7 +162,7 @@ dit() { echo "TEST:<$1><$2><$3>"; }
 
 @test "Verify env_process_options" {
     local envoptions=
-    [ "$(env_process_options $envoptions)" = "clearpath" ]  # Default is 'clearpath'
+    [ "$(env_process_options $envoptions)" = "clearpaths" ]  # Default is 'clearpaths'
     [[ ",$(env_process_options clear)," = *",clearall,gwmsset,osgset,condorset,"* ]] || false  # clear substitution
     [[ ",$(env_process_options aaa,osgset)," = *",condorset,"* ]] || false  # osgset implies condorset
     [[ ",$(env_process_options aaa,osgset)," = *",gwmsset,"* ]] || false  # osgset implies gwmsset
@@ -246,7 +246,7 @@ preset_env() {
     preset_env
     env_preserve
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"
-    [ $count_env_sing -eq 13 ]  # default is clearpath, GWMS set is preserved
+    [ $count_env_sing -eq 13 ]  # default is clearpaths, GWMS set is preserved
     preset_env
     env_preserve gwmsset
     count_env_sing="$(env -0 | tr '\n' '\\n' | tr '\0' '\n' | tr '=' ' ' | awk '{print $1;}' | grep ^SINGULARITYENV_ | wc -l)"

--- a/test/bats/creation_web_base_singularity_lib.bats
+++ b/test/bats/creation_web_base_singularity_lib.bats
@@ -179,6 +179,37 @@ dit() { echo "TEST:<$1><$2><$3>"; }
 }
 
 
+@test "Verify env_clearlist" {
+    VAR1=value1
+    export VAR2="complex var, with_spaces"
+    unset VAR3
+    #export GWMS_OLDENV_VAR1=simplevar
+    #export GWMS_OLDENV_VAR2="complex var, with_spaces"
+    # GWMS_OLDENV_VAR3 missing on purpose
+    env_clearlist VAR1,VAR2,VAR3
+    [ -n "${GWMS_OLDENV_VAR1+x}" ]
+    [ -n "${GWMS_OLDENV_VAR2+x}" ]
+    [ "$GWMS_OLDENV_VAR2" = "complex var, with_spaces" ]
+    [ -z "${GWMS_OLDENV_VAR3+x}" ]
+}
+
+
+@test "Verify env_restorelist" {
+    unset VAR1
+    unset VAR2
+    unset VAR3
+    export GWMS_OLDENV_VAR1=simplevar
+    export GWMS_OLDENV_VAR2="complex var, with_spaces"
+    unset GWMS_OLDENV_VAR3
+    # GWMS_OLDENV_VAR3 missing on purpose
+    env_restorelist VAR1,VAR2,VAR3
+    [ -n "${VAR1+x}" ]
+    [ -n "${VAR2+x}" ]
+    [ "$VAR2" = "complex var, with_spaces" ]
+    [ -z "${VAR3+x}" ]
+}
+
+
 @test "Verify env_restore" {
     # Restoring PATH, LD_LIBRARY_PATH, PYTHONPATH
     unset PATH


### PR DESCRIPTION
Using the env variable GLIDEIN_CONTAINER_ENV_CLEARLIST to clear env variables. 
Fixes #341