### PR TITLE
Workaround for EL7 PyJWT generating bytes instead of str

### DIFF
--- a/factory/glideFactory.py
+++ b/factory/glideFactory.py
@@ -233,7 +233,7 @@ def generate_log_tokens(startup_dir, glideinDescript):
             # Obtain a legal filename from the url, escaping "/" and other tricky symbols
             recipient_safe_url = urllib.parse.quote(recipient_url, "")
 
-            # Generate the token
+            # Generate the monitoring token
             # TODO: in the future must include Frontend tokens as well
             factory_token = "default.jwt"
             token_name = factory_token
@@ -259,6 +259,11 @@ def generate_log_tokens(startup_dir, glideinDescript):
                 "nbf": curtime - 300,
             }
             token = jwt.encode(token_payload, secret, algorithm="HS256")
+            # TODO: PyJWT bug workaround. Remove this conversion once affected PyJWT is no more around
+            #  PyJWT in EL7 (PyJWT <2.0.0) has a bug, jwt.encode() is declaring str as return type, but it is returning bytes
+            #  https://github.com/jpadilla/pyjwt/issues/391
+            if isinstance(token, bytes):
+                token = token.decode("UTF-8")
             try:
                 # Write the factory token
                 with open(token_filepath, "w") as tkfile:

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -1,16 +1,13 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
-#   This module implements the functions needed to advertize
+#   This module implements the functions needed to advertise
 #   and get resources from the Collector
 
+"""
+This module implements the functions needed to advertise and get resources from the Collector
+"""
 
 import calendar
 import copy
@@ -864,6 +861,8 @@ class MultiAdvertizeWork:
                     try:
                         cred_data = cred_el.generated_data
                     except AttributeError:
+                        # TODO: credential parsing form file could fail (wrong permission, not found, ...)
+                        #  Add message? Handle here or declare raising
                         cred_data = cred_el.getString(cred_file)
                     if cred_data:
                         cred_el.loaded_data.append((cred_file, cred_data))

--- a/lib/defaults.py
+++ b/lib/defaults.py
@@ -37,7 +37,8 @@ def force_bytes(instr, encoding=BINARY_ENCODING_CRYPTO):
     """
     if isinstance(instr, str):
         # raise Exception("ALREADY str!")  # Use this for investigations
-        if instr.startswith("b'"):
+        if instr.startswith("b'") and len(instr) > 2 and instr.endswith("'"):
+            # This may cause errors with the random strings generated for unit tests, which may start with "b'"
             raise ValueError(
                 "Input was improperly converted into string (resulting in b'' characters added): %s" % instr
             )

--- a/plugins/scitokens_callout.py
+++ b/plugins/scitokens_callout.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 
-from glideinwms.lib import subprocessSupport, token_util
+from glideinwms.lib import subprocessSupport
 
 # This is a generic implementation of the the Scitoken plugin interface.
 # VOs would implement their own version of this to interact with the
@@ -17,6 +17,7 @@ from glideinwms.lib import subprocessSupport, token_util
 #
 # Dependencies are the python3-scitokens package, and a copy of the
 # scitoken key.
+# You may want to import and use glideinwms.lib.token_util
 #
 # The key details are hardcoded below. At the minimum, key_file,
 # key_id, and issuer need to be changed to the VO specific ones.


### PR DESCRIPTION
There is a bug in older PyJWT versions, like the one in EL7. `jwt.encode()` is returning bytes instead of str. 
Here I'm adding a workaround to protect against it and work with both new and older versions of PyJWT

Here is the PyJWT issue: https://github.com/jpadilla/pyjwt/issues/391
This was fixed in PyJWT v2.0.0, https://github.com/jpadilla/pyjwt/pull/513