### PR TITLE
Disabled completely all shebang mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes since the last release
 
 -   Fixed root unable to remove other users' jobs in the Factory (PR #433)
 -   HTCondor TRUST_DOMAIN configuration macro set to string to avoid Glidein config error (PR #420)
+-   Disabled shebang mangliing in rpm_build to avoid gwms-python not finding the shell (Issue #436, PR #437)
 
 ### Testing / Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes since the last release
 
 -   Fixed root unable to remove other users' jobs in the Factory (PR #433)
 -   HTCondor TRUST_DOMAIN configuration macro set to string to avoid Glidein config error (PR #420)
--   Disabled shebang mangliing in rpm_build to avoid gwms-python not finding the shell (Issue #436, PR #437)
+-   Disabled shebang mangling in rpm_build to avoid gwms-python not finding the shell (Issue #436, PR #437)
 
 ### Testing / Development
 

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Disable shebang mangling (see GHI#436)
+%undefine __brp_mangle_shebangs
+
 # How to build tar file
 
 # git clone http://cdcvs.fnal.gov/projects/glideinwms


### PR DESCRIPTION
Replacement of /bin/sh in glidein script was causing problems with gwms-python failing on some CMS hosts.

See Issue #436 for more fine-grain options.

This fixes #436 