### PR TITLE
Ability to use apptainer in the HTCondor distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 
 ## v3.10.9 \[2024-12-23\]
 
-Fixed the Glidein logging and added an sample log server
+Added support for the HTCondor distributed apptainer.
+Fixed the Glidein logging and added an sample log server.
 
 ### New features / functionalities
 
--   Added custom log server example (glideinwms-logging) (Issue #398, PR #467)
+-   Added custom JWT-authenticated log server example (new RPM glideinwms-logging) (Issue #398, PR #467)
+-   Now using also Apptainer included in the HTCondor tar ball (Issue #364, PR #473)
 
 ### Changed defaults / behaviours
 
 -   Always send SIGQUIT to HTCondor when the Glidein receives INT, TERM, QUIT signals. This speeds up the shutdown (PR #466)
+-   Apptainer downloaded in the HTCondor tar ball is now considered after the PATH in the search for a valid binary.
+    The keyword CONDOR in the parameter SINGULARITY_BIN will make so that the HTCondor Apptainer is preferred
+    ahead of the rest (PR #473)
+-   Added RHEL9 to the list of default OSes used for the container images lookup. Now it is: default,rhel9,rhel7,rhel6,rhel8 (PR #473)
 
 ### Deprecated / removed options and commands
 
@@ -25,6 +31,8 @@ Fixed the Glidein logging and added an sample log server
 -   Removed confusing tac broken pipe messages from the Glidein stderr (PR #465)
 -   Fixed JWT logging credentials not transferred to the Glidein. This includes removal of DictFile.append() and use of add_environment() for JWT tokens (Issue #398, PR #467)
 -   Fixed quotes in Glidein command line unpacking and replaced deprecated add_config_line commands (PR #468)
+-   Allow anonymous SSL authentication for the dynamically generated client config (Issue #222, PR #470)
+-   Checking also the apptainer binary in the SINGULARITY_BIN path, not only singularity (PR #473)
 
 ### Testing / Development
 

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Glidein creation module
-   Classes and functions needed to handle dictionary files
-   created out of the parameter object
+"""Glidein creation module.
+   Classes and functions needed to handle dictionary files.
+   created out of the parameter object.
 """
 
 import os
@@ -27,7 +27,7 @@ from . import cgWConsts, cgWCreate, cgWDictFile, cWConsts, cWDictFile, cWExpand,
 class UnconfiguredScheddError(Exception):
     def __init__(self, schedd):
         self.schedd = schedd
-        self.err_str = "Schedd '%s' used by one or more entries is not configured." % (schedd)
+        self.err_str = f"Schedd '{schedd}' used by one or more entries is not configured."
 
     def __str__(self):
         return repr(self.err_str)
@@ -41,7 +41,7 @@ class UnconfiguredScheddError(Exception):
 
 
 class glideinMainDicts(cgWDictFile.glideinMainDicts):
-    """This Class contains the main dicts"""
+    """This Class contains the main dicts."""
 
     def __init__(self, conf, workdir_name):
         submit_dir = conf.get_submit_dir()

--- a/creation/web_base/condor_platform_select.sh
+++ b/creation/web_base/condor_platform_select.sh
@@ -3,12 +3,6 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# Project:
-#   glideinWMS
-#
-# File Version:
-#
 # Description:
 #   This script will select the appropriate condor tarball
 #   Must be listed in the file_list before the condor tarballs
@@ -16,7 +10,7 @@
 #
 
 glidein_config="$1"
-tmp_fname="${glidein_config}.$$.tmp"
+# not used - tmp_fname="${glidein_config}.$$.tmp"
 
 # import add_config_line function
 add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)

--- a/creation/web_base/frontend/generic_pre_singularity_setup.sh
+++ b/creation/web_base/frontend/generic_pre_singularity_setup.sh
@@ -29,6 +29,7 @@ if [[ "$glidein_config" != "NONE" ]]; then
         export add_config_line_source=$(grep -m1 '^ADD_CONFIG_LINE_SOURCE ' "$glidein_config" | cut -d ' ' -f 2-)
         export       condor_vars_file=$(grep -m1 -i "^CONDOR_VARS_FILE "    "$glidein_config" | cut -d ' ' -f 2-)
     fi
+    # shellcheck source=./add_config_line.source
     . "$add_config_line_source"
 fi
 

--- a/creation/web_base/singularity_setup.sh
+++ b/creation/web_base/singularity_setup.sh
@@ -262,8 +262,8 @@ SINGULARITY_IMAGE_DEFAULT=$(gconfig_get SINGULARITY_IMAGE_DEFAULT "$glidein_conf
 # Select the singularity image:  singularity_get_image platforms restrictions
 # Uses SINGULARITY_IMAGES_DICT and legacy SINGULARITY_IMAGE_DEFAULT, SINGULARITY_IMAGE_DEFAULT6, SINGULARITY_IMAGE_DEFAULT7
 # TODO Should the image be on CVMFS or anywhere is OK?
-info_stdout "`date` Looking for Singularity image for [default,rhel7,rhel6,rhel8] with restrictions $image_restrictions"
-GWMS_SINGULARITY_IMAGE="$(singularity_get_image default,rhel7,rhel6,rhel8 $image_restrictions)"
+info_stdout "`date` Looking for Singularity image for [default,rhel9,rhel7,rhel6,rhel8] with restrictions $image_restrictions"
+GWMS_SINGULARITY_IMAGE="$(singularity_get_image default,rhel9,rhel7,rhel6,rhel8 $image_restrictions)"
 ec=$?
 if [[ $ec -ne 0 ]]; then
     out_str="ERROR selecting a Singularity image ($ec, $GWMS_SINGULARITY_IMAGE)"

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -105,7 +105,9 @@ SPDX-License-Identifier: Apache-2.0
           <li><a href="#vars">Variables used</a></li>
           <li><a href="#admin_vars">Admin variables</a></li>
           <li><a href="#dyn_vars">Dynamic variables </a></li>
-          <li><a href="#singularity_vars">Singularity variables </a></li>
+          <li>
+            <a href="#singularity_vars">Apptainer/Singularity variables </a>
+          </li>
           <li>
             <a href="#cpuscalculation">Set and discover available CPUs</a>
           </li>
@@ -1358,7 +1360,8 @@ MAX_STARTD_LOG          I       10000000        +                               
                 Comma separated list of keywords affecting Glidein debug.
                 Possible options are:<br />
                 userjob - prints debug informations on the user job stderr (at
-                the beginning, when invoked with the Singularity wrapper)<br />
+                the beginning, when invoked with the container -Apptainer-
+                wrapper)<br />
                 nowait - removes the Glidein wait time when it ends with errors.
                 Useful when debugging. The wait time protects against black
                 holes<br />
@@ -2244,7 +2247,10 @@ MAX_STARTD_LOG          I       10000000        +                               
       </div>
 
       <div class="section">
-        <h3><a name="singularity_vars"></a>Singularity Variables (dynamic)</h3>
+        <h3>
+          <a name="singularity_vars"></a>Apptainer/Singularity Variables
+          (dynamic)
+        </h3>
 
         <p>
           These variables can be set in the Factory attributes, set in the
@@ -2256,8 +2262,8 @@ MAX_STARTD_LOG          I       10000000        +                               
           have the ultimate saying.
         </p>
         <p>
-          The resulting invocation of Singularity is something like the text
-          below. Where $singularity_binds is built using
+          The resulting invocation of Apptainer/Singularity is something like
+          the text below. Where $singularity_binds is built using
           GLIDEIN_SINGULARITY_BINDPATH_DEFAULT, GLIDEIN_SINGULARITY_BINDPATH,
           and GWMS_SINGULARITY_BIND_CVMFS, and the $singularity_image is one
           coming from SINGULARITY_IMAGES_DICT or specified in the job. The debug
@@ -2285,11 +2291,13 @@ MAX_STARTD_LOG          I       10000000        +                               
           </li>
           <li>
             If defined (in environment, Frontend or Factory): Try a singularity
-            binary in the directory suggested via SINGULARITY_BIN: (keyword OSG
-            (default)-> OSG_SINGULARITY_BINARY, keyword PATH -> go to the next
-            step and check the system PATH)
+            binary in the directory suggested via SINGULARITY_BIN: (keyword
+            CONDOR -> apptainer in HTCondor tar ball, keyword OSG (default)->
+            OSG_SINGULARITY_BINARY, keyword PATH -> go to the next step and
+            check the system PATH)
           </li>
           <li>Try the singularity binary in PATH</li>
+          <li>Try the apptainer binary in the HTCondor tar ball</li>
           <li>
             Try the singularity binary in PATH after invoking module
             singularitypro
@@ -2650,15 +2658,17 @@ MAX_STARTD_LOG          I       10000000        +                               
               <p>
                 If set to "OSG" or not set (default), the Glidein will try first
                 to use the singularity binary provided by OSG in CVMFS before
-                looking in the system PATH and trying module. If set to "PATH",
-                the Glidein will try first to use the singularity binary in the
-                system PATH. SINGULARITY_BIN can be used also to suggest an
-                arbitrary specific folder for the singularity binary that will
-                be tested (and used) before the other options, but this use is
-                only for debug purposes, not recommended in production, not to
-                overload Factory Ops with tracking site changes. NOTE: in
-                pre-v3.4 versions SINGULARITY_BIN was used also to enable the
-                use of Singularity for a Factory entry. This is no more, use
+                looking in the system PATH and trying module. If set to
+                "CONDOR", the Glidein will try first to use the apptainer binary
+                provided by the HTCondor tar ball. If set to "PATH", the Glidein
+                will try first to use the singularity binary in the system PATH.
+                SINGULARITY_BIN can be used also to suggest an arbitrary
+                specific folder for the singularity binary that will be tested
+                (and used) before the other options, but this use is only for
+                debug purposes, not recommended in production, not to overload
+                Factory Ops with tracking site changes. NOTE: in pre-v3.4
+                versions SINGULARITY_BIN was used also to enable the use of
+                Singularity for a Factory entry. This is no more, use
                 GLIDEIN_SINGULARITY_REQUIRE instead.
               </p>
             </td>


### PR DESCRIPTION
Now using also Apptainer included in the HTCondor tar ball.

Apprainer downloaded in the HTCondor tarball is now considered after the PATH in the search for a valid apptainer/singularity binary.
The keyword CONDOR in the parameter SINGULARITY_BIN (in Factory or Frontend) will make so that the HTCondor Apptainer is preferred ahead of the rest.

We may consider this to become the default in the future. Currently the singularity/apptainer in OSG is considered first.

This fixes Issue #364.
