### PR TITLE
Fixing EL9 compatibility to resolve failing glideins problem

### DIFF
--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -42,7 +42,10 @@ variables_reset() {
 
 	# following set of variables used to store operating system and kernel info
 	GWMS_OS_DISTRO=
-	GWMS_OS_VERSION=
+	GWMS_OS_NAME=
+	GWMS_OS_VERSION_FULL=
+	GWMS_OS_VERSION_MAJOR=
+	GWMS_OS_VERSION_MINOR=
 	GWMS_OS_KRNL_ARCH=
 	GWMS_OS_KRNL_NUM=
 	GWMS_OS_KRNL_VER=
@@ -141,37 +144,42 @@ perform_system_check() {
 	# 	-> assigns "yes" to GWMS_SYSTEM_CHECK to indicate this function
 	# 	has been run.
 
-	if [ -f '/etc/redhat-release' ]; then
+	if [[ -f "/etc/redhat-release" ]]; then
 		GWMS_OS_DISTRO=rhel
 	else
 		GWMS_OS_DISTRO=non-rhel
 	fi
 
-	GWMS_OS_VERSION=`lsb_release -r | awk -F'\t' '{print $2}'`
-	GWMS_OS_KRNL_ARCH=`arch`
-	GWMS_OS_KRNL_NUM=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " `
-	GWMS_OS_KRNL_VER=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $1}'`
-	GWMS_OS_KRNL_MAJOR_REV=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $2}'`
-	GWMS_OS_KRNL_MINOR_REV=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $3}'`
-	GWMS_OS_KRNL_PATCH_NUM=`uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 2 -d " "`
+	# source the os-release file to access the variables defined
+	. /etc/os-release
+	GWMS_OS_VERSION_FULL=$VERSION_ID
+	GWMS_OS_VERSION_MAJOR=$(echo "$GWMS_OS_VERSION_FULL" | awk -F'.' '{print $1}')
+	GWMS_OS_VERSION_MINOR=$(echo "$GWMS_OS_VERSION_FULL" | awk -F'.' '{print $2}')
+	GWMS_OS_NAME=${NAME,,}
+	GWMS_OS_KRNL_ARCH=$(arch)
+	GWMS_OS_KRNL_NUM=$(uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " )
+	GWMS_OS_KRNL_VER=$(uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $1}')
+	GWMS_OS_KRNL_MAJOR_REV=$(uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $2}')
+	GWMS_OS_KRNL_MINOR_REV=$(uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 1 -d " " | awk -F'.' '{print $3}')
+	GWMS_OS_KRNL_PATCH_NUM=$(uname -r | awk -F'-' '{split($2,a,"."); print $1,a[1]}' | cut -f 2 -d " ")
 
 	#df -h | grep /cvmfs &>/dev/null
 	#GWMS_IS_CVMFS_MNT=$?
 	# call function to detect local CVMFS only if the GWMS_IS_CVMFS_MNT variable is not set; if the variable is not empty, do nothing
 	[[ -z "${GWMS_IS_CVMFS_MNT}" ]] && detect_local_cvmfs || :
 
-    max_user_namespaces=$(cat /proc/sys/user/max_user_namespaces)
+	max_user_namespaces=$(cat /proc/sys/user/max_user_namespaces)
 	[[ $max_user_namespaces -gt 0 ]] && true || false
-    GWMS_IS_UNPRIV_USERNS_SUPPORTED=$?
+	GWMS_IS_UNPRIV_USERNS_SUPPORTED=$?
 
 	unshare -U true &>/dev/null
 	GWMS_IS_UNPRIV_USERNS_ENABLED=$?
 
-	yum list installed *fuse* &>/dev/null
+	[[ $GWMS_OS_VERSION_MAJOR -ge 9 ]] && dnf list installed fuse3* &>/dev/null || yum list installed fuse &>/dev/null
 	GWMS_IS_FUSE_INSTALLED=$?
 
-	fusermount -V &>/dev/null
-    GWMS_IS_FUSERMOUNT=$?
+	[[ $GWMS_OS_VERSION_MAJOR -ge 9 ]] && fusermount3 -V &>/dev/null || fusermount -V &>/dev/null
+	GWMS_IS_FUSERMOUNT=$?
 
 	getent group fuse | grep $USER &>/dev/null
 	GWMS_IS_USR_IN_FUSE_GRP=$?
@@ -189,7 +197,7 @@ print_os_info () {
         # INPUT(S): None
         # RETURN(S): Prints a message containing OS and kernel details
 
-        loginfo "Found $GWMS_OS_DISTRO${GWMS_OS_VERSION}-${GWMS_OS_KRNL_ARCH} with kernel $GWMS_OS_KRNL_NUM-$GWMS_OS_KRNL_PATCH_NUM"
+        loginfo "Found $GWMS_OS_NAME [$GWMS_OS_DISTRO] ${GWMS_OS_VERSION_FULL}-${GWMS_OS_KRNL_ARCH} with kernel $GWMS_OS_KRNL_NUM-$GWMS_OS_KRNL_PATCH_NUM"
 }
 
 
@@ -205,8 +213,10 @@ log_all_system_info () {
 
 	loginfo "..."
 	loginfo "Worker node details: "
+	loginfo "Hostname: $(hostname)"
 	loginfo "Operating system distro: $GWMS_OS_DISTRO"
-	loginfo "Operating System version: $GWMS_OS_VERSION"
+	loginfo "Operating system name: $GWMS_OS_NAME"
+	loginfo "Operating System version: $GWMS_OS_VERSION_FULL"
 	loginfo "Kernel Architecture: $GWMS_OS_KRNL_ARCH"
 	loginfo "Kernel version: $GWMS_OS_KRNL_VER"
 	loginfo "Kernel major revision: $GWMS_OS_KRNL_MAJOR_REV"

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -59,7 +59,7 @@ perform_system_check
 
 # gather the worker node information; perform_system_check sets a few variables that can be helpful here
 os_like=$GWMS_OS_DISTRO
-os_ver=$(echo $GWMS_OS_VERSION | awk -F'.' '{print $1}')
+os_ver=$GWMS_OS_VERSION_MAJOR
 arch=$GWMS_OS_KRNL_ARCH
 # construct the name of the cvmfsexec distribution file based on the worker node specs
 dist_file=cvmfsexec-${cvmfs_source}-${os_like}${os_ver}-${arch}

--- a/creation/web_base/cvmfsexec_platform_select.sh
+++ b/creation/web_base/cvmfsexec_platform_select.sh
@@ -32,14 +32,17 @@ if [[ ! $cvmfs_src =~ ^(osg|egi|default)$ ]]; then
 fi
 
 # TODO: is it possible to reuse cvmfs_helper_funcs.sh by sourcing it during the execution of this file????
-if [ -f '/etc/redhat-release' ]; then
+if [[ -f "/etc/redhat-release" ]]; then
     os_distro=rhel
 else
     os_distro=non-rhel
 fi
 
-os_ver=`lsb_release -r | awk -F'\t' '{print $2}' | awk -F"." '{print $1}'`
-krnl_arch=`arch`
+# using os-release file to get OS-related info
+. /etc/os-release
+os_ver_full=$VERSION_ID
+os_ver=$(echo "$os_ver_full" | awk -F '.' '{print $1}')
+krnl_arch=$(arch)
 mach_type=${os_distro}${os_ver}-${krnl_arch}
 
 cvmfsexec_platform="${cvmfs_src}-${mach_type}"


### PR DESCRIPTION
Fixes #423.

As described in the issue, recent tests of the `master` branch (production) revealed that the glidein startup failed. While these changes were already introduced in an ongoing PR for the development branch, these were not merged into the production branch since I was of the opinion that once the PR gets merged to development, the production would also be synced, which later Marco explained is not true (it's the other way around actually).

The test revealed that the production branch resulted in failing glideins with the message `lsb_release: command not found` because `/usr/bin/lsb_release` utility was not installed on the EL9 ITB CE where the changes for issue #371 was tested. It was confirmed by Marco that `lsb_release` is in `epel` repository and therefore, we should not count on it to be installed/available in the target CE where GlideinWMS code runs to start the glidein(s).
