### PR TITLE
Fixed alt code still using python (ie python2) interpreter

### DIFF
--- a/creation/web_base/b64uuencode.source
+++ b/creation/web_base/b64uuencode.source
@@ -3,17 +3,41 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+get_python() {
+    local py_command
+    if command -v python3 > /dev/null 2>&1; then
+        py_command="python3"
+    elif command -v python > /dev/null 2>&1; then
+        py_command="python"
+    elif command -v python2 > /dev/null 2>&1; then
+        py_command="python2"
+    elif command -v gwms-python > /dev/null 2>&1; then
+        py_command="gwms-python"
+    else
+        return 1
+    fi
+    echo "$py_command"
+}
+
+# maxsize controls the line length
+# was 45, changed to 57 (76 chars per line), this is the standard uuencode -m behavior
+# TODO: Should failure return an empty encoding instead of the invalid error message?
 python_b64uuencode() {
     echo "begin-base64 644 -"
-    python -c 'import binascii, sys
-fd = sys.stdin
-buf = fd.read()
-idx, size, maxsize = 0, len(buf), 45
+    if py_command=$(get_python); then
+        $py_command -c 'from __future__ import print_function
+import binascii, sys
+fdb=getattr(sys.stdin, "buffer", sys.stdin)
+buf = fdb.read()
+idx, size, maxsize = 0, len(buf), 57
 while size > maxsize:
-    print binascii.b2a_base64(buf[idx:idx+maxsize]),;
+    print(binascii.b2a_base64(buf[idx:idx+maxsize]).decode(), end="");
     idx += maxsize;
     size -= maxsize;
-print binascii.b2a_base64(buf[idx:]),'
+print(binascii.b2a_base64(buf[idx:]).decode(), end="")'
+    else
+        echo "ERROR_FAILED_ENCODING"
+    fi
     echo "====" }
 }
 

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -100,14 +100,15 @@ log_init_tokens() {
 
     declare -A tokens_arr
     for recip in "${recipients[@]}"; do
-        local recip_dir="$(grep "^${recip} " url_dirs.desc | cut -d ' ' -f 2-)"
+        local recip_dir
+        recip_dir="$(grep "^${recip} " url_dirs.desc | cut -d ' ' -f 2-)"
         local vofe_token_name="TODO"    # TODO: get the name of the frontend + group
         if [ -f "tokens/${recip_dir}/${vofe_token_name}" ]; then
             # Use the token signed by the frontend
             tokens_arr["${recip}"]=$(cat tokens/${recip_dir}/${vofe_token_name}.jwt)
         elif [ -f "tokens/${recip_dir}/default.jwt" ]; then
             # Use the token signed by the factory
-            tokens_arr["${recip}"]=$(cat tokens/${recip_dir}/default.jwt)
+            tokens_arr["${recip}"]=$(cat tokens/"${recip_dir}"/default.jwt)
         else
             warn "log_init_tokens: could not find any valid token for ${recip}"
             # TODO: maybe fail only for this recipient, still serving the others?
@@ -246,8 +247,20 @@ json_escape() {
     # Escape json special characters
     # Arguments:
     #   1: text to escape
-
-    qstr="$(printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+    local py_command
+    if command -v python3 > /dev/null 2>&1; then
+        py_command="python3"
+    elif command -v python > /dev/null 2>&1; then
+        py_command="python"
+    elif command -v python2 > /dev/null 2>&1; then
+        py_command="python2"
+    elif command -v gwms-python > /dev/null 2>&1; then
+        py_command="gwms-python"
+    else
+        echo ERROR_UNABLE_TO_ESCAPE
+    fi
+    # print() with 1 argument OK also for python2, no need for from __future__ import print_function;
+    qstr="$(printf '%s' "$1" | "$py_command" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
     # Remove unwanted outer double quotes
     qstr="${qstr%\"}"
     qstr="${qstr#\"}"
@@ -284,7 +297,8 @@ log_write() {
 
     # Source encoding utilities
     b64uuencode_source=$(gconfig_get B64UUENCODE_SOURCE "${glidein_config}")
-    source "${b64uuencode_source}"
+    # shellcheck source=./b64uuencode.source
+    . "${b64uuencode_source}"
 
     # Argument $1 (invoker)
     invoker="$1"

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -303,21 +303,22 @@ list_get_intersection() {
     # Valid values: rhelNN, default
     local intersection
     [[ -z "$1"  ||  -z "$2" ]] && return 1
-    if [[ "x$1" = "xany" ]]; then
+    if [[ "$1" = "any" ]]; then
         intersection="$2"
     else
-        if [[ "x$2" = "xany" ]]; then
+        if [[ "$2" = "any" ]]; then
             intersection="$1"
         else
             local cmd
-            # desired_os="$(python -c "print sorted(list(set('$2'.split(',')).intersection('$1'.split(','))))[0]" 2>/dev/null)"
-            if cmd=$(command -v python2 2>/dev/null); then
+            if cmd=$(command -v python3 2>/dev/null); then
+                intersection="$($cmd -c "print(','.join(sorted(list(set('$2'.split(',')).intersection('$1'.split(','))))))" 2>/dev/null)"
+            elif cmd=$(command -v python2 2>/dev/null); then
                 intersection="$($cmd -c "print ','.join(sorted(list(set('$2'.split(',')).intersection('$1'.split(',')))))" 2>/dev/null)"
-            elif cmd=$(command -v python3 2>/dev/null); then
+            elif cmd=$(command -v python 2>/dev/null); then
                 intersection="$($cmd -c "print(','.join(sorted(list(set('$2'.split(',')).intersection('$1'.split(','))))))" 2>/dev/null)"
             else
-                # no valid python found
-                warn "Python (python2/python3) not found. Returning empty intersection"
+                # no valid Python found
+                warn "Python (python3/python2/python) not found. Returning empty intersection"
                 return 1
             fi
         fi


### PR DESCRIPTION
Fixed alt code still using python (i.e. python2) interpreter
There were some alternative routines (for jq in logging) and for base64  in a couple of places, using python code when the shell utility was not available.
Now the code is compatible w/ both python2 and python3 and the invocation also looks first for python3 and then for python2.