### PR TITLE
Fixed add_to_path() to avoid partial path matching

### DIFF
--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -221,6 +221,7 @@ if [[ -z "$condor_version" ]]; then
     condor_version="default"
 fi
 
+# Get the first match in condor_platform_check
 condor_platform_check=""
 for version_el in $(echo "$condor_version" | tr ',' ' '); do
   if [[ -z "$condor_platform_check" ]]; then

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -1248,17 +1248,19 @@ fetch_file_base() {
 }
 
 # Adds $1 to GWMS_PATH and update PATH
+# paths are adjusted to avoid adding the same path multiple times
 add_to_path() {
     logdebug "Adding to GWMS_PATH: $1"
-    local old_path=":${PATH%:}:"
-    old_path="${old_path//:$GWMS_PATH:/}"
+    local tmp_path=":${PATH%:}:"
     local old_gwms_path=":${GWMS_PATH%:}:"
-    old_gwms_path="${old_gwms_path//:$1:/}"
+    tmp_path="${tmp_path//${old_gwms_path}/}"
+    old_gwms_path="${old_gwms_path//:${1%:}:/}"
     old_gwms_path="${1%:}:${old_gwms_path#:}"
     export GWMS_PATH="${old_gwms_path%:}"
-    old_path="${GWMS_PATH}:${old_path#:}"
-    export PATH="${old_path%:}"
+    tmp_path="${GWMS_PATH}:${tmp_path#:}"
+    export PATH="${tmp_path%:}"
 }
+
 
 fixup_condor_dir() {
     # All files in the native condor tarballs have a directory like condor-9.0.11-1-x86_64_CentOS7-stripped


### PR DESCRIPTION
Fixed add_to_path() to avoid partial path matching. 
The function prunes from the PATH/GWMS_PATH occurrences of the path being added to avoid indefinite growth of paths with multiple occurrences of the same path.
Before the fix the pruning could have been removing a partial matches, e.g. `/this/path_long` would have been removed when adding `/this/path`.
Added clarification comments