### PR TITLE
Preventing the use of blackhole detection only when not used

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -74,7 +74,7 @@ error_gen=$(gconfig_get ERROR_GEN_PATH "$config_file")
 # Read the knobs coming from the frontend configuration for blackhole detection (GLIDEIN_BLACKHOLE_NUMJOBS and GLIDEIN_BLACKHOLE_RATE)
 glidein_blackhole_numjobs=$(gconfig_get GLIDEIN_BLACKHOLE_NUMJOBS "$config_file")
 glidein_blackhole_rate=$(gconfig_get GLIDEIN_BLACKHOLE_RATE "$config_file")
-if [[ -z "$GLIDEIN_BLACKHOLE_RATE" || "$GLIDEIN_BLACKHOLE_RATE" =~ ^0(\.0*)?$ ]]; then
+if [[ -z "$glidein_blackhole_rate" || "$glidein_blackhole_rate" =~ ^0(\.0*)?$ ]]; then
     use_blackhole_prevention=false
 else
     use_blackhole_prevention=true


### PR DESCRIPTION
Fixes #415.

**Note:** This is a patch fix for the prevention mechanism (PR #415) that was added to the blackhole detection mechanism in #331.

**TLDR;**
PR #415 introduced a bug which resulted in the prevention mechanism to be effective only when the blackhole detection feature was _not enabled_ (via the frontend configuration). When blackhole detection was necessary (aka, _enabled_), the prevention mechanism still continued to determine that blackhole detection was not needed, when in actual it should be needed. Turns out this was caused as a result of using the wrong case of the variable name involved in the determination logic. Specifically, the variable name should have been `glidein_blackhole_rate` (shell variable name in the context of condor_startup.sh) instead of `GLIDEIN_BLACKHOLE_RATE` (which is a frontend knob and is read from `glidein_config`).
