### PR TITLE
Fixed syntax in gangliad ClassAd configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Minor new features, mostly a bug fix release
 -   Changed M2Crypto imports to be compatible with 0.40.0 the code must import also the components (PR #377)
 -   Fixed PATHs handling in glidein_startup.sh (PR #379)
 -   Fixed match policy_file import failure (Issue #378, PR #380)
+-   Fixed syntax error in ClassAd used for gangliad configuration (Issue #368, PR #385)
 
 ### Testing / Development
 

--- a/install/templates/01_gwms_metrics.config
+++ b/install/templates/01_gwms_metrics.config
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
-# SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+// SPDX-License-Identifier: Apache-2.0
 
 [
   Name   = ifThenElse(GLIDEIN_Site is null, "Total_Glideins_RequestIdle", strcat(GLIDEIN_Site, "_Glideins_RequestIdle"));


### PR DESCRIPTION
Fixed syntax in gangliad ClassAd configuration. ClassAd files use C and C++ style comments (`//` or `/* ... */`), not pounds.

This PR fixes #368