### PR TITLE
Fixing Apptainer output validation in apptainer initial test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
+
+Changes since the last release
+
+### New features / functionalities
+
+-   item one of the list
+-   item N
+
+### Changed defaults / behaviours
+
+### Deprecated / removed options and commands
+
+### Security Related Fixes
+
+### Bug Fixes
+
+-   Fixed Apptainer validation not considering uid_map w/o initial blank (Issue #395, PR #396)
+
+### Testing / Development
+
+### Known Issues
+
 ## v3.10.6 \[2024-01-25\]
 
 Minor new features, mostly a bug fix release

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1356,6 +1356,11 @@ singularity_test_exec() {
         info "Singularity at '$singularity_bin' appears to work ($singularity_mode mode), user namespaces not available"
         echo "$singularity_mode"
         # true - not needed echo returns true
+    elif [[ $singularity_ec -eq 0 ]]; then
+        singularity_mode=privileged
+        warn "Singularity at '$singularity_bin' exited correctly (ec: 0) but returned unexpected output ($check_singularity). Continuing assuming $singularity_mode mode."
+        echo "$singularity_mode"
+        # true - not needed echo returns true
     else
         # test failed
         [[ "$check_singularity" = ',' ]] && info "Singularity at $singularity_bin failed (ec:$singularity_ec)" ||


### PR DESCRIPTION
The normal singularity/apptainer validation has 2 parts:
1. return exit code 0
2. return a valid output that allows us to determine the apptainer/singularity mode or at least verify the correct execution of the command in the provided image

The 1st commit was "Accepting apptainer test also when returning the wrong output", was disabling 2 and accepting the apptainer executable as long as the exit code is 0. It also provides further debug output to help with troubleshooting. It was as a temporary workaround. 

The second commit is the final solution and fixes #395 
It kept the additional debug output, it is back to failing if the test returns the wrong output, and it fixes the regular expression validating the output.
There may be no initial blank if the first number in /proc/self/uid_map  is big enough. This was tailing the previous expression.