### PR TITLE
Fixed DictFile.append(), Glidein logging, and added logserver

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,6 +13,10 @@ Files: .codecov.yml .coveragerc .editorconfig .gitattributes .gitignore .gitmodu
 Copyright: 2009 Fermi Research Alliance, LLC
 License: Apache-2.0
 
+Files: logserver/logging_config.json logserver/composer.json
+Copyright: 2009 Fermi Research Alliance, LLC
+License: Apache-2.0
+
 Files: .github/ISSUE_TEMPLATE/* bigfiles/* etc/* config/* creation/templates/*.service creation/templates/*.cron creation/templates/*.timer doc/tags*txt lib/logging.conf test/bats/fixtures/* unittests/*.fixture unittests/fixtures/*
 Copyright: 2009 Fermi Research Alliance, LLC
 License: Apache-2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
-## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
+## v3.10.9 \[2024-12-23\]
 
-Changes since the last release
+Fixed the Glidein logging and added an sample log server
 
 ### New features / functionalities
 
--   item one of the list
--   item N
+-   Added custom log server example (glideinwms-logging) (Issue #398, PR #467)
 
 ### Changed defaults / behaviours
 
@@ -24,6 +23,7 @@ Changes since the last release
 
 -   Fixed early truncation in log files configuration and inconsistent documentation (Issue #464, PR #462, PR #463)
 -   Removed confusing tac broken pipe messages from the Glidein stderr (PR #465)
+-   Fixed JWT logging credentials not transferred to the Glidein. This includes removal of DictFile.append() and use of add_environment() for JWT tokens (Issue #398, PR #467)
 -   Fixed quotes in glidein command line unpacking and replaced deprecated add_config_line commands (PR #468)
 
 ### Testing / Development

--- a/build/packaging/rpm/gwms-logserver.conf.httpd
+++ b/build/packaging/rpm/gwms-logserver.conf.httpd
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# This is the httpd conf file
+# GlideinWMS Logging Server web configuration
+
+Alias /logserver /var/lib/gwms-logserver/web-area
+<Directory /var/lib/gwms-logserver/web-area/>
+    <IfModule mod_authz_core.c>
+        # Apache 2.4
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        # Apache 2.2
+        Order allow,deny
+        Allow from all
+    </IfModule>
+    <IfModule mod_authnz_jwt>
+        AuthType jwt
+        AuthName "private area"
+        # Require valid-user
+    </IfModule>
+    # Options +Indexes
+    AllowMethods PUT GET POST OPTIONS
+    # Require method PUT GET POST OPTIONS
+    #<Limit GET POST PUT OPTIONS DELETE PATCH HEAD>
+    #  Require all granted
+    #</Limit>
+</Directory>
+
+# Use the following version if you are using mod_jwt (authnz_mod_jwt)
+# This will allow a simpler PUT uploader because it will not need to validate the JWT
+
+#AuthJWTSignatureAlgorithm HS256
+#AuthJWTSignatureSharedSecret VG9rZVNlY3JldEtleQo=
+#AuthJWTIss factory-workspace.glideinwms.org
+#
+#Alias /logging /var/lib/gwms-logging/logging
+#<Directory /var/lib/gwms-logging/logging/>
+#    <IfModule mod_authz_core.c>
+#        # Apache 2.4
+#        Require all granted
+#    </IfModule>
+#    <IfModule !mod_authz_core.c>
+#        # Apache 2.2
+#        Order allow,deny
+#        Allow from all
+#    </IfModule>
+#    <IfModule mod_authnz_jwt>
+#        AuthType jwt
+#        AuthName "private area"
+#        # Require valid-user
+#    <IFModule>
+#    # Options +Indexes
+#    AllowMethods PUT GET POST OPTIONS
+#    # Require method PUT GET POST OPTIONS
+#</Directory>
+#
+# # This is needed to always forward the HTTP_AUTHORIZATION header
+# # See: https://www.codepunker.com/blog/php-a-primer-on-the-basic-authorization-header
+# RewriteEngine On
+# RewriteCond %{HTTP:Authorization} ^(.+)$
+# RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

--- a/creation/lib/cgWCreate.py
+++ b/creation/lib/cgWCreate.py
@@ -113,11 +113,11 @@ def get_factory_log_recipients(entry):
         entry: dict-like object representing the entry configuration
 
     Returns:
-        list: list contaning the URLs of the log servers, empty if none present
+        list: list containing the URLs of the log servers, empty if none present
     """
     entr_attrs = entry.get_child_list("attrs")
     for attr in entr_attrs:
-        if attr["name"] == "LOG_RECIPIENTS_FACTORY":
+        if attr["name"] == "GLIDEIN_LOG_RECIPIENTS_FACTORY":
             return attr["value"].split()
     return []
 

--- a/creation/lib/cgWCreate.py
+++ b/creation/lib/cgWCreate.py
@@ -193,7 +193,8 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
         frontend_recipients = []  # TODO: change when adding support for LOG_RECIPIENTS_CLIENT
         log_recipients = list(set(factory_recipients + frontend_recipients))
         if len(log_recipients) > 0:
-            self.append("environment", '"LOG_RECIPIENTS=' + "'" + " ".join(log_recipients) + "'" + '"')
+            # self.append("environment", '"LOG_RECIPIENTS=' + "'" + " ".join(log_recipients) + "'" + '"')
+            self.add_environment("LOG_RECIPIENTS='" + " ".join(log_recipients) + "'")
         # print("Token dir: " + token_basedir)  # DEBUG
 
         # Add in some common elements before setting up grid type specific attributes

--- a/creation/lib/cgWDictFile.py
+++ b/creation/lib/cgWDictFile.py
@@ -159,22 +159,34 @@ class CondorJDLDictFile(cWDictFile.DictFile):
         cWDictFile.DictFile.__init__(self, dir, fname, sort_keys, order_matters, fname_idx)
         self.jobs_in_cluster = jobs_in_cluster
 
-    def append(self, key, val):
-        # TODO add_environment would allow an easier handling of the environment attribute:
-        #  - ordered dict as input
-        #  - handling quoting and escaping
-        #  - formatting and overwriting the environment attribute in the submit file dict
-        if key == "environment":
-            # assumed to be in the new format (quoted)
-            if key not in self.keys:
-                self.add(key, val)
-            else:
-                # should add some protection about correct quoting
-                self.add(f"{val[:-1]} {self[key][1:]}", True)
-        else:
-            raise RuntimeError(f"CondorJDLDictFile append unsupported for key {key} (val: {val})!")
+    # append has been replaced by add_environment to ease the quote handling
+    # If a generic version is needed, the code can be modified and restored
+    # def append(self, key, val):
+    #     if key == "environment":
+    #         # assumed to be in the new format (quoted)
+    #         if key not in self.keys:
+    #             self.add(key, val)
+    #         else:
+    #             # should add some protection about correct quoting
+    #             self.add(key, f"{val[:-1]} {self[key][1:]}", True)
+    #     else:
+    #         raise RuntimeError(f"CondorJDLDictFile append unsupported for key {key} (val: {val})!")
 
     def add_environment(self, val):
+        """Add a variable definition to the "environment" key in the CondorJDLDictFile.
+        Defines a new "environment" entry if not there,
+        appends to the existing environment if there.
+        The whole environment value is enclosed in double quotes (")
+
+        Args:
+            val (str): variable definition to add to the environment. Cannot contain double quotes (")
+                Single quotes (') are OK and can be used to quote string values
+        """
+        # TODO: improve environment handling:
+        #  - allow ordered dict as input
+        #  - handling quoting and escaping, e.g. validate val for double quotes
+        #  - formatting and overwriting the environment attribute in the submit file dict
+        #    e.g. add a variable already in the environment
         curenv = self.get("environment")
         if curenv:
             if curenv[0] == '"':

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -510,7 +510,7 @@ fi
 logging_utils_source=$(gconfig_get LOGGING_UTILS_SOURCE "${config_file}")
 # shellcheck source=logging_utils.source
 . "${logging_utils_source}"
-log_setup "${config_file}"
+glog_setup "${config_file}"
 
 # At this point, we need to define two times:
 #  die_time = time that glidein will enter graceful shutdown

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -503,9 +503,10 @@ glidein_exit() {
         fi
     fi
 
-    log_write "glidein_startup.sh" "text" "glidein is about to exit with retcode $1" "info"
-    send_logs_to_remote
-
+    glog_write "glidein_startup.sh" "text" "glidein is about to exit with retcode $1" "info"
+    if ! glog_send; then
+        warn "Failed to send Glidein Logging"
+    fi
     glidien_cleanup
 
     print_tail "$1" "${final_result_simple}" "${final_result_long}"
@@ -1742,8 +1743,14 @@ fi
 # Move the token files from condor to glidein workspace
 # TODO: compare this w/ setup_x509.sh
 # monitoring tokens, Should be using same credentials directory?
-mv "${start_dir}/tokens.tgz" .
-mv "${start_dir}/url_dirs.desc" .
+# TODO: url_dirs.desc seems to be defined only if there is a log url and requires factory upgrade
+#     this should be investigated and maybe changed
+if [[ -f "${start_dir}/tokens.tgz" && -f "${start_dir}/url_dirs.desc" ]]; then
+    mv "${start_dir}/tokens.tgz" .
+    mv "${start_dir}/url_dirs.desc" .
+else
+    warn "Unable to find Glidein Logging files: $([[ -f "${start_dir}/url_dirs.desc" ]] || echo description), $([[ -f "${start_dir}/tokens.tgz" ]] || echo tokens)."
+fi
 # idtokens are handled in setup_x509.sh - TODO: remove once verified
 #for idtk in ${start_dir}/*.idtoken; do
 #   if cp "${idtk}" . ; then
@@ -1834,13 +1841,19 @@ params2file ${params}
 
 ############################################
 # Setup logging
-log_init "${glidein_uuid}" "${work_dir}"
+if ! glog_init "${glidein_uuid}" "${work_dir}"; then
+    warn "Failed to initialize Glidein Logging"
+fi
 # Remove these files, if they are still there
 rm -rf tokens.tgz url_dirs.desc tokens
-log_setup "${glidein_config}"
+if ! glog_setup "${glidein_config}"; then
+    warn "Failed to setup Glidein Logging"
+fi
 
 echo "Downloading files from Factory and Frontend"
-log_write "glidein_startup.sh" "text" "Downloading file from Factory and Frontend" "debug"
+if ! glog_write "glidein_startup.sh" "text" "Downloading file from Factory and Frontend" "debug"; then
+    warn "Failed first write to Glidein Logging"
+fi
 
 #####################################
 # Fetch descript and signature files
@@ -2008,9 +2021,11 @@ fixup_condor_dir
 # Start the glidein main script
 gconfig_add "GLIDEIN_INITIALIZED" "1"
 
-log_write "glidein_startup.sh" "text" "Starting the glidein main script" "info"
-log_write "glidein_startup.sh" "file" "${glidein_config}" "debug"
-send_logs_to_remote          # checkpoint
+glog_write "glidein_startup.sh" "text" "Starting the glidein main script" "info"
+glog_write "glidein_startup.sh" "file" "${glidein_config}" "debug"
+if ! glog_send; then          # checkpoint
+    echo "Failed to checkpoint Glidein Logging"
+fi
 echo "# --- Last Script values ---" >> glidein_config
 last_startup_time=$(date +%s)
 ((validation_time=last_startup_time-startup_time)) || true

--- a/creation/web_base/logging_test.sh
+++ b/creation/web_base/logging_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Example custom script using the Glidein logging utility
+#
+# Use: logging_test.sh glidein_config
+# Test the logging utils: correct setup, writing, upload of the logs
+# Enable logging, e.g. in the Factory with:
+#       <attr name="GLIDEIN_LOG_RECIPIENTS_FACTORY" const="False" glidein_publish="True" job_publish="True"
+#       parameter="True" publish="True" type="string"
+#       value="https://factory-workspace.glideinwms.org/logserver/put.php"/>
+
+# Get the Glidein configuration file name to access the global variables
+glidein_config=$1
+
+# import add_config_line/glidein_config functions
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
+
+# find error reporting helper script
+#error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+# shellcheck source=./logging_utils.source
+. "$(gconfig_get LOGGING_UTILS_SOURCE)"
+
+# add an attribute
+gconfig_add custom_log_test "run_$(date)"
+
+# read an attributes (set by you or some other script)
+#myvar=$(gconfig_get myattribute)
+
+fn_exists() {
+    # Test if $1 is a valid function (true if it is)
+    # LC_ALL=C type $1 | grep -q 'shell function'
+    LC_ALL=C type $1 | grep -q 'function'
+}
+
+log_defined=no
+if fn_exists glog_write; then
+  log_defined=OK
+fi
+
+log_did_setup=no
+if glog_setup "$glidein_config"; then
+  log_did_setup=OK
+fi
+
+log_written=no
+if glog_write logging_test.sh text "Message 1 from logging_test.sh" info; then
+  log_written=OK
+fi
+
+log_sent=no
+if glog_send; then
+  log_sent=OK
+fi
+
+# Everything worked out fine
+"$error_gen" -ok use_log.sh log_defined "$log_defined" log_did_setup "$log_did_setup" log_written "$log_written" log_sent "$log_sent" ended OK

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -9,6 +9,8 @@
 # Every logged event is recorded in a separate file. Eventually, these shards
 # are merged into a single log file; metadata is added at the beginning.
 # Logs are sent to one or more remote servers via https.
+#
+# if GLIDEIN_QUIET is set warn messages are not print
 
 log_initialized=0
 log_ready=0
@@ -28,7 +30,7 @@ warn() {
 }
 
 
-serialize_assoc_arr() {
+_glog_serialize_assoc_arr() {
     # Serialize an associative array to a file
     # To deserialize, use:
     #   eval "declare -A <arr>=$(cat <file>)"
@@ -42,7 +44,7 @@ serialize_assoc_arr() {
 }
 
 
-generate_glidein_metadata_json() {
+_glog_generate_glidein_metadata_json() {
     # Create a log shard file containing information about the glidein
 
     if command -v jq >/dev/null 2>&1; then
@@ -75,7 +77,7 @@ generate_glidein_metadata_json() {
 }
 
 
-log_init_tokens() {
+_glog_init_tokens() {
     # Process the tokens received from the factory to authenticate with log server:
     # keep only the necessary ones, delete everything else
     # An associative array is created and serialized: it maps server urls to tokens
@@ -84,17 +86,17 @@ log_init_tokens() {
 
     local recipients=("$@")
     if [ "${#recipients[@]}" -eq 0 ]; then
-        warn "log_init_tokens: empty argument (list of recipients)"
+        warn "_glog_init_tokens: empty argument (list of recipients)"
         return 1
     fi
 
     if [ ! -f tokens.tgz ] || [ ! -f url_dirs.desc ]; then
-        warn "log_init_tokens: missing token files (tar and descriptor)"
+        warn "_glog_init_tokens: missing token files (tar and descriptor)"
         return 2
     fi
 
     if ! tar xf tokens.tgz; then
-        warn "log_init_tokens: failed to untar the tokens archive"
+        warn "_glog_init_tokens: failed to untar the tokens archive"
         return 3
     fi
 
@@ -110,20 +112,20 @@ log_init_tokens() {
             # Use the token signed by the factory
             tokens_arr["${recip}"]=$(cat tokens/"${recip_dir}"/default.jwt)
         else
-            warn "log_init_tokens: could not find any valid token for ${recip}"
+            warn "_glog_init_tokens: could not find any valid token for ${recip}"
             # TODO: maybe fail only for this recipient, still serving the others?
             return 4
         fi
     done
 
-    serialize_assoc_arr "tokens_arr" tokens_arr
+    _glog_serialize_assoc_arr "tokens_arr" tokens_arr
 
     # It's important to remove these files because they contain private information
     rm -rf tokens.tgz url_dirs.desc tokens
 }
 
 
-log_init() {
+glog_init() {
     # Initializes the log utility with the specified configuration.
     # This also creates the necessary folders, and should be called only once per glidein.
     # Arguments:
@@ -131,13 +133,13 @@ log_init() {
 
     # Validate number of arguments
     if [ "$#" -ne 2 ]; then
-        warn "log_init: could not initialize log. Expected 2 arguments, got $#."
+        warn "glog_init: could not initialize log. Expected 2 arguments, got $#."
         return 1
     fi
 
     # Inherit glidein_config from caller. It is necessary for logging to be properly configured.
     if [ ! -f "${glidein_config}" ]; then
-        warn "log_init: glidein_config not defined in ${0}. Logging will not work here."
+        warn "glog_init: glidein_config not defined in ${0}. Logging will not work here."
         return 2
     else
         add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "${glidein_config}" | cut -d ' ' -f 2-)
@@ -162,13 +164,13 @@ log_init() {
     fi
 
     # Setup tokens to authenticate with log servers
-    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
+    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS_FACTORY "${glidein_config}") $(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
     local no_send=0
     if [ "${#log_recipients[@]}" -eq 0 ]; then
-        warn "log_init: no recipients configured. Logs will still be produced, but not forwarded to remote servers."
+        warn "glog_init: no recipients configured. Logs will still be produced, but not forwarded to remote servers."
         no_send=1
-    elif ! log_init_tokens "${log_recipients[@]}"; then
-        warn "log_init: error while initializing tokens. Logs will still be produced, but not forwarded to remote servers."
+    elif ! _glog_init_tokens "${log_recipients[@]}"; then
+        warn "glog_init: error while initializing tokens. Logs will still be produced, but not forwarded to remote servers."
         no_send=1
     fi
 
@@ -177,7 +179,7 @@ log_init() {
         curl_version=$(curl --version 2>&1 | head -1)
     else
         curl_version="not installed"
-        warn "log_init: curl not installed. Logs will still be produced, but not forwarded to remote servers."
+        warn "glog_init: curl not installed. Logs will still be produced, but not forwarded to remote servers."
         no_send=1
     fi
 
@@ -188,7 +190,7 @@ log_init() {
     mkdir -p "${logdir}/shards/creating"
 
     # Create an 'empty' log, containing only glidein metadata
-    generate_glidein_metadata_json
+    _glog_generate_glidein_metadata_json
     echo "[" > "${logdir}/${log_logfile}"
     cat "${logdir}/glidein_metadata.json" >> "${logdir}/${log_logfile}"
     echo "]" >> "${logdir}/${log_logfile}"
@@ -196,33 +198,33 @@ log_init() {
     # Log a copy of stdout and stderr too
     exec >  >(tee -ia "${logdir}/${stdout_logfile}")
     exec 2> >(tee -ia "${logdir}/${stderr_logfile}" >&2)
-    echo "$(date): Started logging stdout on file too"
-    echo "$(date): Started logging stderr on file too" >&2
+    echo "$(date): glog_init: Started logging stdout on file too"
+    echo "$(date): glog_init: Started logging stderr on file too" >&2
 
     gconfig_add "GLIDEIN_LOG_INITIALIZED" "1"
 }
 
 
-log_setup() {
+glog_setup() {
     # Setup the logging utilities for the caller script with the specified configuration
     # Arguments:
     #   1: glidein config filename
 
     # Validate number of arguments
     if [ "$#" -ne 1 ]; then
-        warn "log_setup: could not setup log for ${0}. Expected 1 arguments, got $#."
+        warn "glog_setup: could not setup log for ${0}. Expected 1 arguments, got $#."
         return 1
     fi
     local glidein_config=${1}
 
     if [ ! -f "${glidein_config}" ]; then
-        warn "log_setup: glidein_config not defined in ${0}. Logging will not work here."
+        warn "glog_setup: glidein_config not defined in ${0}. Logging will not work here."
         return 1
     fi
 
     log_initialized=$(gconfig_get GLIDEIN_LOG_INITIALIZED "${glidein_config}")
     if [ "${log_initialized}" != 1 ]; then
-        warn_ready "log_setup: apparently the logging configuration has not been initialiazed yet (${0}). Logging will not work here."
+        warn_ready "glog_setup: apparently the logging configuration has not been initialized yet (${0}). Logging will not work here."
         return 1
     fi
 
@@ -230,7 +232,7 @@ log_setup() {
     stdout_logfile=$(gconfig_get GLIDEIN_STDOUT_LOGFILE "${glidein_config}")
     stderr_logfile=$(gconfig_get GLIDEIN_STDERR_LOGFILE "${glidein_config}")
     log_logfile=$(gconfig_get GLIDEIN_LOG_LOGFILE "${glidein_config}")
-    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
+    log_recipients=($(gconfig_get GLIDEIN_LOG_RECIPIENTS_FACTORY "${glidein_config}") $(gconfig_get GLIDEIN_LOG_RECIPIENTS "${glidein_config}"))
     log_no_send=$(gconfig_get GLIDEIN_LOG_NO_SEND "${glidein_config}")
     log_relative_basepath=$(gconfig_get GLIDEIN_LOG_RELATIVE_BASEPATH "${glidein_config}")
     curl_version=$(gconfig_get CURL_VERSION "${glidein_config}")
@@ -243,7 +245,7 @@ log_setup() {
 }
 
 
-json_escape() {
+_glog_json_escape() {
     # Escape json special characters
     # Arguments:
     #   1: text to escape
@@ -268,7 +270,7 @@ json_escape() {
 }
 
 
-get_logfile_path_relative() {
+_glog_get_logfile_path_relative() {
     # Get the relative path of the logfile w.r.t. the work dir
 
     if [ "${log_ready}" != 1 ]; then
@@ -279,7 +281,7 @@ get_logfile_path_relative() {
 }
 
 
-log_write() {
+glog_write() {
     # Log an event. This involves the creation of a 'shard', i.e. a file storing the log entry
     # The content can include either a string or the body of a file (encoded in base64)
     # If type is file, then the filepath can be either absolute or relative to work_dir
@@ -288,7 +290,7 @@ log_write() {
     #   1:invoker, 2:type of message, 3:content/filepath, 4:severity
 
     if [ "${log_ready}" != 1 ]; then
-        warn_ready "log_write: missing logging configuration in (${0}); perhaps forgot to call log_setup before?"
+        warn_ready "glog_write: missing logging configuration in (${0}); perhaps forgot to call log_setup before?"
         return 1
     fi
 
@@ -351,8 +353,8 @@ log_write() {
                   --arg sev "${severity}" \
                   '{invoker: $inv, pid: $pid, timestamp: $ts, severity: $sev, type: $ty, filename: $fn, content: $body}' )
     else
-        invoker="$(json_escape "${invoker}")"
-        content="$(json_escape "${content}")"
+        invoker="$(_glog_json_escape "${invoker}")"
+        content="$(_glog_json_escape "${content}")"
         json_logevent="{\"invoker\":\"${invoker}\", \"pid\":\"${pid}\", \"timestamp\":\"${cur_time}\", \"severity\":\"${severity}\", \"type\":\"${type}\", \"filename\":\"${filename}\", \"content\":\"${content}\"}"
     fi
 
@@ -362,11 +364,11 @@ log_write() {
 }
 
 
-log_coalesce_shards() {
+_glog_coalesce_shards() {
     # Merge log shards in a single file (for each glidein process)
     # Skip (and return with code 1) if another process is already coaleascing,
     # so that this operation is non-blocking. Retcode 1 may be exploited to loop
-    # log_coalesce_shards until it succeeds, when you want to force the merging
+    # _glog_coalesce_shards until it succeeds, when you want to force the merging
 
     if [ "${log_ready}" != 1 ]; then
         warn_ready "log_coalesce_shards: missing logging configuration in (${0}); perhaps forgot to call log_setup before?"
@@ -377,7 +379,7 @@ log_coalesce_shards() {
 
     if mkdir shards/coalescing; then
         # Coalescing is performed in a separate directory, to avoid
-        # interference from other processes calling log_write in the meanwhile.
+        # interference from other processes calling glog_write in the meanwhile.
         # Only one process at a time is allowed to use the merging folder.
         # The 'trylock' is based on the atomicity of the mkdir command
         cur_time=$(date +%Y-%m-%dT%H:%M:%S%:z)
@@ -405,25 +407,29 @@ log_coalesce_shards() {
     fi
 }
 
-send_logs_to_remote() {
+
+glog_send() {
     # Forward the logs to a remote HTTPS server.
     # A token must be included in the header for authentication.
     # Note:
     #   it also merges the shards before sending
+    # Exit codes:
+    # 1 - failed to coalesce or to send
+    # 2 - sending disabled via log_no_send=1
 
-    if ! log_coalesce_shards; then
+    if ! _glog_coalesce_shards; then
         return 1
     fi
 
     # log_no_send is set when the recipients initialization failed for some
     # reason, but the system is still capable of producing logs
     if [ "${log_no_send}" = 1 ]; then
-        return 1
+        return 2
     fi
 
     # Retrieve the tokens (by deserializing the tokens_arr file)
     if [ ! -f tokens_arr ]; then
-        warn "send_logs_to_remote: cannot find tokens_arr file"
+        warn "glog_send: cannot find tokens_arr file"
         return 1
     fi
     eval "declare -A tokens_arr=$(cat tokens_arr)"
@@ -431,13 +437,23 @@ send_logs_to_remote() {
     # Upload stdout, stderr and log file
     logfiles=("${stdout_logfile}" "${stderr_logfile}" "${log_logfile}")
 
+    local recipient_addr logfile curl_resp curl_retval send_failed=0
     for recipient_addr in "${log_recipients[@]}"; do
         for logfile in "${logfiles[@]}"; do
-            curl_resp=$(curl -X PUT --upload-file "${log_relative_basepath}/${logdir}/${logfile}" "${recipient_addr}/${logfile}" -H "Authorization: Bearer ${tokens_arr["${recipient_addr}"]}" 2>&1)
+            curl_resp=$(curl -w "LOG_HTTP_CODE:%{http_code}\n" -X PUT --upload-file "${log_relative_basepath}/${logdir}/${logfile}" "${recipient_addr}/${logfile}" -H "Authorization: Bearer ${tokens_arr["${recipient_addr}"]}" 2>&1)
             curl_retval=$?
             if [ ${curl_retval} -ne 0 ]; then
-                warn "Failed to deliver ${logfile} to remote server (${recipient_addr}). curl_version: ${curl_version} curl_exit_code: ${curl_retval} curl_err_msg: ${curl_resp}"
+                warn "Failed with cURL error to deliver ${logfile} to remote server (${recipient_addr}). curl_version: ${curl_version} curl_exit_code: ${curl_retval} curl_err_msg: ${curl_resp}"
+                ((send_failed++))
+            fi
+            if [[ ! "${curl_resp#*LOG_HTTP_CODE:}" = 2* ]]; then
+                warn "Failed with HTTP error to deliver ${logfile} to remote server (${recipient_addr}). curl_version: ${curl_version} curl_exit_code: ${curl_retval} curl_err_msg: ${curl_resp}"
+                ((send_failed++))
             fi
         done
     done
+    if [ "$send_failed" -gt 0 ]; then
+        warn "glog_send: failed to send $send_failed files"
+        return 1
+    fi
 }

--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -265,6 +265,13 @@ SPDX-License-Identifier: Apache-2.0
                 value="(queue=default)(jobtype=single)(maxWalltime=$$(GLIDEIN_Max_Walltime))(memory=$$(GLIDEIN_MaxMemMBs))"
                 /&gt;</a
               ><br />
+              <a href="#attrs"
+                >&lt;attr name="GLIDEIN_LOG_RECIPIENTS_FACTORY" const="False"
+                glidein_publish="True" job_publish="True" parameter="True"
+                publish="True" type="string"
+                value="https://factory.glideinwms.org/logserver/put.php"
+                /&gt;</a
+              ><br />
             </blockquote>
             <a href="#attrs">&lt;/attrs&gt;</a><br />
             <a href="#entry">&lt;entries&gt;</a><br />

--- a/doc/factory/custom_scripts.html
+++ b/doc/factory/custom_scripts.html
@@ -107,6 +107,7 @@ SPDX-License-Identifier: Apache-2.0
           <li><a href="#glidein_config">Configuration file</a></li>
           <li><a href="#condor_vars">HTCondor vars file</a></li>
           <li><a href="#xml_output">Reporting script exit status</a></li>
+          <li><a href="#logging">Logging</a></li>
           <li><a href="#periodic">Periodic scripts</a></li>
           <li><a href="#order">Loading order</a></li>
           <li><a href="#examples">Examples</a></li>
@@ -273,7 +274,7 @@ SPDX-License-Identifier: Apache-2.0
         </blockquote>
         <blockquote>
           # read an attributes (set by you or some other script)<br />
-          <i>myvar</i>=gconfig_get <i>myattribute</i>
+          <i>myvar</i>=$(gconfig_get <i>myattribute</i>)
         </blockquote>
       </div>
 
@@ -448,7 +449,32 @@ MAX_STARTD_LOG          I       10000000        +                               
           code.
         </p>
       </div>
-
+      <div class="section">
+        <h2><a name="logging"></a>Logging</h2>
+        <p>
+          Standard output and standard error of all custom scripts (except the
+          periodic ones) is captured in the Glidein stdout and stderr and it is
+          transferred back to the Factory by HTCondor at the end of the Glidein.
+          Anyway this process may be insufficient: if the Glidein is killed the
+          transfer may not happen, if there are multi-Glideins all their
+          stdout/err are intermixed in the same files, and a user may desire to
+          have this output back earlier or in a different place. For all these
+          needs there is also a logging utility. It is defined in
+          <tt>logging_utils.source</tt>, can be used in any custom script,
+          requires a web server to receive the logging messages, and needs to
+          set up <tt>GLIDEIN_LOG_RECIPIENTS_FACTORY</tt> as <tt>attr</tt> in the
+          Factory configuration. The Web servers at the URLs in
+          GLIDEIN_LOG_RECIPIENTS_FACTORY must be able to receive
+          JWT-authenticated PUT requests HS256-encoded with the secret set in
+          the Factory secret file
+          (<tt>/var/lib/gwms-factory/server-credentials/jwt_secret.key</tt>).
+          This secret file must be HMAC 256 compatible, e.g. a 32 bytes string.
+          The Factory will create the file at startup if it is not there or
+          empty. Scripts can use <tt>glog_setup</tt>, <tt>glog_write</tt>, and
+          <tt>glog_send</tt> to set up, write, and checkpoint/upload log files.
+          There is an example of how to use logging in <tt>logging_test.sh</tt>.
+        </p>
+      </div>
       <div class="section">
         <h2><a name="periodic"></a>Periodic scripts</h2>
         <p>
@@ -646,7 +672,7 @@ Order:
 glidein_config=&quot;$1&quot;
 
 # find error reporting helper script
-error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+error_gen=$(grep -m1 '^ERROR_GEN_PATH ' "$glidein_config" | awk '{print $2}')
 
 if [ -z &quot;/usr/lib/libcrypto.so.0.9.8&quot; ]; then
   &quot;$error_gen&quot; -error &quot;libtest.sh&quot; &quot;WN_Resource&quot; &quot;Crypto library not found.&quot; &quot;file&quot; &quot;/usr/lib/libcrypto.so.0.9.8&quot;
@@ -667,7 +693,7 @@ glidein_config=&quot;$1&quot;
 # Get the data
 
 # find error reporting helper script
-error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+error_gen=$(grep -m1 '^ERROR_GEN_PATH ' "$glidein_config" | awk '{print $2}')
 
 if [ -f &quot;$VO_SW_DIR/setup.sh&quot; ]; then
    source &quot;$VO_SW_DIR/setup.sh&quot;
@@ -677,23 +703,23 @@ else
    exit 1
 fi
 
-tmpname=$PWD/installed_software_tmp_$$.tmp
+tmpname="$PWD"/installed_software_tmp_$$.tmp
 software_list&gt; $tmpname
 
 
 ###########################################################
-# import add_config_line and add_condor_vars_line functions
+# Import add_config_line and add_condor_vars_line functions
 
-add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
-source $add_config_line_source
-
-condor_vars_file=`grep -i &quot;^CONDOR_VARS_FILE &quot; $glidein_config | awk '{print $2}'`
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
+condor_vars_file=$(gconfig_get CONDOR_VARS_FILE "$glidein_config")
 
 
 ##################
 # Format the data
 
-sw_list=`cat $tmpname | awk '{if (length(a)!=0) {a=a &quot;,&quot; $0} else {a=$0}}END{print a}'`
+sw_list=$(cat $tmpname | awk '{if (length(a)!=0) {a=a &quot;,&quot; $0} else {a=$0}}END{print a}')
 
 if [ -z &quot;$sw_list&quot; ]; then
   ERRSTR=&quot;No SW found.
@@ -707,7 +733,7 @@ fi
 #################
 # Export the data
 
-add_config_line GLIDEIN_SW_LIST &quot;$sw_list&quot;
+gconfig_add GLIDEIN_SW_LIST &quot;$sw_list&quot;
 add_condor_vars_line GLIDEIN_SW_LIST &quot;S&quot; &quot;-&quot; &quot;+&quot; &quot;Y&quot; &quot;Y&quot; &quot;+&quot;
 
 &quot;$error_gen&quot; -ok  &quot;swfind.sh&quot; &quot;sw_list&quot; &quot;$sw_list&quot;
@@ -721,14 +747,15 @@ exit 0
 glidein_config=$1
 entry_dir=$2
 
-# find error reporting helper script
-error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
-
 # import add_config_line function, will use glidein_config
-add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
-source $add_config_line_source
+add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | awk '{print $2}')
+# shellcheck source=./add_config_line.source
+. "$add_config_line_source"
 
-vo_scalability=`grep '^VO_SCALABILITY ' $glidein_config | awk '{print $2}'`
+# find the error reporting helper script
+error_gen=$(gconfig_get ERROR_GEN_PATH "$glidein_config")
+
+vo_scalability=$(gconfig_get VO_SCALABILITY "$glidein_config")
 
 if [ -z &quot;$vo_scalability&quot; ]; then
   # set a reasonable default
@@ -746,7 +773,7 @@ if [ &quot;$tot_mem&quot; -lt 500000 ]; then
   fi
 
   # write it back
-  add_config_line VO_SCALABILITY $vo_scalability
+  gconfig_add VO_SCALABILITY $vo_scalability
   &quot;$error_gen&quot; -ok  &quot;memset.sh&quot; &quot;vo_scalability&quot; &quot;$vo_scalability&quot;
   exit 0
 fi

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -1139,6 +1139,27 @@ MAX_STARTD_LOG          I       10000000        +                               
               </p>
             </td>
           </tr>
+          <tr>
+            <td><b>GLIDEIN_LOG_RECIPIENTS_FACTORY</b></td>
+            <td>String</td>
+            <td>""</td>
+
+            <td>
+              <p>
+                Space separated list of URLs to use to publish the
+                <a href="custom_scripts.html#logging">custom logs</a>.
+              </p>
+              <p>
+                A token-authenticated Web server must be running at the given
+                URL to receive the POST requests from the Glideins
+              </p>
+              <p>
+                This attribute requires a <tt>factory upgrade</tt>. A
+                <tt>reconfig</tt> is not sufficient because it changes the files
+                transferred via HTCondor.
+              </p>
+            </td>
+          </tr>
         </table>
       </div>
       <div class="section">

--- a/logserver/README.md
+++ b/logserver/README.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Glidein Logging Server
+
+This is a simple server using the httpd server to receive Glidein logs via PUT
+
+-   getjwt.py is a python script to generate tokens
+-   put.php is a script to receive JWT authenticated HTTP PUT requests
+-   jwt.php is a test script to generate or verify JWT tokens
+-   logging.config.json is a config file for both PHP scripts
+-   the httpd config to allow PUT is in build/packaging/rpm/gwms-logserver.conf.httpd
+
+The `put.php` script requires the `uploads` and `uploads_unauthorized` sub-directories.
+Both PHP scripts require PHP and php-fpm to be executed by the Web server:
+
+```commandline
+# run as root
+dnf install php
+dnf install php-fpm
+systemctl start php-fpm
+systemctl enable php-fpm httpd
+```
+
+Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_using-the-php-scripting-language_installing-and-using-dynamic-programming-languages
+Both PHP scripts use [Firebase PHP-JWT](https://github.com/firebase/php-jwt)
+installed via [Composer](https://getcomposer.org/download/)
+as done in [this tutorial](https://www.sitepoint.com/php-authorization-jwt-json-web-tokens/).
+To install the required dependencies do:
+
+```commandline
+cd /var/lib/gwms-logserver
+composer install
+# sometimes the command times out the first time and needs to re-run
+```
+
+Once Apache 2.5 (now dev version) or 2.6 are available you can use
+[mod_auth_jwt](https://httpd.apache.org/docs/trunk/mod/mod_autht_jwt.html) and
+[mod_auth_bearer](https://httpd.apache.org/docs/trunk/mod/mod_auth_bearer.html)
+to enable JWT bearer token authentication.
+
+## Apache troubleshooting
+
+You can use `apachectl configtest` to verify if your httpd configuration is correct
+(Apache silently ignores bad config files).
+More suggestions at
+<https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/deploying_web_servers_and_reverse_proxies/setting-apache-http-server_deploying-web-servers-and-reverse-proxies>
+E.g. you may need to set selinux context:
+
+```commandline
+# run as root
+semanage fcontext -a -t httpd_sys_content_t "/srv/example.com(/.*)?"
+restorecon -Rv /srv/example.com/
+semanage fcontext -a -t httpd_sys_content_t "/srv/example.net(/.\*)?"
+restorecon -Rv /srv/example.net/
+```
+
+To troubleshoot httpd you may increase the log level using `/etc/httpd/conf.d/temp_debug.conf` as
+[suggested here](https://serverfault.com/a/1168882/1189965):
+
+```
+LogLevel trace4
+GlobalLog "logs/debug.log" "%v:%p %h %l %u %t \"%r\" %>s %O file=%f"
+
+# http://httpd.apache.org/docs/current/mod/mod_log_config.html#formats
+# %v    The canonical ServerName of the server serving the request.
+# %f    Filename.
+```
+
+To see the PHP error messages in `put.php` you need to edit `/etc/php.ini` and enable the Development options like:
+
+```doctest
+error_reporting = E_ALL
+display_errors = On
+display_startup_errors = On
+```
+
+Remember to disable that for production

--- a/logserver/composer.json
+++ b/logserver/composer.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "firebase/php-jwt": "^5.2",
+    "laminas/laminas-config": "^3.5.0"
+  }
+}

--- a/logserver/getjwt.py
+++ b/logserver/getjwt.py
@@ -1,0 +1,94 @@
+#!/bin/env python3
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print a JWT token
+python getjwt.py -k your_secret_key -i https://your-issuer.com
+Options
+-k --key JWT signing key
+-
+"""
+
+import argparse
+import os
+import socket
+import time
+import urllib.parse
+
+import jwt
+
+
+def log(msg: str):
+    print(msg)
+
+
+tokens_dir = "./"
+this_host = socket.gethostname()
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Generate a JWT token for the GlideinWMS logging.")
+parser.add_argument("-k", "--key", default=None, help="Secret key for JWT signing (overrides the key-file).")
+parser.add_argument("-K", "--key-file", required=False, help="Binary file containing the secret key for JWT signing.")
+parser.add_argument(
+    "-d", "--duration", type=int, default=604800, help="Duration of the token in seconds (default: 3600)."
+)
+parser.add_argument("-e", "--entry", default="TEST_TOKEN", help="Entry, for the Subject (sub) claim for the JWT.")
+parser.add_argument("-f", "--factory", default=this_host, help="Factory, for Issuer (iss) claim for the JWT.")
+parser.add_argument("-a", "--algorithm", default="HS256", help="JWT encoding algorithm.")
+parser.add_argument(
+    "-u", "--log-url", default=f"http://{this_host}/logging/put.php", help="Issuer (iss) claim for the JWT."
+)
+parser.add_argument("-o", "--output", default=None, help="Output file to write the JWT.")
+args = parser.parse_args()
+if args.key is None and not args.key_file:
+    # log("ERROR: You must provide a key string or a key file")
+    parser.error("ERROR: You must provide a key string or a key file")
+
+curtime = int(time.time())
+
+token_key = args.key
+if token_key is None:
+    if args.key_file:
+        try:
+            with open(args.key_file, "rb") as key_file:
+                token_key = key_file.read()
+        except OSError:
+            log(f"ERROR: Unable to read token key from file: {args.key_file}")
+            raise
+
+# Define payload with issuer from arguments
+# Payload fields:
+# iss->issuer,      sub->subject,       aud->audience
+# iat->issued_at,   exp->expiration,    nbf->not_before
+payload = {
+    "user_id": 123,  # Replace with actual user ID or other data
+    "iss": args.factory,  # Set issuer from command-line argument
+    "sub": args.entry,
+    # Obtain a legal filename safe string from the url, escaping "/" and other tricky symbols
+    "aud": urllib.parse.quote(args.log_url, ""),
+    # "issued_at": curtime,
+    "iat": curtime,
+    "exp": curtime + args.duration,
+    "nbf": curtime - 300,
+}
+
+# Generate JWT using secret key from arguments
+print(f"Encoding token with key: <{token_key}>")
+token = jwt.encode(payload, token_key, algorithm=args.algorithm)
+# TODO: PyJWT bug workaround. Remove this conversion once affected PyJWT is no more around
+#  PyJWT in EL7 (PyJWT <2.0.0) has a bug, jwt.encode() is declaring str as return type, but it is returning bytes
+#  https://github.com/jpadilla/pyjwt/issues/391
+if isinstance(token, bytes):
+    token = token.decode("UTF-8")
+
+if args.output is None:
+    print(token)
+else:
+    token_filepath = os.path.join(tokens_dir, args.output)
+    try:
+        # Write the token to a text file
+        with open(token_filepath, "w") as tkfile:
+            tkfile.write(token)
+        log(f"Token for {args.log_url} ({urllib.parse.quote(args.log_url, '')}) written to {token_filepath}")
+    except OSError:
+        log(f"ERROR: Unable to create JWT file: {token_filepath}")
+        raise

--- a/logserver/jwt.php
+++ b/logserver/jwt.php
@@ -1,0 +1,76 @@
+<?php
+// SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+/*  Script to test JWT generation and verification in PHP:
+    php jwt.php // To run self test
+    php jwt.php TOKEN  // To decode the token
+    php jwt.php PAYLOAD TOKEN  // To encode PAYLOAD and save it to TOKEN
+    Uses the configuration in logging_config.json:
+    - secret_key_path (/var/lib/gwms-factory/server-credentials/jwt_secret.key)
+    - secret_key  // Key value as alternative to the key file content
+    - verbose (True)  // Print verbose output
+    - debug (False)  // Print debug output
+*/
+// declare(strict_types=1);
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+require_once('./vendor/autoload.php');
+
+// Hardcoded parameters
+$configFile = 'logging_config.json';
+// Read and extract configuration
+$config = json_decode(file_get_contents($configFile), true);
+if (! $config) {
+    trigger_error("Empty config ($configFile) - the file may be missing or be invalid JSON", E_USER_WARNING);
+}
+$secretKeyFile = $config['secret_key_path'] ?? '/var/lib/gwms-factory/server-credentials/jwt_secret.key';
+$defaultSecretKey = $config['secret_key'] ?? '';
+$verbose = $config['verbose'] ?? True;
+$debug = $config['debug'] ?? False;
+
+if ($debug) {
+    ini_set('display_errors', 1);
+}
+
+$key = trim(file_get_contents($secretKeyFile)) ?: $defaultSecretKey;
+if (! $key) {
+    exit("JWT key is not set. Aborting.")
+}
+
+$payload = [
+    'iss' => 'http://example.org',
+    'aud' => 'http://example.com',
+    'iat' => 1356999524,
+    'nbf' => 1357000000
+];
+
+echo "Encoding/decoding payload using key: <$key>\n";
+
+if ($argc>1) {
+    if ($argc==2) {
+        echo "Decoding token in $argv[1]\n";
+        $jwt = file_get_contents($argv[1]);
+        print_r($jwt);
+        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        print_r($decoded);
+    } else {
+        echo "Encoding payload in $argv[1]\n";
+        $payload = json_decode(file_get_contents($argv[1]));
+        $payload_array = (array) $payload;
+        $jwt = JWT::encode($payload_array, $key, 'HS256');
+        print_r($jwt);
+        echo "Saving token to $argv[2]\n";
+        file_put_contents($argv[2], $jwt);
+        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        print_r($decoded);
+    }
+} else {
+    echo "Encode/decode test with payload\n";
+    $jwt = JWT::encode($payload, $key, 'HS256');
+    print_r($jwt);
+    $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+    print_r($decoded);
+}
+
+?>

--- a/logserver/logging_config.json
+++ b/logserver/logging_config.json
@@ -1,0 +1,10 @@
+{
+  "secret_key_path": "/var/lib/gwms-factory/server-credentials/jwt_secret.key",
+  "token_issuer": "gfactory_service",
+  "uri_regex_file_name": "#logserver/put.php/(\\S+)#",
+  "upload_dir": "uploads/",
+  "upload_dir_unauthorized": "uploads_unauthorized/",
+  "require_authentication": true,
+  "verbose": false,
+  "debug": false
+}

--- a/logserver/web-area/put.php
+++ b/logserver/web-area/put.php
@@ -1,0 +1,179 @@
+<?php
+// SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+/*  PHP script to implement file upload via PUT
+    The file content is received via stdin (Apache PUT implementation)
+    A JSON configuration is in logging_config.json, valid parameters are:
+    - secret_key_path (/var/lib/gwms-factory/server-credentials/jwt_secret.key)
+    - secret_key (the-key-string - used if the file is not specified)
+    - default_file_name (glideinlog.txt)
+    - uri_regex_file_name ()#logging/put.php/(\S+)#)
+    - token_issuer (gethostname())  // Should be the Factory, assuming is the same host by default
+    - upload_dir (uploads/)
+    - upload_dir_unauthorized (uploads_unauthorized/)
+    - require_authentication (True)
+    - verbose (True)  // Print verbose output
+    - debug (False)  // Print debug output
+    The destination file name is retrieved from the URI:
+    - as GET parameter fname, e.g.    ...put.php?fname=NAME
+    - as path, e.g.  ...logging/put.php/NAME
+    The authentication is via JWT
+    - HS256 encoded JWT
+    - iss must be the Factory
+    - the key is stored in '/var/lib/gwms-factory/server-credentials/jwt_secret.key'
+    - aud should be the Web server
+    If requireAuthentication is False, files are uploaded also w/o valid JWT
+*/
+
+/* This script uses composer to manage its dependencies
+*/
+// declare(strict_types=1);
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+require_once('../vendor/autoload.php');
+
+// Hardcoded parameters
+$configFile = '../logging_config.json';
+
+// Read and extract configuration
+$config = json_decode(file_get_contents($configFile), true);
+if (! $config) {
+    trigger_error("Empty config ($configFile) - the file may be missing or be invalid JSON", E_USER_WARNING);
+}
+$secretKeyFile = $config['secret_key_path'] ?? '/var/lib/gwms-factory/server-credentials/jwt_secret.key';
+$defaultSecretKey = $config['secret_key'] ?? '';
+$defaultFileName = $config['default_file_name'] ?? 'glideinlog.txt';
+$uriRegexFileName = $config['uri_regex_file_name'] ?? '#logging/put.php/(\S+)#';
+$tokenIssuer = $config["token_issuer"] ?? gethostname();  // Should be the factory
+$uploadPath = $config['upload_dir'] ?? 'uploads/';
+$uploadPathUnauthorized = $config['upload_dir_unauthorized'] ?? 'uploads_unauthorized/';
+$requireAuthentication = $config['require_authentication'] ?? True;
+$verbose = $config['verbose'] ?? True;
+$debug = $config['debug'] ?? False;
+
+if ($debug) {
+    ini_set('display_errors', 1);
+}
+
+function filename_sanitizer($unsafeFilename){
+  // our list of "unsafe characters", add/remove characters if necessary
+  $dangerousCharacters = array(" ", '"', "'", "&", "/", "\\", "?", "#", "<", ">", "..");
+  // every forbidden character is replaced by an underscore
+  $safeFilename = str_replace($dangerousCharacters, '_', $unsafeFilename);
+  return $safeFilename;
+}
+
+function auth_failed($headerCode, $msg){
+    if ($GLOBALS['requireAuthentication']) {
+        http_response_code($headerCode);
+        echo "$headerCode: $msg\n";
+        exit;
+    }
+    if ($GLOBALS['verbose']) {
+        echo "$headerCode: $msg\n";
+    }
+}
+
+
+/* The file name (default from the config file) is specified in the URI either as
+   GET parameter fname   put.php?fname=NAME
+   or as path  logging/put.php/NAME
+   */
+$fileName = $_GET['fname'] ?? $defaultFileName;
+if (preg_match($uriRegexFileName, $_SERVER['REQUEST_URI'], $matches)) {
+    $fileName = $matches[1];
+}
+
+// Not authorized unless the token verification is successful
+$isAuthorized = False;
+// Get authorization header and extract the token
+$authorizationHeader = getallheaders()["Authorization"] ?? "";
+//$token = preg_match("/Bearer (?P<token>[^\s]+)/", $authorizationHeader, $matches) ? $matches["token"] : "";
+if (! preg_match('/Bearer\s(?P<token>\S+)/', $authorizationHeader, $matches)) {
+    // No token in request
+    auth_failed(400, 'Token not found in request');
+    $jwt = "";
+} else {
+    $jwt = $matches["token"];
+}
+if (! $jwt) {
+    // Unable to extract token from the authorization header
+    auth_failed(400, 'Unable to extract token from the authorization header');
+} else {
+    try {
+        // Read secret key from file or set to the default
+        $secretKey = trim(file_get_contents($secretKeyFile)) ?: $defaultSecretKey;
+        if (! $secretKey) {
+            if ($debug) {
+                echo "Server mis-configured. JWT key not defined.";
+            }
+            auth_failed(500, 'Server error. Error decoding JWT');
+        }
+        $token = JWT::decode($jwt, new Key($secretKey, 'HS256'));
+        $now = new DateTimeImmutable();
+        $serverAddress = 'https://' . $_SERVER['SERVER_ADDR'];
+        $serverName = 'https://' . $_SERVER['SERVER_NAME'];
+        // Verify token (iss, aud and expiration)
+        if ($token->iss !== $tokenIssuer ||
+            ( ! str_starts_with($token->aud, urlencode($serverAddress)) &&
+             ! str_starts_with($token->aud, urlencode($serverName))) ||
+            $token->nbf > $now->getTimestamp() ||
+            $token->exp < $now->getTimestamp())
+        {
+            if ($debug) {
+                $res0 = ! str_starts_with($token->aud, urlencode($serverAddress)) &&
+                    ! str_starts_with($token->aud, urlencode($serverName)) ? 'true' : 'false';
+                $res1 = str_starts_with($token->aud, urlencode($serverAddress)) ? 'true' : 'false';
+                $res2 = urlencode($serverAddress);
+                $res3 = str_starts_with($token->aud, urlencode($serverName)) ? 'true' : 'false';
+                $res4 = urlencode($serverName);
+                $res5 = $token->nbf > $now->getTimestamp() ? 'true' : 'false';
+                $res6 = $token->exp < $now->getTimestamp() ? 'true' : 'false';
+                $res7 = $token->iss !== $tokenIssuer ? 'true' : 'false';
+                echo "Authorization failed:\n- iss $res7: {$token->iss} VS {$tokenIssuer}\n".
+                    "- aud $res0, addr $res1, name $res3: {$token->aud} VS $res2, $res4\n- nbf $res5\n- exp $res6\n";
+            }
+            auth_failed(401, 'Wrong authorization (wrong claims or token expired)');
+        } else {
+            $isAuthorized = True;
+        }
+    } catch (Firebase\JWT\SignatureInvalidException $e) {
+        auth_failed(401, 'Invalid JWT signature');
+    } catch (Exception $e) {
+        auth_failed(500, 'Error decoding JWT');
+    }
+}
+
+// debug variables printout
+if ($debug) {
+    var_dump( get_defined_vars() );
+}
+
+$fname = filename_sanitizer($fileName);
+if (! $isAuthorized) {
+    $uploadPath = $uploadPathUnauthorized;
+}
+
+// Save the file in the desired location and return error upon failure
+try {
+    // PUT data comes in on the stdin stream
+    $putdata = fopen('php://input', 'r');
+
+    if ($fp = fopen($uploadPath . $fname, 'w')) {
+        // Read the data 1 KB at a time and write to the file
+        while ($data = fread($putdata, 1024))
+            fwrite($fp, $data);
+        fclose($fp);
+    } else {
+        http_response_code(500);
+        echo "500: Error opening the output file\n";
+        exit;
+    }
+    fclose($putdata);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo "500: Error saving the upload file\n";
+    exit;
+}
+?>


### PR DESCRIPTION
Fixed and disabled DictFile.append(), replaced by add_environment()

append was used only for environment variables in the condor submit file and was causing a malformed submit file.
add_environment was already used at times and is a better method. append was fixed and is still there commented in case we'd like to use it for other attributes in the future.
