### PR TITLE
Fixed TRUST_DOMAIN in setup_x509 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Bug fix quick release
 
 ### Bug Fixes
 
+-   Workaround for EL7 PyJWT bug, generating bytes instead of str (PR #355)
 -   Added bash requirement to files using bashisms, notably `glidein_sitewms_setup.sh` (PR #358)
+-   Fixed syntax errors in analyze_queues (PR #357)
+-   Fixed setup_x509 to be successful w/ TRUST_DOMAIN set in the as Factory or Frontend parameter (PR #359)
+-   GLIDEIN_SINGULARITY_BINARY_OVERRIDE set also with Frontend and Factory params, not only WN environment (PR #360)
 
 ### Testing / Development
 

--- a/creation/web_base/setup_x509.sh
+++ b/creation/web_base/setup_x509.sh
@@ -441,7 +441,9 @@ _main() {
         gconfig_add GLIDEIN_CONDOR_TOKEN "$GLIDEIN_CONDOR_TOKEN"
         gconfig_add GLIDEIN_CONDOR_TOKEN_ORIG "$GLIDEIN_CONDOR_TOKEN_ORIG"
         out=$(gconfig_get TRUST_DOMAIN "${glidein_config}")
-        if [[ -z "$out" ]]; then
+        if [[ -n "$out" ]]; then
+            cred_updated+=idtoken,
+        else
             # Retrieve TRUST_DOMAIN from COLLECTOR_HOST and CCB if not already defined in condor_config (config attrs)
             if out=$(get_trust_domain); then
                 export TRUST_DOMAIN="$out"


### PR DESCRIPTION
Fixed setup_x509 to be successful w/ TRUST_DOMAIN set in the as Factory or Frontend parameter