### PR TITLE
Fixed failed log rotation due to wrong log file creation time recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes since the last release
 -   Disabled shebang mangling in rpm_build to avoid gwms-python not finding the shell (Issue #436, PR #437)
 -   Dynamic creation of HTCondor IDTOKEN password (Issue #440, PR #441)
 -   Autodetect CONDOR_OS in the manual_glidein_submit tool (Issue #449, PR #453)
+-   Failed log rotation due to wrong file creation time (Issue #451, PR #457)
 
 ### Testing / Development
 

--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -158,7 +158,7 @@ SPDX-License-Identifier: Apache-2.0
             entry_parallel_workers="0"&gt;</a
           ><br />
           <blockquote>
-            <a href="#">&lt;log_retention &gt;</a><br />
+            <a href="#log_retention">&lt;log_retention &gt;</a><br />
             <blockquote>
               <a href="#"
                 >&lt;condor_logs max_days="14.0" max_mbytes="100.0"
@@ -181,13 +181,13 @@ SPDX-License-Identifier: Apache-2.0
                   backup_count="5" /&gt;</a
                 ><br />
               </blockquote>
-              <a href="#">&lt;/process_logs &gt;</a><br />
-              <a href="#"
+              <a href="#process_logs">&lt;/process_logs &gt;</a><br />
+              <a href="#log_retention"
                 >&lt;summary_logs max_days="31.0" max_mbytes="100.0"
                 min_days="3.0" /&gt;</a
               ><br />
             </blockquote>
-            <a href="#">&lt;/log_retention &gt;</a><br />
+            <a href="#log_retention">&lt;/log_retention &gt;</a><br />
             <a href="#monitor"
               >&lt;monitor base_dir="/var/www/html/glidefactory/monitor"
               flot_dir="/opt/javascriptrrd-0.6.3/flot"
@@ -579,6 +579,7 @@ SPDX-License-Identifier: Apache-2.0
             </ul>
           </li>
           <li>
+            <a name="log_retention" />
             <a name="process_logs" />
             <div class="xml">
               &lt;glidein&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
@@ -624,20 +625,25 @@ SPDX-License-Identifier: Apache-2.0
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>
             <br /><br />
-            Log files are rotated based on a time and size of the log files as
-            follows:
+            Log files can be rotated based on the time and size of the log files
+            as follows:
             <ul>
               <li>
                 If the log file size reaches <i>max_bytes</i> it will be rotated
-                (NOTE: the value will be truncated and 0 means no rotation).
+                (NOTE: the value will be truncated and 0 means no size-based
+                rotation).
               </li>
               <li>
                 If the log file size is less that <i>max_bytes</i> but the file
-                is older than max_days, it will be rotated.
+                is older than max_days, it will be rotated. Use floats for
+                fractions of a day, the value will be converted in seconds, 0
+                means no time-based rotation
               </li>
               <li>
-                <i>min_days</i> is not used and is there for backwards
-                compatibility.
+                <i>min_days</i> Used in combination with max_bytes to delay file
+                size rotation until min_days are gone by. Use floats for
+                fractions of a day, the value will be converted in seconds, 0
+                means no delay (default).
               </li>
               <li>
                 Rotated files may be compressed. Supported compressions are Gzip
@@ -648,6 +654,11 @@ SPDX-License-Identifier: Apache-2.0
                 be kept and older ones are deleted. Defaults to 5.
               </li>
             </ul>
+            NOTE: Time-based rotation and rotation delay use the file creation
+            time which may not be available on your system or file system. In
+            that case, the delay is disabled and time-based location will use
+            the log file modification time when the logger is restarted. This
+            may lead to incorrect time-based rotation.
           </li>
           <li>
             <a name="condor_tarball" />

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -154,9 +154,9 @@ SPDX-License-Identifier: Apache-2.0
             enable_attribute_expansion="False"&gt;</a
           ><br />
           <blockquote>
-            <a href="#">&lt;log_retention &gt;</a><br />
+            <a href="#log_retention">&lt;log_retention &gt;</a><br />
             <blockquote>
-              <a href="#">&lt;process_logs &gt;</a><br />
+              <a href="#process_logs">&lt;process_logs &gt;</a><br />
               <blockquote>
                 <a href="#process_logs"
                   >&lt;process_log structured="False" extension="info"
@@ -169,9 +169,9 @@ SPDX-License-Identifier: Apache-2.0
                   msg_types="DEBUG,ERR,WARN" backup_count="5" /&gt;</a
                 ><br />
               </blockquote>
-              <a href="#">&lt;/process_logs &gt;</a><br />
+              <a href="#process_logs">&lt;/process_logs &gt;</a><br />
             </blockquote>
-            <a href="#">&lt;/log_retention &gt;</a><br />
+            <a href="#log_retention">&lt;/log_retention &gt;</a><br />
             <a href="#match"
               >&lt;match match_expr="True"
               start_expr="$(JOBSTR_ATTR)&lt;$$(JOBSTR_VAL)"
@@ -518,6 +518,7 @@ SPDX-License-Identifier: Apache-2.0
             </p>
           </li>
           <li>
+            <a name="log_retention" />
             <a name="process_logs" />
             <div class="xml">
               &lt;frontend&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
@@ -557,20 +558,25 @@ SPDX-License-Identifier: Apache-2.0
             <br /><br />
             <b>Log Retention and Rotation Policy:</b>
             <br /><br />
-            Log files are rotated based on a time and size of the log files as
-            follows:
+            Log files can be rotated based on the time and size of the log files
+            as follows:
             <ul>
               <li>
                 If the log file size reaches <i>max_bytes</i> it will be rotated
-                (NOTE: the value will be truncated and 0 means no rotation).
+                (NOTE: the value will be truncated and 0 means no size-based
+                rotation).
               </li>
               <li>
                 If the log file size is less that <i>max_bytes</i> but the file
-                is older than max_days it will be rotated.
+                is older than max_days, it will be rotated. Use floats for
+                fractions of a day, the value will be converted in seconds, 0
+                means no time-based rotation
               </li>
               <li>
-                <i>min_days</i> is not used and is there for backwards
-                compatibility.
+                <i>min_days</i> Used in combination with max_bytes to delay file
+                size rotation until min_days are gone by. Use floats for
+                fractions of a day, the value will be converted in seconds, 0
+                means no delay (default).
               </li>
               <li>
                 Rotated files may be compressed. Supported compressions are Gzip
@@ -581,8 +587,12 @@ SPDX-License-Identifier: Apache-2.0
                 be kept and older ones are deleted. Defaults to 5.
               </li>
             </ul>
+            NOTE: Time-based rotation and rotation delay use the file creation
+            time which may not be available on your system or file system. In
+            that case, the delay is disabled and time-based location will use
+            the log file modification time when the logger is restarted. This
+            may lead to incorrect time-based rotation.
           </li>
-
           <li>
             <p>
               <a name="wmscollector" />


### PR DESCRIPTION
Fixed failed log rotation due to wrong log file creation time recording
POSIX provides only access, modification and metadata change times. Timed rotation should be based on creation time, available sometimes as `os.stat(path).st_birthtime`.
This fix uses the correct creation time and disables timed rotation when the creation time is not available.

This fixes #451 
