### PR TITLE
Fix rrdtool fetch call

### DIFF
--- a/lib/rrdSupport.py
+++ b/lib/rrdSupport.py
@@ -466,7 +466,7 @@ class BaseRRDSupport:
 
         if os.path.exists(filename):
             try:
-                return self.rrd_obj.fetch(filename)
+                return self.rrd_obj.fetch(*args)
             except Exception as e:
                 raise RuntimeError(f"Error when running rrdtool.fetch") from e
         else:


### PR DESCRIPTION
Fetch should be called with all the command line arguments, not only the file name.
This error was introduced in v3.10.3 (PR #339)
Fixes #351