### PR TITLE
Advertizing information about unprivileged user namespaces in glidein classad

### DIFF
--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -297,7 +297,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["file_list"].add_from_file(
             cvmfs_helper,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(cvmfs_helper), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(cvmfs_helper),
+                "exec",
             ),
             os.path.join(cgWConsts.WEB_BASE_DIR, cvmfs_helper),
         )
@@ -307,7 +308,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["file_list"].add_from_file(
             dist_select_script,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(dist_select_script), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(dist_select_script),
+                "exec",
             ),
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -160,8 +160,9 @@ perform_system_check() {
 	# call function to detect local CVMFS only if the GWMS_IS_CVMFS_MNT variable is not set; if the variable is not empty, do nothing
 	[[ -z "${GWMS_IS_CVMFS_MNT}" ]] && detect_local_cvmfs || :
 
-	sysctl user.max_user_namespaces &>/dev/null
-	GWMS_IS_UNPRIV_USERNS_SUPPORTED=$?
+    max_user_namespaces=$(cat /proc/sys/user/max_user_namespaces)
+	[[ $max_user_namespaces -gt 0 ]] && true || false
+    GWMS_IS_UNPRIV_USERNS_SUPPORTED=$?
 
 	unshare -U true &>/dev/null
 	GWMS_IS_UNPRIV_USERNS_ENABLED=$?
@@ -170,7 +171,7 @@ perform_system_check() {
 	GWMS_IS_FUSE_INSTALLED=$?
 
 	fusermount -V &>/dev/null
-        GWMS_IS_FUSERMOUNT=$?
+    GWMS_IS_FUSERMOUNT=$?
 
 	getent group fuse | grep $USER &>/dev/null
 	GWMS_IS_USR_IN_FUSE_GRP=$?
@@ -503,3 +504,17 @@ perform_cvmfs_mount () {
 
         #loginfo "End log for mounting CVMFS"
 }
+
+glidein_config="$1"
+
+# import add_config_line function
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
+
+# adding system information about unprivileged user namespaces to the glidein classad
+glidein_work_dir=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
+unprivileged_user_namespaces=$(has_unpriv_userns)
+gconfig_add "HAS_UNPRIVILEGED_USER_NAMESPACES" "$unprivileged_user_namespaces"
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "${glidein_config}" "-i")
+add_condor_vars_line "HAS_UNPRIVILEGED_USER_NAMESPACES" "S" "-" "+" "Y" "Y" "+"

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -513,8 +513,6 @@ add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" |
 . "$add_config_line_source"
 
 # adding system information about unprivileged user namespaces to the glidein classad
-glidein_work_dir=$(gconfig_get GLIDEIN_WORK_DIR "$glidein_config")
-unprivileged_user_namespaces=$(has_unpriv_userns)
-gconfig_add "HAS_UNPRIVILEGED_USER_NAMESPACES" "$unprivileged_user_namespaces"
+gconfig_add "HAS_UNPRIVILEGED_USER_NAMESPACES" "$(has_unpriv_userns)"
 condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "${glidein_config}" "-i")
 add_condor_vars_line "HAS_UNPRIVILEGED_USER_NAMESPACES" "S" "-" "+" "Y" "Y" "+"


### PR DESCRIPTION
Fixes #371 

As identified in the issue description, the `cvmfs_helper_funcs.sh` contains a utility `has_unpriv_userns` that can be used to fetch information whether unprivileged user namespaces are (1) supported and (2) enabled on the worker node. This utility internally uses the variables `GWMS_IS_UNPRIV_USERNS_SUPPORTED` and `GWMS_IS_UNPRIV_USERNS_ENABLED`. The utility returns one of four values: 

* `enabled`: unprivileged user namespaces is **supported and enabled** on the worker node
* `disabled`: unprivileged user namespaces is **supported but not enabled** on the worker node
* `unavailable`: unprivileged user namespaces is **neither supported nor enabled** on the worker node
* `error`: unprivileged user namespaces is **not supported but enabled** on the worker node

It is this value that gets advertized to the glidein classad and can be accessed using `HAS_UNPRIVILEGED_USER_NAMESPACES` attribute.

As an example, if the worker node supports unprivileged user namespaces and has unprivileged user namespaces enabled, the glidein classad on the client should show:
```
[testuser@gwms-frontend ~]$ condor_status -l slot1@glidein_1649634_917375096@fermicloudxxx.fnal.gov | grep -i "namespaces"
HAS_UNPRIVILEGED_USER_NAMESPACES = "enabled"
HasUserNamespaces = true
```

Additionally, the same variable is also exported to the user job environment (with the same name `HAS_UNPRIVILEGED_USER_NAMESPACES`). 