### PR TITLE
HTCondor TRUST_DOMAIN configuration macro set to string

### DIFF
--- a/creation/web_base/condor_vars.lst
+++ b/creation/web_base/condor_vars.lst
@@ -113,7 +113,7 @@ SiteWMS_WN_Preempt  C   False       +   N   Y   -
 GLIDEIN_PROVIDES    S	-			+   N	Y	+
 GLIDEIN_BLACKHOLE   C   False       +   N   Y   +
 GLIDEIN_CONDOR_TOKEN        S   -               +   N   Y   @
-TRUST_DOMAIN                C   -               +   N   Y   @
+TRUST_DOMAIN                S   -               +   N   Y   @
 
 # Entry specific User modifiable variables
 GLIDEIN_Site		S	$GLIDEIN_Entry_Name	+			N	Y	@


### PR DESCRIPTION
HTCondor TRUST_DOMAIN configuration macro set to string to avoid config error

StartdLog had errors like: 
```
CONFIGURATION PROBLEM: Failed to insert ClassAd attribute TRUST_DOMAIN = myhost.domain.org:9618?sock=collectorRANDOM.  The most common reason for this is that you forgot to quote a string value in the list of attributes being added to the STARTD ad.
```
Probably because the TRUST_DOMAIN was considered a condor expression.
NOTE that in 2018 HTCondor required to change TRUST_DOMAIN config macro from string to expression