### PR TITLE
Modify GPU Resource Declaration When Not Requested

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -880,6 +880,9 @@ EOF
                     cat >> "$CONDOR_CONFIG" <<EOF
 # Declare resource: ${i}
 MACHINE_RESOURCE_${res_name} = ${res_num}
+# Declare no use of GPUs, i.e. the worker node (WN) should not have GPUs.
+# Even though the WN may physically have them, we want them to be ignored.
+MACHINE_RESOURCE_GPUs = 0
 EOF
                 fi
                 if [[ "$res_opt" == "extra" ]]; then
@@ -946,7 +949,13 @@ if defined MACHINE_RESOURCE_NAMES
 endif
 START = (\$(START)) && (\$(EXTRA_SLOTS_START))
 EOF
-
+        else
+	    # when GLIDEIN_Resource_Slots is not defined
+            cat >> "$CONDOR_CONFIG" <<EOF
+# Declare no use of GPUs, i.e. the worker node (WN) should not have GPUs.
+# Even though the WN may physically have them, we want them to be ignored.
+MACHINE_RESOURCE_GPUs = 0
+EOF
         fi  # end of resource slot if
 
         # Set to shutdown if total idle exceeds max idle, or if the age


### PR DESCRIPTION
Fixes #444.

Discussed with Marco to understand the existing logic and behavior of using `GLIDEIN_Resource_Slots` attribute in factory configuration. The details are as follows:

To cater to the new behavior change in HTCondor when it comes to GPUs, three conditions were necessary to be included in order to set GPUS explicitly to 0 when GPUs are not requested. The three conditions are:
1. when `GLIDEIN_Resource_Slots` attribute is not defined in factory configuration, or
2. when `GLIDEIN_Resource_Slots` attribute's value does not include `GPUs`, or
3. when `GLIDEIN_Resource_Slots` attribute's value is set to 0.

**Logic to cater to behavior arising from conditions (1) and (2) is added newly as part of this PR while previously existing logic already had the behavior defined when condition (3) occurs.**

<hr />


**Additional details:**
Following examples of `GLIDEIN_Resource_Slots` attribute were used for testing all of the three conditions which constitute the updated logic: 
```
<!-- for testing condition (2) -->
<attr name="GLIDEIN_Resource_Slots" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="ioslot,2,200,static"/>
```
```
<!-- for testing condition (3) -->
<attr name="GLIDEIN_Resource_Slots" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="GPUs,0,type=main"/>
```

Following were also used for generic testing and debugging of the existing code before the changes were made to `condor_startup.sh`:
```
<attr name="GLIDEIN_Resource_Slots" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="GPUs,1,type=main"/>
```
```
<attr name="GLIDEIN_Resource_Slots" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="ioslot,2,disk=1GB;monitor;GPUs,3,,main"/>
```