### PR TITLE
Remove confusing tac Broken pipe error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes since the last release
 ### Bug Fixes
 
 -   Fixed early truncation in log files configuration and inconsistent documentation (Issue #464, PR #462, PR #463)
+-   Removed confusing tac broken pipe messages from the Glidein stderr (PR #465)
 
 ### Testing / Development
 

--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -46,8 +46,9 @@ gconfig_get() {
     [[ -z "${config_file}" ]] && { warn "Error: glidein_config not provided and glidein_config variable not defined. Forcing exit."; exit 1; }
     [[ -n "$3" && ! "$3" = \-* ]] && { warn "Error: gconfig_get 3rd parameter must start with '-' Forcing exit."; exit 1; }
     [[ -r "$config_file" ]] || { true; return; }
+    # Redirected tac stderr to /dev/null to avoid "tac: write error: Broken pipe" message when grep closes early the pipe after the result is found
     # Leave the extra space in the grep, to parse correctly strings w/ the same beginning
-    $TAC "$config_file" | grep -m1 $3 "^$1 " | cut -d ' ' -f 2-
+    $TAC "$config_file" 2>/dev/null | grep -m1 $3 "^$1 " | cut -d ' ' -f 2-
 }
 
 gconfig_log_name() {


### PR DESCRIPTION
Redirecting tac stderr in gconfig_get to /dev/null to avoid "tac: write error: Broken pipe" message when grep closes early the pipe after the result is found

The message is harmless but creating noise and confusing the operators