### PR TITLE
Always send SIGQUIT to HTCondor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
+-   Always send SIGQUIT to HTCondor when the Glidein receives INT, TERM, QUIT signals. This speeds up the shutdown (PR #466)
+
 ### Deprecated / removed options and commands
 
 ### Security Related Fixes

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -23,9 +23,11 @@ trap_with_arg() {
 # all of its children. When each child exits, the master will send a SIGKILL to any remaining descendants.
 # Once all of the children exit, the master then exits.
 on_die() {
-    condor_signal=$1
-    # Can receive SIGTERM SIGINT SIGQUIT, condor understands SIGTERM SIGQUIT. Send SIGQUIT for SIGQUIT, SIGTERM otherwise
-    [[ "$condor_signal" != SIGQUIT ]] && condor_signal=SIGTERM
+    # Can receive SIGTERM SIGINT SIGQUIT as $1, condor understands SIGTERM (graceful) SIGQUIT (fast). Send SIGQUIT for SIGQUIT, SIGTERM otherwise
+    # condor_signal=$1
+    # [[ "$condor_signal" != SIGQUIT ]] && condor_signal=SIGTERM
+    # The HTCondor team suggested to send always SIGQUIT to speedup the shutdown and avoid leftover files
+    condor_signal=SIGQUIT
     condor_pid_tokill=$condor_pid
     [[ -z "$condor_pid_tokill" ]] && condor_pid_tokill=`cat $PWD/condor_master2.pid 2> /dev/null`
     echo "Condor startup received $1 signal ... shutting down condor processes (forwarding $condor_signal to $condor_pid_tokill)"


### PR DESCRIPTION
Before SIGTERM was used for graceful shutdown. Now SIGQUIT is forwarded to HTCondor no matter the signal received by the Glidein (INT, TERM, QUIT)

This was requested by FactoryOps -J.Dost- under HTCondor -J.Frey- suggestion to reduce the leftover files problem when Glideins are killed