### PR TITLE
Added protection disabling mod_ssl when it is installed but there are no certificates

### DIFF
--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -679,6 +679,17 @@ fi
 #  chown frontend.frontend /var/lib/gwms-frontend/passwords.d/FRONTEND
 
 %post vofrontend-httpd
+# Protecting from missing SSL certificate file
+if [ -f /etc/httpd/conf.d/ssl.conf ]; then
+    ssl_certfile=$(grep "^SSLCertificateFile" /etc/httpd/conf.d/ssl.conf | cut -f2 -d ' ')
+    if [ -z "$ssl_certfile" ]; then
+        mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.disable
+    elif [ ! -f "$ssl_certfile" ]; then
+        echo "<IfFile \"$ssl_certfile\" >" | cat - /etc/httpd/conf.d/ssl.conf > /etc/httpd/conf.d/ssl.conf.new
+        echo "</IfFile>" >> /etc/httpd/conf.d/ssl.conf.new
+        mv /etc/httpd/conf.d/ssl.conf.new /etc/httpd/conf.d/ssl.conf
+    fi
+fi
 # Protecting from failure in case it is not running/installed
 /sbin/service httpd reload > /dev/null 2>&1 || true
 
@@ -706,6 +717,17 @@ systemctl daemon-reload
 /sbin/service condor condrestart > /dev/null 2>&1 || true
 
 %post factory-httpd
+# Protecting from missing SSL certificate file
+if [ -f /etc/httpd/conf.d/ssl.conf ]; then
+    ssl_certfile=$(grep "^SSLCertificateFile" /etc/httpd/conf.d/ssl.conf | cut -f2 -d ' ')
+    if [ -z "$ssl_certfile" ]; then
+        mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.disable
+    elif [ ! -f "$ssl_certfile" ]; then
+        echo "<IfFile \"$ssl_certfile\" >" | cat - /etc/httpd/conf.d/ssl.conf > /etc/httpd/conf.d/ssl.conf.new
+        echo "</IfFile>" >> /etc/httpd/conf.d/ssl.conf.new
+        mv /etc/httpd/conf.d/ssl.conf.new /etc/httpd/conf.d/ssl.conf
+    fi
+fi
 # Protecting from failure in case it is not running/installed
 /sbin/service httpd reload > /dev/null 2>&1 || true
 


### PR DESCRIPTION
Added protection disabling mod_ssl when it is installed but there are no certificates

To keep in draft until we have responses from stakeholders

Here the email sent to stakeholders with background info:
```
GWMS 3.10.9 added mod_ssl as a requirement for glideinwms-vofrontend-httpd and glideinwms-factory-httpd RPMs (included respectively in vofrontend-standalone/vofrontend and factory). This is to support the monitoring pages that default to https.
The configuration change happened years ago when Fermilab and other institutions requested to move all services to https and we obtained an exemption for serving the Glidein stage files (to ease caching) but not the monitoring pages. The new configuration was working on most hosts because they had already mod_ssl but testing on a bare-bone install I noticed that the monitoring pages were working but using http instead of https as expected.

In a separate thread was reported that mod_ssl is problematic for the Kubernetes installations and other installations without a SSL certificate.

What could be the preferred solution for the next releases of GlideinWMS?

1. Leave things as they are

2. Remove the SSL dependency from the glideinwms-*-httpd RPMs and add new glideinwms-*-https RPMs that can be installed optionally (or instruct to install mod_ssl)

3. Add a post-install code in the RPM that disables mod_ssl if the CA file is missing (like the code below). This may interfere with a setup where the certificate file is added after the glideinwms RPM installation and ssl.conf has been edited and includes “<IfFile>” directives. This seems rare enough to be OK with the risk

# Protecting from missing SSL certificate file
if [ -f /etc/httpd/conf.d/ssl.conf ]; then
 ssl_certfile=$(grep "^SSLCertificateFile" /etc/httpd/conf.d/ssl.conf | cut -f2 -d ' ‘)
 if [ -z "$ssl_certfile" ]; then
   mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.disable
 elif [ ! -f "$ssl_certfile" ]; then
   echo "<IfFile \"$ssl_certfile\" >" | cat - /etc/httpd/conf.d/ssl.conf > /etc/httpd/conf.d/ssl.conf.new
   echo "</IfFile>" >> /etc/httpd/conf.d/ssl.conf.new
   mv /etc/httpd/conf.d/ssl.conf.new /etc/httpd/conf.d/ssl.conf
 fi
fi
```