### PR TITLE
Replacing xmlrunner with unittest-xml-reporting

### DIFF
--- a/build/ci/utils.sh
+++ b/build/ci/utils.sh
@@ -234,7 +234,7 @@ setup_python3_venv() {
         # importlib and argparse are in std Python 3.6 (>=3.1)
         # leaving mock, anyway mock is std in Python 3.6 (>=3.3), as unittest.mock
         pip_packages="toml ${PYCODESTYLE} ${COVERAGE} ${PYLINT} ${ASTROID}"
-        pip_packages="$pip_packages pyyaml ${MOCK} xmlrunner PyJWT requests"
+        pip_packages="$pip_packages pyyaml ${MOCK} unittest-xml-reporting PyJWT requests"
         pip_packages="$pip_packages ${HYPOTHESIS} ${AUTOPEP8} ${TESTFIXTURES}"
         pip_packages="$pip_packages ${HTCONDOR} ${JSONPICKLE} ${M2CRYPTO}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,5 @@ mock
 pytest
 tabulate
 # std in p3 unittest
-xmlrunner
+# xmlrunner incompatible w/ 3.12, use:
+unittest-xml-reporting


### PR DESCRIPTION
Replacing xmlrunner with unittest-xml-reporting that works also in Py3.12
pip install of xmlrunner was giving an error