### PR TITLE
Updated the release upload script to work with osg-sw-submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes since the last release
 ### Testing / Development
 
 -   Replacing xmlrunner with unittest-xml-reporting (PR #428)
+-   Updated the release upload script to work with osg-sw-submit (PR #439)
 
 ### Known Issues
 


### PR DESCRIPTION
Updated the release upload script to work with osg-sw-submit, the new host to access the OSG upload library. 
Note the new parameter in the invocation to specify the Kerberos principal

Use `osg-release.sh -h` for more info

