### PR TITLE
Setting blackhole mechanism only if enabled in the configuration

### DIFF
--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -1709,13 +1709,14 @@ MAX_STARTD_LOG          I       10000000        +                               
                 This attribute represents number of jobs completed too quickly
                 before raising the black hole detection flag. More details in
                 black hole detection section, on the bottom of who webpage
-                (Lifetime of a Glidein).
+                (Lifetime of a Glidein). When defined, must be an integer bigger
+                than 0.
               </p>
             </td>
           </tr>
           <tr>
             <td><b>GLIDEIN_BLACKHOLE_RATE</b></td>
-            <td>Int</td>
+            <td>Float</td>
             <td>
               <p>
                 Rate at which a Glidein is flagged as a black hole and retired.


### PR DESCRIPTION
Setting the blackhole mechanism only if enabled in the configuration

Before there was an error when the attributes were not set in the frontend/factory configuration.
The last error here was preventing the Startd from starting:
```
06/13/24 06:14:14 (pid:240950) eth0 enabled Wake-on: no (raw: 0x00)
06/13/24 06:14:14 (pid:240950) Using network interface eth0 for hibernation
06/13/24 06:14:14 (pid:240950) my_popenv: Failed to exec /var/lib/condor/execute/dir_226360/glide_gQGfYg/main/condor/libexec/condor_power_state, errno=2 (No such file or directory)
06/13/24 06:14:14 (pid:240950) Initially invoking hibernation plugin '/var/lib/condor/execute/dir_226360/glide_gQGfYg/main/condor/libexec/condor_power_state ad'
06/13/24 06:14:14 (pid:240950) Failed to run hibernation plugin '/var/lib/condor/execute/dir_226360/glide_gQGfYg/main/condor/libexec/condor_power_state ad'
06/13/24 06:14:14 (pid:240950) Detected hibernation states:
06/13/24 06:14:17 (pid:240950) VM universe will be tested to check if it is available
06/13/24 06:14:17 (pid:240950) ERROR "Syntax error in START expression: '((TRUE && (SiteWMS_WN_Draining =?= False)) && (ifThenElse(isUndefined((RecentJobBusyTimeAvg < (1.0/)) && (RecentJobBusyTimeCount >= )), False, (RecentJobBusyTimeAvg < (1.0/)) && (RecentJobBusyTimeCount >= )) =?= False)) && ((True) && (True) && (True) && (True)) && (((GLIDEIN_ToRetire =?= UNDEFINED) || (CurrentTime < GLIDEIN_ToRetire))) && (True)'" at line 587 in file /var/lib/condor/execute/slot1/dir_2508072/userdir/build-ba6TSX/BUILD/condor-10.6.0/src/condor_startd.V6/util.cpp
```
You can see how the missing attributes (shell variables in condor_startup.sh) are causing a malformed START expression.