### PR TITLE
Advertising the submit attributes to the glidefactory ClassAd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
-## Changes Since Last Release OR v3.10.6 \[2023-12-dd\]
+## v3.10.6 \[2024-01-dd\]
 
-Bug fix quick release
+Minor new features, mostly a bug fix release
 
 ### New features / functionalities
 
 -   Add knobs to allow overloading of memory, GLIDEIN_OVERLOAD_MEMORY, and CPU, GLIDEIN_OVERLOAD_CPUS. (Issue #370, PR #374)
 -   Added HTCondor tarball downloader (Issue #367, PR #366)
 -   Added default (/bin,/usr/bin) when PATH is empty in glidein_startup.sh (PR #373)
--   Advertising Factory's HTCondor submit parameters (Issue #307)
+-   Advertising Factory's HTCondor submit parameters (Issue #307, PR #382)
 
 ### Changed defaults / behaviours
 
@@ -24,6 +24,7 @@ Bug fix quick release
 
 -   Changed M2Crypto imports to be compatible with 0.40.0 the code must import also the components (PR #377)
 -   Fixed PATHs handling in glidein_startup.sh (PR #379)
+-   Fixed match policy_file import failure (Issue #378, PR #380)
 
 ### Testing / Development
 

--- a/creation/lib/cWDictFile.py
+++ b/creation/lib/cWDictFile.py
@@ -2043,18 +2043,18 @@ class FileSubDicts(FileCommonDicts, DirsSupport):
 
 
 class FileDicts:
-    """This Class contains both the main and the sub dicts"""
+    """This Class contains both the main and the sub dicts for a file dictionary"""
 
     def __init__(self, work_dir, stage_dir, sub_list=[], workdir_name="work", simple_work_dir=False, log_dir=None):
-        """
+        """Constructor for Class containing both the main and the sub dicts for a file dictionary
 
         Args:
-            work_dir:
-            stage_dir:
-            sub_list:
-            workdir_name:
-            simple_work_dir: if True, do not create the lib and lock work_dir subdirs
-            log_dir: used only if simple_work_dir=False
+            work_dir (str, Path): work directory
+            stage_dir (str, Path): stage directory
+            sub_list (list): List of sub items (Entries), empty by default
+            workdir_name: work dir name (Default: "work")
+            simple_work_dir (bool): if True, do not create the lib and lock work_dir subdirs
+            log_dir (str, Path, None): Log directory. Used only if simple_work_dir=False
         """
         self.work_dir = work_dir
         self.workdir_name = workdir_name
@@ -2075,11 +2075,10 @@ class FileDicts:
         for el in list(self.sub_dicts.values()):
             el.set_readonly(readonly)
 
-    # TODO: the code seems to do the opposite of what the comment mentions
-    def erase(self, destroy_old_subs=True):  # if false, the sub names will be preserved
+    def erase(self, destroy_old_subs=True):
         """Erase the fileDict
         If `destroy_old_subs` is True, then the sub list and dict are reset; if it is False,
-        then erase() is called recursively on the sub_list items.
+        then erase() is called recursively on the sub_list items but the sub names is preserved.
 
         Args:
             destroy_old_subs (bool): if false, the sub names will be preserved
@@ -2093,10 +2092,11 @@ class FileDicts:
                 self.sub_dicts[sub_name].erase()
         return
 
-    def load(self, destroy_old_subs=True):  # if false, overwrite the subs you load, but leave the others as they are
+    def load(self, destroy_old_subs=True):
         """Load all the dictionaries (from files).
-        If `destroy_old_subs` is False, existing items are preserved if not over-written by a loaded one with the same
-        name. If it is True, old items are dropped and only the new ones will be in the dictionary.
+        If `destroy_old_subs` is False, existing (in the FileDicts dictionary) items are preserved if not over-written
+        by a loaded one with the same name.
+        If it is True, old items are dropped and only the new ones will be in the dictionary.
 
         Args:
             destroy_old_subs (bool): if false, overwrite the subs you load, but leave the others as they are
@@ -2142,7 +2142,7 @@ class FileDicts:
 
     def is_equal(
         self,
-        other,  # other must be of the same class
+        other,
         compare_work_dir: bool = False,
         compare_stage_dir: bool = False,
         compare_fnames: bool = False,
@@ -2151,7 +2151,7 @@ class FileDicts:
         Return False if the content is different and optionally also if file name or staging or work directory differ.
 
         Args:
-            other (:obj:): other fileDict of the same type to compare
+            other (FileDicts): other FileDicts object to compare to self. Must be of the same class as self
             compare_work_dir (bool): if True, fail if the 2 fileDict are not in the same directory (same work directory)
             compare_stage_dir (bool): if True, fail if the 2 fileDict don't use the same staging directory
             compare_fnames (bool): if True, fail if the file name is different
@@ -2182,8 +2182,15 @@ class FileDicts:
                 return False
         return True
 
-    # reuse as much of the other as possible
-    def reuse(self, other):  # other must be of the same class
+    def reuse(self, other):
+        """Populate the dictionary (re)using as much as possible of `other`. I.e. all the items with the same key.
+
+        Args:
+            other (FileDicts): File dictionary to reuse. Must be of the same class as self
+
+        Raises:
+            RuntimeError: if the file dict is incompatible, i.e. the work_dir or stage_dir are different
+        """
         if self.work_dir != other.work_dir:
             raise RuntimeError(f"Cannot change {self.workdir_name} base_dir! '{self.work_dir}'!='{other.work_dir}'")
         if self.stage_dir != other.stage_dir:
@@ -2206,9 +2213,12 @@ class FileDicts:
     # PRIVATE
     ###########
 
-    # this should be redefined by the child
-    # and return a child of FileMainDicts
     def new_MainDicts(self):
+        """This should be redefined by the child and return a child of FileMainDicts
+
+        Returns:
+            FileMainDicts: return a main dictionary of the same type (child of FileMainDicts)
+        """
         return FileMainDicts(self.work_dir, self.stage_dir, self.workdir_name, self.simple_work_dir, self.log_dir)
 
     def new_SubDicts(self, sub_name):
@@ -2218,7 +2228,7 @@ class FileDicts:
             sub_name (str): sub dictionary name
 
         Returns:
-
+            FileSubDicts: return a sub dictionary of the same type (child of FileSubDicts)
         """
         return FileSubDicts(
             self.work_dir,
@@ -2230,14 +2240,14 @@ class FileDicts:
             self.log_dir,
         )
 
-    def get_sub_name_from_sub_stage_dir(self, sign_key):
-        """This should be redefined by the child
+    def get_sub_name_from_sub_stage_dir(self, stage_dir):
+        """This must be redefined by the child and return the sub (e.g. Entry) name
 
         Args:
-            sign_key:
+            stage_dir (str, Path): sub item stage directory
 
         Returns:
-
+            str: sub item name (e.g. Entry name)
         """
         raise RuntimeError("Undefined")
 

--- a/creation/lib/cWExpand.py
+++ b/creation/lib/cWExpand.py
@@ -28,7 +28,7 @@ def expand_DD(qstr, attr_dict):
         if m is None:
             break  # no more substitutions to do
         attr_name = m.group("attrname")
-        if not attr_dict.has_key(attr_name):
+        if not attr_name in attr_dict:
             raise KeyError("Missing attribute %s" % attr_name)
         attr_val = attr_dict[attr_name]
         if type(attr_val) == int:
@@ -63,7 +63,7 @@ def expand_DLR(qstr, attr_dict):
             qstr = f"{qstr[: m.start()]}${qstr[m.end() :]}"
             continue
 
-        if not attr_dict.has_key(attr_name):
+        if not attr_name in attr_dict:
             raise KeyError(
                 "Missing attribute %s (or loop detected). If you do not intend to use the attribute expansion feature and just want to use a dollar, please use $(DOLLAR) instead of $. You can also turn off attribute expansion by setting 'enable_attribute_expansion=\"False\"'."
                 % attr_name

--- a/creation/lib/cgWConsts.py
+++ b/creation/lib/cgWConsts.py
@@ -1,17 +1,8 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Keep all the constants used to create glidein entries in this module
-#
-# Author: Igor Sfiligoi
-#
 
 import os.path
 
@@ -34,6 +25,7 @@ CVMFSEXEC_ATTR = "CVMFSEXEC_DIR"
 
 
 # these are in the submit dir, so they can be changed
+SUBMIT_ATTRS_FILE = "submit_attrs.cfg"
 PARAMS_FILE = "params.cfg"
 ATTRS_FILE = "attributes.cfg"
 CVMFSEXEC_BUILD_FILE = "cvmfsexec.cfg"

--- a/creation/lib/cgWCreate.py
+++ b/creation/lib/cgWCreate.py
@@ -1,18 +1,9 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   Functions needed to create files used by the glidein entry points
-#
-# Author: Igor Sfiligoi
-#
-####################################
+
 
 import io
 import os
@@ -24,8 +15,6 @@ import tarfile
 from glideinwms.lib.util import chmod
 
 from . import cgWDictFile, cWDictFile
-
-##############################
 
 
 # Create condor tarball and store it into a StringIO
@@ -141,14 +130,19 @@ def get_factory_log_recipients(entry):
 class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
     # MM5345 passing job_descript instead of entry (was sub_params in common root), used only in first section to eval variables
     def populate(self, exe_fname, entry_name, conf, entry):
-        """
-        Since there are only two parameters that ever were passed that didn't already exist in the params dict or the
+        """Since there are only two parameters that ever were passed that didn't already exist in the params dict or the
         sub_params dict, the function signature has been greatly simplified into just those two parameters and the
         two dicts.
 
         This has the added benefit of being "future-proof" for as long as we maintain this particular configuration
         method.  Any new attribute that may be in params or sub_params can be accessed here without having to add yet
         another parameter to the function.
+
+        Args:
+            exe_fname (str, Path): startup file name (glidein_startup.sh)
+            entry_name (str): Name of the Entry
+            conf (factoryXmlConfig.Config): XML configuration
+            entry (factoryXmlConfig.EntryElement): Entry element XML configuration
         """
 
         glidein_name = conf["glidein_name"]
@@ -289,8 +283,8 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
         self.jobs_in_cluster = "$ENV(GLIDEIN_COUNT)"
 
     def populate_standard_grid(self, rsl, auth_method, gridtype, entry_enabled, entry_name, enc_input_files=None):
-        """
-        create a standard condor jdl file to submit to  OSG grid
+        """Create a standard condor jdl file to submit to  OSG grid
+
         Args:
             rsl (str):
             auth_method (str): grid_proxy, voms_proxy, key_pair, cert_pair, username_password,
@@ -343,6 +337,9 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
                 or gridtype.startswith("batch ")
                 or gridtype in ("condor", "gce", "ec2", "arc")
             ):
+                # TODO: If switching to f-string, must use different quotes in the following line
+                #  to avoid error w/ f-string (fixed in Py 3.12) - check that formatter is not changing things
+                # self.add(f'{attr_prefix}{submit_attr["name"]}', submit_attr["value"])
                 self.add("{}{}".format(attr_prefix, submit_attr["name"]), submit_attr["value"])
 
     def populate_condorc_grid(self):

--- a/creation/lib/cgWDictFile.py
+++ b/creation/lib/cgWDictFile.py
@@ -353,7 +353,7 @@ def load_common_dicts(dicts, description_el):  # update in place
 
 
 def load_main_dicts(main_dicts):  # update in place
-    """Load (from file) the entry dictionaries
+    """Load (from file) the main dictionaries
     Loads also the common ones, calling load_common_dicts
 
     Args:
@@ -803,7 +803,7 @@ class glideinEntryDicts(cWDictFile.FileSubDicts):
             workdir_name (str): work directory name
             base_log_dir (str): base log directory name
             base_client_log_dirs (str): base client log directory name
-            base_client_proxies_dirs (str): base client credentials direcoty name
+            base_client_proxies_dirs (str): base client credentials directory name
         """
         cWDictFile.FileSubDicts.__init__(
             self,

--- a/creation/lib/cgWDictFile.py
+++ b/creation/lib/cgWDictFile.py
@@ -17,6 +17,7 @@ attrs (cWDictFile.ReprDictFile, cgWConsts.ATTRS_FILE): attributes in the "entry"
 description (cWDictFile.DescriptionDictFile, cWConsts.DESCRIPTION_FILE, versioned): factory/entry description
 consts (cWDictFile.StrDictFile, cWConsts.CONSTS_FILE, versioned): constant attrs - TODO: not written?
 params (cWDictFile.ReprDictFile, cgWConsts.PARAMS_FILE): attrs that are not constant (const="False", default)
+submit (cWDictFile.ReprDictFile, cgWConsts.SUBMIT_ATTRS_FILE): submit configuration attributes
 vars (cWDictFile.VarsDictFile, cWConsts.VARS_FILE, versioned): condor variables
 untar_cfg (cWDictFile.StrDictFile, cWConsts.UNTAR_CFG_FILE, versioned): instructions for files to un-compress
 file_list (cWDictFile.FileDictFile, cWConsts.FILE_LISTFILE, versioned): list of files to transfers
@@ -256,6 +257,7 @@ def get_common_dicts(submit_dir, stage_dir):
             stage_dir, cWConsts.insert_timestr(cWConsts.CONSTS_FILE), fname_idx=cWConsts.CONSTS_FILE
         ),
         "params": cWDictFile.ReprDictFile(submit_dir, cgWConsts.PARAMS_FILE),
+        "submit": cWDictFile.ReprDictFile(submit_dir, cgWConsts.SUBMIT_ATTRS_FILE),
         "vars": cWDictFile.VarsDictFile(
             stage_dir, cWConsts.insert_timestr(cWConsts.VARS_FILE), fname_idx=cWConsts.VARS_FILE
         ),
@@ -335,6 +337,7 @@ def load_common_dicts(dicts, description_el):  # update in place
         description_el:
     """
     # first submit dir ones (mutable)
+    dicts["submit"].load()
     dicts["params"].load()
     dicts["attrs"].load()
     # now the ones keyed in the description
@@ -496,6 +499,7 @@ def save_common_dicts(dicts, is_main, set_readonly=True):  # will update in plac
     dicts["signature"].save(set_readonly=set_readonly)
 
     # finally save the mutable one(s)
+    dicts["submit"].save(set_readonly=set_readonly)
     dicts["params"].save(set_readonly=set_readonly)
     dicts["attrs"].save(set_readonly=set_readonly)
 
@@ -575,7 +579,7 @@ def reuse_common_dicts(dicts, other_dicts, is_main, all_reused):
             dicts[k].set_readonly(True)
 
     # check the mutable ones
-    for k in ("attrs", "params"):
+    for k in ("attrs", "params", "submit"):
         reuse_simple_dict(dicts, other_dicts, k)
 
     return all_reused

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -872,13 +872,14 @@ class glideinDicts(cgWDictFile.glideinDicts):
 
         return
 
-    def populate(self, other=None):  # will update params (or self.params)
+    def populate(self, other=None):
         """Will update params (or self.params) using the values from `other`.
-        Set the schedd to use preserving the onses set in `other` and populate
-        the common element in the entry using the main dictionary content.
+        When `other` is provided, set the schedd to use for an Entry preserving
+        the ones set in `other` and populate the common element in the entry using
+        the main dictionary content.
 
         Args:
-            other (glideinDicts|None): other dictionary of the same type
+            other (glideinDicts|None): other dictionary of the same Class
         """
         self.main_dicts.populate(other)
         self.active_sub_list = self.main_dicts.active_sub_list

--- a/creation/lib/cvWDictFile.py
+++ b/creation/lib/cvWDictFile.py
@@ -409,7 +409,7 @@ def reuse_group_dicts(group_dicts, other_group_dicts, group_name):
 ################################################
 
 
-class frontendMainDicts(cWDictFile.fileMainDicts):
+class frontendMainDicts(cWDictFile.FileMainDicts):
     def __init__(
         self,
         work_dir,
@@ -420,7 +420,7 @@ class frontendMainDicts(cWDictFile.fileMainDicts):
         log_dir=None,
     ):  # used only if simple_work_dir=False
         self.assume_groups = assume_groups
-        cWDictFile.fileMainDicts.__init__(self, work_dir, stage_dir, workdir_name, simple_work_dir, log_dir)
+        cWDictFile.FileMainDicts.__init__(self, work_dir, stage_dir, workdir_name, simple_work_dir, log_dir)
 
     ######################################
     # Redefine methods needed by parent
@@ -432,7 +432,7 @@ class frontendMainDicts(cWDictFile.fileMainDicts):
 
     # reuse as much of the other as possible
     def reuse(self, other):  # other must be of the same class
-        cWDictFile.fileMainDicts.reuse(self, other)
+        cWDictFile.FileMainDicts.reuse(self, other)
         reuse_main_dicts(self.dicts, other.dicts)
 
     ####################
@@ -454,7 +454,7 @@ class frontendMainDicts(cWDictFile.fileMainDicts):
 ################################################
 
 
-class frontendGroupDicts(cWDictFile.fileSubDicts):
+class frontendGroupDicts(cWDictFile.FileSubDicts):
     ######################################
     # Redefine methods needed by parent
     def load(self):
@@ -468,7 +468,7 @@ class frontendGroupDicts(cWDictFile.fileSubDicts):
 
     # reuse as much of the other as possible
     def reuse(self, other):  # other must be of the same class
-        cWDictFile.fileSubDicts.reuse(self, other)
+        cWDictFile.FileSubDicts.reuse(self, other)
         reuse_group_dicts(self.dicts, other.dicts, self.sub_name)
 
     ####################
@@ -499,7 +499,7 @@ class frontendGroupDicts(cWDictFile.fileSubDicts):
 ################################################
 
 
-class frontendDicts(cWDictFile.fileDicts):
+class frontendDicts(cWDictFile.FileDicts):
     def __init__(
         self,
         work_dir,
@@ -509,7 +509,7 @@ class frontendDicts(cWDictFile.fileDicts):
         simple_work_dir=False,  # if True, do not create the lib and lock work_dir subdirs, nor the params dict
         log_dir=None,
     ):  # used only if simple_work_dir=False
-        cWDictFile.fileDicts.__init__(self, work_dir, stage_dir, group_list, workdir_name, simple_work_dir, log_dir)
+        cWDictFile.FileDicts.__init__(self, work_dir, stage_dir, group_list, workdir_name, simple_work_dir, log_dir)
 
     ###########
     # PRIVATE

--- a/creation/lib/cvWParamDict.py
+++ b/creation/lib/cvWParamDict.py
@@ -238,9 +238,9 @@ class frontendMainDicts(cvWDictFile.frontendMainDicts):
             log_dir=params.log_dir,
         )
         self.monitor_dir = params.monitor_dir
-        self.add_dir_obj(cWDictFile.monitorWLinkDirSupport(self.monitor_dir, self.work_dir))
+        self.add_dir_obj(cWDictFile.MonitorWLinkDirSupport(self.monitor_dir, self.work_dir))
         self.monitor_jslibs_dir = os.path.join(self.monitor_dir, "jslibs")
-        self.add_dir_obj(cWDictFile.simpleDirSupport(self.monitor_jslibs_dir, "monitor"))
+        self.add_dir_obj(cWDictFile.SimpleDirSupport(self.monitor_jslibs_dir, "monitor"))
         self.params = params
         self.enable_expansion = str2bool(self.params.data.get("enable_attribute_expansion", "False"))
         self.active_sub_list = []
@@ -498,7 +498,7 @@ class frontendGroupDicts(cvWDictFile.frontendGroupDicts):
             base_log_dir=params.log_dir,
         )
         self.monitor_dir = cvWConsts.get_group_monitor_dir(params.monitor_dir, sub_name)
-        self.add_dir_obj(cWDictFile.monitorWLinkDirSupport(self.monitor_dir, self.work_dir))
+        self.add_dir_obj(cWDictFile.MonitorWLinkDirSupport(self.monitor_dir, self.work_dir))
         self.params = params
         self.enable_expansion = str2bool(self.params.data.get("enable_attribute_expansion", "False"))
         self.client_security = {}

--- a/factory/glideFactoryConfig.py
+++ b/factory/glideFactoryConfig.py
@@ -1,13 +1,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
-
 import os
 import os.path
 import shutil
@@ -25,11 +18,13 @@ class FactoryConfig:
     def __init__(self):
         # set default values
         # user should modify if needed
+        # These values should be consistent w/ creation/lib/c?WConst.py files content
 
         self.glidein_descript_file = "glidein.descript"
         self.job_descript_file = "job.descript"
         self.job_attrs_file = "attributes.cfg"
         self.job_params_file = "params.cfg"
+        self.job_submit_attrs_file = "submit_attrs.cfg"
         self.frontend_descript_file = "frontend.descript"
         self.signatures_file = "signatures.sha1"
         self.aggregated_stats_file = "aggregated_stats_dict.data"
@@ -47,13 +42,17 @@ factoryConfig = FactoryConfig()
 ############################################################
 
 
-# loads a file composed of
-#   NAME VAL
-# and creates
-#   self.data[NAME]=VAL
-# It also defines:
 #   self.config_file="name of file"
 class ConfigFile:
+    """In memory dictionary-like representation of key-value config files
+    Loads a file composed of
+        NAME VAL
+    and creates
+        self.data[NAME]=VAL
+    It also defines:
+        self.config_file="name of file"
+    """
+
     def __init__(self, config_file, convert_function=repr):
         self.config_file = config_file
         self.load(config_file, convert_function)
@@ -211,7 +210,7 @@ class GlideinDescript(ConfigFile):
                 shutil.copy(self.default_rsakey_fname, self.backup_rsakey_fname)
                 self.data["OldPubKeyType"] = self.data["PubKeyType"]
                 return
-            except:
+            except Exception:
                 # In case of failure, the requests from frontend get
                 # delayed. So it is not critical enough to fail.
                 pass
@@ -232,7 +231,7 @@ class GlideinDescript(ConfigFile):
         if self.data["OldPubKeyType"] is not None:
             try:
                 self.data["OldPubKeyObj"] = GlideinKey(self.data["OldPubKeyType"], key_fname=self.backup_rsakey_fname)
-            except:
+            except Exception:
                 self.data["OldPubKeyType"] = None
                 self.data["OldPubKeyObj"] = None
         return
@@ -286,6 +285,18 @@ class JobParams(JoinConfigFile):
         global factoryConfig
         JoinConfigFile.__init__(
             self, entry_name, factoryConfig.job_params_file, lambda s: s
+        )  # values are in python format
+
+
+class JobSubmitAttrs(JoinConfigFile):
+    def __init__(self, entry_name):
+        global factoryConfig
+        JoinConfigFile.__init__(
+            # Using repr instead of identity (convert into strings) would keep the quotes in the values
+            self,
+            entry_name,
+            factoryConfig.job_submit_attrs_file,
+            lambda s: s,
         )  # values are in python format
 
 

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -5,6 +5,7 @@
 
 # Description:
 #   Entry class
+#   Model and behavior of a Factory Entry (element describing a resource)
 
 
 import copy
@@ -12,7 +13,6 @@ import logging
 import os
 import os.path
 import signal
-import string
 import sys
 import tempfile
 import traceback
@@ -54,6 +54,7 @@ class Entry:
         self.jobDescript = glideFactoryConfig.JobDescript(name)
         self.jobAttributes = glideFactoryConfig.JobAttributes(name)
         self.jobParams = glideFactoryConfig.JobParams(name)
+        self.jobSubmitAttrs = glideFactoryConfig.JobSubmitAttrs(name)
 
         # glideFactoryMonitoring.monitoringConfig.monitor_dir
         self.monitorDir = os.path.join(self.startupDir, "monitor/entry_%s" % self.name)
@@ -578,6 +579,7 @@ class Entry:
             auth_method,
             self.gflFactoryConfig.supported_signtypes,
             pub_key_obj=pub_key_obj,
+            glidein_submit=self.jobSubmitAttrs.data.copy(),
             glidein_attrs=myJobAttributes,
             glidein_params=self.jobParams.data.copy(),
             glidein_monitors=glidein_monitors.copy(),

--- a/factory/glideFactoryInterface.py
+++ b/factory/glideFactoryInterface.py
@@ -587,11 +587,11 @@ class EntryClassad(classadSupport.Classad):
         """Class Constructor
 
         glidein_attrs is a dictionary of values to publish like {"Arch":"INTEL","MinDisk":200000}
-        similar for glidein_submits, glidein_params, glidein_monitor_monitors and the other disctionaries.
+        similar for glidein_submits, glidein_params, glidein_monitor_monitors and the other dictionaries.
 
         Args:
             factory_name (str): Name of the factory
-            glidein_name (str): Name of the resource in the glideclient classad?
+            glidein_name (str): Name of the resource in the glideclient classad
             entry_name (str): Name of the resource in the glidefactory classad
             trust_domain (str): trust domain for this Entry
             auth_method (str): the authentication methods this entry supports in glidein submission, i.e. grid_proxy, scitoken
@@ -602,7 +602,7 @@ class EntryClassad(classadSupport.Classad):
             glidein_params (dict, optional): params to be published, can be overwritten by Frontends. Defaults to {}.
             glidein_monitors (dict, optional): monitor attrs to be published. Defaults to {}.
             glidein_stats (dict, optional): aggregated Entry(entry) and Factory(total) statistics to be published. Defaults to {}.
-            glidein_web_attrs (dict, optional): _description_. Defaults to {}.
+            glidein_web_attrs (dict, optional): Web attributes to be published. Defaults to {}.
             glidein_config_limits (dict, optional): Factory configuration limits to be published. Defaults to {}.
         """
         # TODO: rename glidein_ to entry_ (entry_monitors)?
@@ -611,7 +611,7 @@ class EntryClassad(classadSupport.Classad):
 
         classadSupport.Classad.__init__(self, factoryConfig.factory_id, "UPDATE_AD_GENERIC", "INVALIDATE_ADS_GENERIC")
 
-        # Short hand for easy access
+        # Shorthand for easy access
         classad_name = f"{entry_name}@{glidein_name}@{factory_name}"
         self.adParams["Name"] = classad_name
         self.adParams["FactoryName"] = "%s" % factory_name

--- a/factory/glideFactoryInterface.py
+++ b/factory/glideFactoryInterface.py
@@ -56,6 +56,9 @@ class FactoryConfig:
         # String to prefix for the attributes
         self.glidein_attr_prefix = ""
 
+        # String to prefix for the submit attributes
+        self.glidein_submit_prefix = "GlideinSubmit"
+
         # String to prefix for the parameters
         self.glidein_param_prefix = "GlideinParam"
         self.encrypted_param_prefix = "GlideinEncParam"
@@ -573,6 +576,7 @@ class EntryClassad(classadSupport.Classad):
         auth_method,
         supported_signtypes,
         pub_key_obj=None,
+        glidein_submit={},
         glidein_attrs={},
         glidein_params={},
         glidein_monitors={},
@@ -582,23 +586,24 @@ class EntryClassad(classadSupport.Classad):
     ):
         """Class Constructor
 
-        :param factory_name: Name of the factory
-        :param glidein_name: Name of the resource in the glideclient classad?
-        :param entry_name: Name of the resource in the glidefactory classad
-        :param trust_domain: trust domain for this entry
-        :param auth_method: the authentication methods this entry supports in glidein submission, i.e. grid_proxy
-        :param supported_signtypes: suppported sign types, i.e. sha1
-        :param pub_key_obj: GlideinKey - for the frontend to use in encryption
-        :param glidein_attrs: glidein attrs to be published, not be overwritten by Frontends
-        :param glidein_params: params to be published, can be overwritten by Frontends
-        :param glidein_monitors: monitor attrs to be published
-        :param glidein_stats: aggregated Entry(entry) and Factory(total) statistics to be published
-        :param glidein_config_limits: Factory configuration limits to be published
-        :return:
-
         glidein_attrs is a dictionary of values to publish like {"Arch":"INTEL","MinDisk":200000}
-        similar for glidein_params and glidein_monitor_monitors
+        similar for glidein_submits, glidein_params, glidein_monitor_monitors and the other disctionaries.
 
+        Args:
+            factory_name (str): Name of the factory
+            glidein_name (str): Name of the resource in the glideclient classad?
+            entry_name (str): Name of the resource in the glidefactory classad
+            trust_domain (str): trust domain for this Entry
+            auth_method (str): the authentication methods this entry supports in glidein submission, i.e. grid_proxy, scitoken
+            supported_signtypes (str): suppported sign types, i.e. sha1 (comma separated list)
+            pub_key_obj (_type_, optional): GlideinKey - for the frontend to use in encryption. Defaults to None.
+            glidein_submit (dict, optional): Submit attributes in the configuration. Defaults to {}.
+            glidein_attrs (dict, optional): glidein attrs to be published, not be overwritten by Frontends. Defaults to {}.
+            glidein_params (dict, optional): params to be published, can be overwritten by Frontends. Defaults to {}.
+            glidein_monitors (dict, optional): monitor attrs to be published. Defaults to {}.
+            glidein_stats (dict, optional): aggregated Entry(entry) and Factory(total) statistics to be published. Defaults to {}.
+            glidein_web_attrs (dict, optional): _description_. Defaults to {}.
+            glidein_config_limits (dict, optional): Factory configuration limits to be published. Defaults to {}.
         """
         # TODO: rename glidein_ to entry_ (entry_monitors)?
 
@@ -633,6 +638,7 @@ class EntryClassad(classadSupport.Classad):
 
         # write out both the attributes, params and monitors
         for prefix, data in (
+            (factoryConfig.glidein_submit_prefix, glidein_submit),
             (factoryConfig.glidein_attr_prefix, glidein_attrs),
             (factoryConfig.glidein_param_prefix, glidein_params),
             (factoryConfig.glidein_monitor_prefix, glidein_monitors),

--- a/unittests/fixtures/factory/work-dir/entry_el7_osg34/submit_attrs.cfg
+++ b/unittests/fixtures/factory/work-dir/entry_el7_osg34/submit_attrs.cfg
@@ -1,0 +1,4 @@
+# File: submit_attrs.cfg
+#
+RequestMemory   '2000'
+MySubmitAttr2       'Test12234567i'

--- a/unittests/fixtures/factory/work-dir/entry_el8_osg34/submit_attrs.cfg
+++ b/unittests/fixtures/factory/work-dir/entry_el8_osg34/submit_attrs.cfg
@@ -1,0 +1,2 @@
+# File: submit_attrs.cfg
+#

--- a/unittests/fixtures/factory/work-dir/entry_el8_osg35/submit_attrs.cfg
+++ b/unittests/fixtures/factory/work-dir/entry_el8_osg35/submit_attrs.cfg
@@ -1,0 +1,2 @@
+# File: submit_attrs.cfg
+#

--- a/unittests/fixtures/factory/work-dir/submit_attrs.cfg
+++ b/unittests/fixtures/factory/work-dir/submit_attrs.cfg
@@ -1,0 +1,2 @@
+# File: submit_attrs.cfg
+#


### PR DESCRIPTION
Adding the submit attributes (glidein/submit/submit_attrs, glidein/entry/config/submit/submit_attrs) to the glidefactory (Entry) ClassAd

This PR solves #307

This includes also some code quality improvements:
- Docstrings and PIP compliant (classes uppercase names, less generic exceptions) code improvements
- Removed fermilab hostname from test names in validate_node comment
- Removed no more supported use of has_key

For the review. The actual code changes important for the review are in the 3rd (last) commit