### PR TITLE
Added a test Apptainer image to use when the configured one is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ Changes since the last release
 
 ### New features / functionalities
 
--   item one of the list
--   item N
+-   Added a test Apptainer image to use when the configured one is not available (PR #482)
 
 ### Changed defaults / behaviours
+
+-   The new variable SINGULARITY_IMAGE_REQUIRED defaults to false and allows to use Singularity/Apptainer also when the configured image is not available.
+    The image must be provided by the job or a future custom script in order not to fail. (PR #482)
+-   APPTAINER_TEST_IMAGE can be set to an always available Singularity/Apptainer image to use for testing.
+    Defaults to oras://ghcr.io/apptainer/alpine:latest (PR #482)
 
 ### Deprecated / removed options and commands
 

--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -33,6 +33,43 @@ TAC=$(command -v tac)
 PSPID="$(command -v ps) -q"
 [[ "$OSTYPE" =~ darwin* ]] && PSPID="$(command -v ps) -p"  # Quick-pid option not available on Mac/BSD
 
+# Convert to lowercase the output of gconfig_get
+gconfig_get_tolower() {
+    gconfig_get "$@" | tr '[:upper:]' '[:lower:]'
+}
+
+# Convert to uppercase the output of gconfig_get
+gconfig_get_toupper() {
+    gconfig_get "$@" | tr '[:lower:]' '[:upper:]'
+}
+
+# Check for Truth values (case insensitive) from gconfig_get: TRUE, T, YES, Y, 1 (or positive numbers)
+# Anything else, including empty is false
+gconfig_get_bool() {
+    local res
+    # sed "s/[\"' \t\r\n]//g" not working on OS X, '\040\011\012\015' = ' '$'\t'$'\r'$'\n'
+    res=$(gconfig_get "$@" | tr -d '\040\011\012\015')
+    res=${res^^}
+    re="^[0-9]+$"
+    if [[ "$res" == "TRUE" || "$res" == "T" || "$res" == "YES" || "$res" == "Y" || "$res" == "1" ]]; then
+        true
+    elif [[ "$res" =~ $re ]]; then
+            if [[ $res -eq 0 ]]; then
+                false
+            else
+                true
+            fi
+    else
+        false
+    fi
+}
+
+# Strip from space characters and quotes the gconfig_get output.
+# Remove all space and quote characters in front and at the end of the string.
+gconfig_get_trim() {
+    gconfig_get "$@" | sed -e "s/^[\"' \t\n\r]*//g" -e "s/[\"' \t\n\r]*$//g"
+}
+
 # Return the value stored in glidein_config
 #  1: id (key) of the value to retrieve;
 #  2(opt): path of the config file ("$glidein_config" by default)
@@ -58,7 +95,8 @@ gconfig_log_name() {
 }
 
 gconfig_log_add() {
-    local log_name=$(gconfig_log_name "$1")
+    local log_name
+    log_name=$(gconfig_log_name "$1")
     shift
     echo "$@" | dd bs=$GWSM_CONFIG_LINE_MAX 2>/dev/null >> "${log_name}"
 }

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2532,7 +2532,39 @@ MAX_STARTD_LOG          I       10000000        +                               
             <td>
               <p>
                 Comma separated list of restrictions on the Singularity images.
-                Possible values are: cvmfs (the image must be on cvmfs).
+                Possible values are: cvmfs (the image must be on cvmfs); remote
+                (it is OK to use remote images via URI); test (if no valid image
+                is found, return the test image and not error).
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>SINGULARITY_IMAGE_REQUIRED</b></td>
+            <td>String (Enum)</td>
+            <td>false</td>
+            <td>Factory Frontend</td>
+            <td>
+              <p>
+                If "false" the Glidein will continue the Singularity/Apptainer
+                setup even if no valid image is found. The setup will use a test
+                image. The user will have to provide the image with a later
+                setup script or in the job. Possible values are: false or true.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>APPTAINER_TEST_IMAGE</b></td>
+            <td>String (Enum)</td>
+            <td>Not set</td>
+            <td>Factory Frontend CE</td>
+            <td>
+              <p>
+                URI (local path or remote URI) of a Singularity/Apptainer image
+                to use for testing. If not set, GWMS_SINGULARITY_IMAGE_DEFAULT,
+                otherwise <tt>oras://ghcr.io/apptainer/alpine:latest</tt>, a
+                small Alpine Linux sif image provided by the Apptainer
+                developers. This can be set in the worker node environment,
+                which takes precedence, or as attribute.
               </p>
             </td>
           </tr>

--- a/test/bats/creation_web_base_singularity_lib.bats
+++ b/test/bats/creation_web_base_singularity_lib.bats
@@ -60,6 +60,7 @@ setup_nameprint() {
     [ "$output" = "bar" ]
 }
 
+
 ## Tests for dict_... functions
 @test "Test dictionary values" {
     my_dict=" key 1:val1:opt1,key2:val2,key3:val3:opt3,key4,key5:,key6 :val6"
@@ -145,6 +146,25 @@ dit() { echo "TEST:<$1><$2><$3>"; }
     [ "$(list_get_intersection "$list3" "$list2")" = "$list2" ]
 }
 
+
+## Test for utility functions
+@test "Verify uri_is_valid_file_or_remote" {
+    # Remote URI
+    uri_is_valid_file_or_remote http://user@host:port/path/to/file
+    uri_is_valid_file_or_remote ftp://host/path/to/file
+    fixture_dir=$(realpath fixtures)
+    # Local or file:// - both file:// and file:/// are absolute paths
+    # file fixtures/glidein_config is expected to exist
+    uri_is_valid_file_or_remote fixtures/glidein_config
+    uri_is_valid_file_or_remote "$fixture_dir/glidein_config"
+    uri_is_valid_file_or_remote file:/"$fixture_dir/glidein_config"
+    uri_is_valid_file_or_remote file://"$fixture_dir/glidein_config"
+    # file fixtures/this_file_is_not_there is expected NOT to exist
+    ! uri_is_valid_file_or_remote "fixtures/this_file_is_not_there"
+    ! uri_is_valid_file_or_remote "$fixture_dir/this_file_is_not_there"
+    ! uri_is_valid_file_or_remote "file:/$fixture_dir/this_file_is_not_there"
+    ! uri_is_valid_file_or_remote "file://$fixture_dir/this_file_is_not_there"
+}
 
 
 ## Tests for env_... functions


### PR DESCRIPTION
A test Apptainer image has been added so that it can be used when the provided one is not available.
This allows the test of the singularity/apptainer binary when the configured image is not available