### PR TITLE
Fix Factory reconfig/upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bug fix quick release
 ### Bug Fixes
 
 -   Workaround for EL7 PyJWT bug, generating bytes instead of str (PR #355)
+-   Fixed missing `cvmfsexec.cfg` files from Factory reconfig and improved cvmfsexec warnings (Issue #348, PR #356)
 -   Added bash requirement to files using bashisms, notably `glidein_sitewms_setup.sh` (PR #358)
 -   Fixed syntax errors in analyze_queues (PR #357)
 -   Fixed setup_x509 to be successful w/ TRUST_DOMAIN set in the as Factory or Frontend parameter (PR #359)

--- a/creation/lib/cWDictFile.py
+++ b/creation/lib/cWDictFile.py
@@ -94,8 +94,8 @@ class DictFile:
         return self.vals[key]
 
     # MM .get() added 5345, check no trouble
-    def get(self, key):
-        return self.vals.get(key)
+    def get(self, key, default=None):
+        return self.vals.get(key, default)
 
     def get_fname(self):
         return self.fname

--- a/creation/lib/cgWDictFile.py
+++ b/creation/lib/cgWDictFile.py
@@ -231,7 +231,6 @@ def get_common_dicts(submit_dir, stage_dir):
         "signature": cWDictFile.SHA1DictFile(
             stage_dir, cWConsts.insert_timestr(cWConsts.SIGNATURE_FILE), fname_idx=cWConsts.SIGNATURE_FILE
         ),
-        "build_cvmfsexec": cWDictFile.ReprDictFile(submit_dir, cgWConsts.CVMFSEXEC_BUILD_FILE),
     }
     refresh_description(common_dicts)
     return common_dicts
@@ -241,6 +240,7 @@ def get_main_dicts(submit_dir, stage_dir):
     main_dicts = get_common_dicts(submit_dir, stage_dir)
     main_dicts["summary_signature"] = cWDictFile.SummarySHA1DictFile(submit_dir, cWConsts.SUMMARY_SIGNATURE_FILE)
     main_dicts["glidein"] = cWDictFile.StrDictFile(submit_dir, cgWConsts.GLIDEIN_FILE)
+    main_dicts["build_cvmfsexec"] = cWDictFile.ReprDictFile(submit_dir, cgWConsts.CVMFSEXEC_BUILD_FILE)
     main_dicts["frontend_descript"] = cWDictFile.ReprDictFile(submit_dir, cgWConsts.FRONTEND_DESCRIPT_FILE)
     main_dicts["gridmap"] = cWDictFile.GridMapDict(stage_dir, cWConsts.insert_timestr(cWConsts.GRIDMAP_FILE))
     main_dicts["at_file_list"] = cWDictFile.FileDictFile(
@@ -271,7 +271,6 @@ def load_common_dicts(dicts, description_el):  # update in place
     # first submit dir ones (mutable)
     dicts["params"].load()
     dicts["attrs"].load()
-    dicts["build_cvmfsexec"].load()
     # now the ones keyed in the description
     dicts["signature"].load(fname=description_el.vals2["signature"])
     dicts["file_list"].load(fname=description_el.vals2["file_list"])
@@ -289,6 +288,8 @@ def load_main_dicts(main_dicts):  # update in place
     main_dicts["frontend_descript"].load()
     # summary_signature has keys for description
     main_dicts["summary_signature"].load()
+    # load the cvmfsexec build
+    main_dicts["build_cvmfsexec"].load()
     # load the description
     # print "\ndebug %s main_dicts['summary_signature']['main'][1] = %s" % (__file__, main_dicts['summary_signature']['main'][1])
     main_dicts["description"].load(fname=main_dicts["summary_signature"]["main"][1])
@@ -417,13 +418,13 @@ def save_common_dicts(dicts, is_main, set_readonly=True):  # will update in plac
     # finally save the mutable one(s)
     dicts["params"].save(set_readonly=set_readonly)
     dicts["attrs"].save(set_readonly=set_readonly)
-    dicts["build_cvmfsexec"].save(set_readonly=set_readonly)
 
 
 # must be invoked after all the entries have been saved
 def save_main_dicts(main_dicts, set_readonly=True):  # will update in place, too
     main_dicts["glidein"].save(set_readonly=set_readonly)
     main_dicts["frontend_descript"].save(set_readonly=set_readonly)
+    main_dicts["build_cvmfsexec"].save(set_readonly=set_readonly)
     save_common_dicts(main_dicts, True, set_readonly=set_readonly)
     summary_signature = main_dicts["summary_signature"]
     summary_signature.add_from_file(
@@ -494,7 +495,7 @@ def reuse_common_dicts(dicts, other_dicts, is_main, all_reused):
             dicts[k].set_readonly(True)
 
     # check the mutable ones
-    for k in ("attrs", "params", "build_cvmfsexec"):
+    for k in ("attrs", "params"):
         reuse_simple_dict(dicts, other_dicts, k)
 
     return all_reused
@@ -502,6 +503,7 @@ def reuse_common_dicts(dicts, other_dicts, is_main, all_reused):
 
 def reuse_main_dicts(main_dicts, other_main_dicts):
     reuse_simple_dict(main_dicts, other_main_dicts, "glidein")
+    reuse_simple_dict(main_dicts, other_main_dicts, "build_cvmfsexec")
     reuse_simple_dict(main_dicts, other_main_dicts, "frontend_descript")
     reuse_simple_dict(main_dicts, other_main_dicts, "gridmap")
     all_reused = reuse_common_dicts(main_dicts, other_main_dicts, True, True)

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -326,6 +326,7 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             print(cvmfsexec_distros_build_out)  # prints the output from the shell script executed in the previous line
             # get the location of the tarballs created during reconfig/upgrade
             distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
+            distros = []
             try:
                 distros = [
                     d for d in os.listdir(distros_loc) if d.startswith("cvmfsexec")

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -359,7 +359,7 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                     try:
                         distro_info = distros[cvmfsexec_idx].split(".")[0].split("_", 3)
                     except:
-                        print(f"Problem parsing name: {distros[cvmfsexec_idx]}!")
+                        print(f"Problem parsing the cvmfsexec distro name: {distros[cvmfsexec_idx]}! Ignoring it.")
                         continue
                     platform = "-".join(distro_info[1:])
 
@@ -385,29 +385,24 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                     self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
         else:
             print("...No sources specified. Building/Rebuilding of cvmfsexec distributions disabled!")
-            ondemand_cvmfs = 0
-            try:
-                # fetch the on-demand cvmfs provisioning feature setting
-                ondemand_cvmfs = self.dicts["attrs"]["GLIDEIN_USE_CVMFSEXEC"]
-            except KeyError as e:
-                # on-demand CVMFS not used at the global level; ignore and continue
-                pass
-            else:
-                # check if on demand cvmfs provisioning is requested/enabled
-                if ondemand_cvmfs != 0:
-                    # check the dir containing cvmfsexec distros to see if they were built previously
-                    if os.path.exists(os.path.join(self.work_dir, "cvmfsexec/tarballs")) and os.listdir(
-                        os.path.join(self.work_dir, "cvmfsexec/tarballs")
-                    ):
-                        # cvmfsexec distros were found from a previous factory reconfig
-                        print(f"...Found cvmfsexec distributions in {os.path.join(self.work_dir)}")
-                        print("......RECOMMENDED: Rebuild distributions using the latest version of cvmfsexec.")
-                    else:
-                        # can be overridden at the entry level, so ignore and [entry supersedes global setting]
-                        print(
-                            "...cvmfsexec distributions unavailable but on-demand CVMFS requested via GLIDEIN_USE_CVMFSEXEC; Continuing..."
-                        )
-                print("...Ignoring building/rebuilding of cvmfsexec distributions")
+            # TODO: This check could be done in the XML, checking if the entries are consistent in the current version
+            # fetch the on-demand cvmfs provisioning feature setting
+            # if on-demand CVMFS not used at the global level; ignore and continue
+            ondemand_cvmfs = self.dicts["attrs"].get("GLIDEIN_USE_CVMFSEXEC", 0)
+            # check if on demand cvmfs provisioning is requested/enabled
+            if ondemand_cvmfs != 0:
+                # check the dir containing cvmfsexec distros to see if they were built previously
+                if os.path.exists(os.path.join(self.work_dir, "cvmfsexec/tarballs")) and os.listdir(
+                    os.path.join(self.work_dir, "cvmfsexec/tarballs")
+                ):
+                    # cvmfsexec distros were found from a previous factory reconfig
+                    print(f"...Found cvmfsexec distributions in {os.path.join(self.work_dir)}")
+                    print("......RECOMMENDED: Rebuild distributions using the latest version of cvmfsexec.")
+                else:
+                    # can be overridden at the entry level, so ignore and [entry supersedes global setting]
+                    print(
+                        "...cvmfsexec distributions unavailable but on-demand CVMFS requested via GLIDEIN_USE_CVMFSEXEC; Continuing..."
+                    )
 
         # add additional system scripts
         for script_name in at_file_list_scripts:
@@ -707,29 +702,23 @@ class glideinEntryDicts(cgWDictFile.glideinEntryDicts):
         for attr in entry_attrs:
             add_attr_unparsed(attr, self.dicts, self.sub_name)
 
-        ondemand_cvmfs = 0
-        try:
-            # fetch the on-demand cvmfs provisioning feature setting
-            ondemand_cvmfs = self.dicts["attrs"]["GLIDEIN_USE_CVMFSEXEC"]
-        except KeyError as e:
-            # on-demand CVMFS not used by entry; ignore and continue
-            pass
-        else:
-            # check if on demand cvmfs provisioning is requested/enabled on an active entry
-            if ondemand_cvmfs != 0:
-                # check the dir containing cvmfsexec distros to see if they were built previously
-                if os.path.exists(os.path.join(self.work_dir, "../cvmfsexec/tarballs")) and os.listdir(
-                    os.path.join(self.work_dir, "../cvmfsexec/tarballs")
-                ):
-                    # cvmfsexec distros were found from a previous factory reconfig
-                    print(f"...Found cvmfsexec distributions in {os.path.dirname(os.path.join(self.work_dir))}")
-                    print("......RECOMMENDED: Rebuild distributions using the latest version of cvmfsexec.")
-                else:
-                    print(
-                        "...cvmfsexec distributions unavailable but on-demand CVMFS is requested via GLIDEIN_USE_CVMFSEXEC; Aborting!"
-                    )
-                    exit(1)
-            print("...Ignoring building/rebuilding of cvmfsexec distributions")
+        # TODO: This check could be done in the XML, checking if the entries are consistent in the current version
+        # fetch the on-demand cvmfs provisioning feature setting
+        # if on-demand CVMFS not used by entry, ignore and continue
+        ondemand_cvmfs = self.dicts["attrs"].get("GLIDEIN_USE_CVMFSEXEC", 0)
+        if ondemand_cvmfs != 0:
+            # check the dir containing cvmfsexec distros to see if they were built previously
+            if os.path.exists(os.path.join(self.work_dir, "../cvmfsexec/tarballs")) and os.listdir(
+                os.path.join(self.work_dir, "../cvmfsexec/tarballs")
+            ):
+                # cvmfsexec distros were found from a previous factory reconfig
+                print(f"...Found cvmfsexec distributions in {os.path.dirname(os.path.join(self.work_dir))}")
+                print("......RECOMMENDED: Rebuild distributions using the latest version of cvmfsexec.")
+            else:
+                print(
+                    "...cvmfsexec distributions unavailable but on-demand CVMFS is requested via GLIDEIN_USE_CVMFSEXEC; Aborting!"
+                )
+                exit(1)
 
         # put standard attributes into config file
         # override anything the user set


### PR DESCRIPTION
Factory reconfig or upgrade is giving errors about missing files upgrading to 3.10.4.
The failure to reconfig was misleading (due to local changes in the test instance).

The cvmfsexec building configuration is only in the main section, not in the entries.
The dictionaries (dictfiles) have been fixed accordingly.

The warning about possible outdated builds is printed only if there are builds

During testing was discovered that `distros` was not initialized in case of exception

This fixes #348 