### PR TITLE
Added APPTAINER/SINGULARITY_CACHEDIR and APPTAINER/SINGULARITY_TMPDIR

### DIFF
--- a/creation/web_base/frontend/generic_pre_singularity_setup.sh
+++ b/creation/web_base/frontend/generic_pre_singularity_setup.sh
@@ -39,15 +39,15 @@ fi
 # If you set an image for the key 'default', this will be picked if no preference is expressed by the job
 # And also remember that for now, GWMS supports Singularity images under /cvmfs/, preferably under
 # /cvmfs/singularity.opensciencegrid.org/ or at least on a path which existence can be verified (-e test)
-# CVMFS path as /cvmfs, the eventual translation to $CVMFS_MOUNT_DIR will happen later since the value may change
+# If $CVMFS_MOUNT_DIR is set, it is considered the root dir of CVMFS and replaces /cvmfs in the paths.
 
 # Note that you can add SINGULARITY_IMAGES_DICT also as attribute in the Factory or Frontend configuration
 
 # Note the legacy variables/attributes  SINGULARITY_IMAGE_DEFAULT, SINGULARITY_IMAGE_DEFAULT6 and SINGULARITY_IMAGE_DEFAULT7 will override the
-# dictionary values fro 'rhel7', 'rhel6' and 'rhel8' respectively
+# dictionary values for 'default', 'rhel6' and 'rhel7' respectively
 # you have to comment out both export and advertise lines together!!
 
-export SINGULARITY_IMAGES_DICT="rhel7:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el7:latest,rhel6:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el6:latest,rhel8:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el8:latest"
+export SINGULARITY_IMAGES_DICT="rhel9:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el9:latest,rhel8:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el8:latest,rhel7:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el7:latest,rhel6:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el6:latest"
 advertise SINGULARITY_IMAGES_DICT "$SINGULARITY_IMAGES_DICT" "S"
 
 exit 0

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -42,7 +42,7 @@
 # plat1:URL1,plat2:URL2,default:URLd
 # No comma is allowed in platform IDs or URLs, no colon is allowed in platform IDs.
 # A platform is an arbitrary string, could be the OS name, or a dash separated list (os-arch)
-# GWMS will do an exact match with the requested or default ones (rhel7,rhel6,default).
+# GWMS will do an exact match with the requested or default ones (default,rhel9,rhel8,rhel7,rhel6).
 # 'defult' is used for the default platform (no special meaning in reality)
 # The legacy variables SINGULARITY_IMAGE_DEFAULT6, SINGULARITY_IMAGE_DEFAULT7 are mapped to rhel6, rhel7
 # GLIDEIN_REQUIRED_OS (Factory - OS are allowed on the entry) and  REQUIRED_OS (Frontend or Job - OSes the job requires)
@@ -1887,8 +1887,8 @@ singularity_prepare_and_invoke() {
             return
         fi
         if [[ "$DESIRED_OS" = any ]]; then
-            # Prefer the platforms default,rhel7,rhel6,rhel8, otherwise pick the first one available
-            GWMS_SINGULARITY_IMAGE=$(singularity_get_image default,rhel7,rhel6,rhel8 ${GWMS_SINGULARITY_IMAGE_RESTRICTIONS:+$GWMS_SINGULARITY_IMAGE_RESTRICTIONS,}any)
+            # Prefer the platforms default,rhel9,rhel8,rhel7,rhel6, otherwise pick the first one available
+            GWMS_SINGULARITY_IMAGE=$(singularity_get_image default,rhel9,rhel8,rhel7,rhel6 ${GWMS_SINGULARITY_IMAGE_RESTRICTIONS:+$GWMS_SINGULARITY_IMAGE_RESTRICTIONS,}any)
         else
             GWMS_SINGULARITY_IMAGE=$(singularity_get_image "$DESIRED_OS" $GWMS_SINGULARITY_IMAGE_RESTRICTIONS)
         fi

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2408,8 +2408,8 @@ MAX_STARTD_LOG          I       10000000        +                               
                 used to select the platform: the first platform in the list that
                 matches a key will be used. You can use any string to identify
                 the images as lons as you are consistent with REQUIRED_OS, but
-                we recommend to use standard names like: rhel7 (for RHEL7 or
-                SL7), rhel6 (fpr RHEL6 or SL6). The default set in
+                we recommend to use standard names like: rhel9 (for RHEL9 or
+                AlmaLinux9), rhel7 (fpr RHEL7 or SL7). The default set in
                 generic_pre_singularity_setup.sh is
                 "rhel7:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el7:latest,rhel6:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el6:latest,rhel8:/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el8:latest"
                 or by running a pre_singularity setup script.

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2598,6 +2598,35 @@ MAX_STARTD_LOG          I       10000000        +                               
             </td>
           </tr>
           <tr>
+            <td><b>APPTAINER_CACHEDIR</b> b>SINGULARITY_CACHEDIR</b></td>
+            <td>String</td>
+            <td>$GLIDEIN_LOCAL_TMP_DIR/apptainer/cache</td>
+            <td>Frontend Factory</td>
+            <td>
+              <p>
+                Set to control where Apptainer and singularity place their
+                cache directory, default (only if the variable is unset, not if it is set
+                and empty) is $GLIDEIN_LOCAL_TMP_DIR/apptainer/cache.
+                Note that you can set any Apptainer/Singularity variable to
+                affect their behavior.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>APPTAINER_CACHEDIR</b> b>SINGULARITY_CACHEDIR</b></td>
+            <td>String</td>
+            <td>$GLIDEIN_LOCAL_TMP_DIR/apptainer/tmp</td>
+            <td>Frontend Factory</td>
+            <td>
+              <p>
+                Set to control where Apptainer and singularity place their
+                temp directory, default (only if the variable is unset, not if it is set
+                and empty) is $GLIDEIN_LOCAL_TMP_DIR/apptainer/tmp.
+                If set to null (""), Apptainer will search in /tmp and $TMPDIR.
+             </p>
+            </td>
+          </tr>
+          <tr>
             <td><b>GLIDEIN_CONTAINER_ENV</b></td>
             <td>String</td>
             <td></td>

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -1046,8 +1046,9 @@ SPDX-License-Identifier: Apache-2.0
                     If the users do not specify their own singularity image, the
                     default singularity image will be used.
                     SINGULARITY_IMAGES_DICT will be searched for 'default',
-                    'rhel7' and 'rhel6' images. Users can select a specific
-                    image form SINGULARITY_IMAGES_DICT by using REQUIRED_OS:
+                    'rhel9', 'rhel8', 'rhel7' and 'rhel6' images (in order).
+                    Users can select a specific image form
+                    SINGULARITY_IMAGES_DICT by using REQUIRED_OS:
                     <blockquote>+REQUIRED_OS = &quot;rhel6&quot;.</blockquote>
                     If the users specify a value different from 'any' for
                     <b>REQUIRED_OS</b> (e.g. rhel6, rhel7), the corresponding


### PR DESCRIPTION
Added APPTAINER/SINGULARITY_CACHEDIR and APPTAINER/SINGULARITY_TMPDIR to make sure that Apptainer/Singularity files are in the Glidein tree

The default cache in Apptainer is ~/.apptainer/cache which was in outside the Glidein space. Temp dir uses $TMPDIR which is $GLIDEIN_LOCAL_TMP_DIR in Glideins. 
The new defaults are $GLIDEIN_LOCAL_TMP_DIR/apptainer/cache and $GLIDEIN_LOCAL_TMP_DIR/apptainer/tmp
Define the variables to an empty value to use Apptainer defaults.

This PR fixes #403 