### PR TITLE
Fix bytes/megabytes confusion and premature int truncation in logging configuration

### DIFF
--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -584,7 +584,7 @@ SPDX-License-Identifier: Apache-2.0
             <div class="xml">
               &lt;glidein&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
               max_days=&quot;<i>max days</i>&quot; min_days=&quot;<i>min days</i
-              >&quot; max_bytes=&quot;<i>max bytes</i>&quot;
+              >&quot; max_mbytes=&quot;<i>max mega bytes</i>&quot;
               type=&quot;<i>INFO</i>&quot; backup_count=&quot;<i>backup count</i
               >&quot; compression=&quot;<i>gz</i>&quot;/&gt;
             </div>
@@ -629,19 +629,20 @@ SPDX-License-Identifier: Apache-2.0
             as follows:
             <ul>
               <li>
-                If the log file size reaches <i>max_bytes</i> it will be rotated
-                (NOTE: the value will be truncated and 0 means no size-based
-                rotation).
+                If the log file size reaches <i>max_mbytes</i> MB it will be
+                rotated. Use floats for fractions of a MegaByte. (NOTE: the
+                value will be truncated after converting to Bytes (multiply by
+                2^20) and 0 means no size-based rotation).
               </li>
               <li>
-                If the log file size is less that <i>max_bytes</i> but the file
+                If the log file size is less than <i>max_mbytes</i> but the file
                 is older than max_days, it will be rotated. Use floats for
                 fractions of a day, the value will be converted in seconds, 0
                 means no time-based rotation
               </li>
               <li>
-                <i>min_days</i> Used in combination with max_bytes to delay file
-                size rotation until min_days are gone by. Use floats for
+                <i>min_days</i> Used in combination with max_mbytes to delay
+                file size rotation until min_days are gone by. Use floats for
                 fractions of a day, the value will be converted in seconds, 0
                 means no delay (default).
               </li>

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -523,8 +523,8 @@ SPDX-License-Identifier: Apache-2.0
             <div class="xml">
               &lt;frontend&gt;&lt;log_retention&gt;&lt;process_logs&gt;&lt;process_log
               structured="True" max_days=&quot;<i>max days</i>&quot;
-              min_days=&quot;<i>min days</i>&quot; max_bytes=&quot;<i
-                >max bytes</i
+              min_days=&quot;<i>min days</i>&quot; max_mbytes=&quot;<i
+                >max megabytes</i
               >&quot; backup_count=&quot;<i>backup count</i>&quot;
               type=&quot;<i>ALL</i>&quot; compression=&quot;<i>gz</i>&quot;/&gt;
             </div>
@@ -562,19 +562,20 @@ SPDX-License-Identifier: Apache-2.0
             as follows:
             <ul>
               <li>
-                If the log file size reaches <i>max_bytes</i> it will be rotated
-                (NOTE: the value will be truncated and 0 means no size-based
-                rotation).
+                If the log file size reaches <i>max_mbytes</i> MB it will be
+                rotated. Use floats for fractions of a MegaByte. (NOTE: the
+                value will be truncated after converting to Bytes (multiply by
+                2^20) and 0 means no size-based rotation).
               </li>
               <li>
-                If the log file size is less that <i>max_bytes</i> but the file
+                If the log file size is less than <i>max_mbytes</i> but the file
                 is older than max_days, it will be rotated. Use floats for
                 fractions of a day, the value will be converted in seconds, 0
                 means no time-based rotation
               </li>
               <li>
-                <i>min_days</i> Used in combination with max_bytes to delay file
-                size rotation until min_days are gone by. Use floats for
+                <i>min_days</i> Used in combination with max_mbytes to delay
+                file size rotation until min_days are gone by. Use floats for
                 fractions of a day, the value will be converted in seconds, 0
                 means no delay (default).
               </li>

--- a/lib/logSupport.py
+++ b/lib/logSupport.py
@@ -525,9 +525,9 @@ def get_logger_with_handlers(name, directory, config_data, level=logging.DEBUG):
             directory,
             plog["msg_types"],
             plog["extension"],
-            int(float(plog["max_days"])),
-            int(float(plog["min_days"])),
-            int(float(plog["max_mbytes"])),
+            float(plog["max_days"]),
+            float(plog["min_days"]),
+            float(plog["max_mbytes"]),
             int(float(plog["backup_count"])),
             plog["compression"],
         )


### PR DESCRIPTION
Fix bytes/megabytes confusion and premature int truncation in logging configuration