### PR TITLE
Ready for release v3_10_11

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,7 +61,7 @@ REUSE is installed as development dependency or you can install it manually
       --license="Apache-2.0" --template=compact FILEPATH
     ```
 -   Files that are not supported and have no comments to add the SPDX notice
-    can be added to the `.reuse/dep5` file
+    can be added to the `REUSE.toml` file
 -   New licenses can be added to the project using `reuse download LCENSEID`. Please
     contact project management if this is needed.
 

--- a/build/ReleaseManager/osg-release.sh
+++ b/build/ReleaseManager/osg-release.sh
@@ -31,7 +31,9 @@ if [ $# -eq 4 ]; then
 fi
 
 # On August 2024 OSG switched to osg-sw-submit.chtc.wisc.edu. moria and library.cs.wisc.edu are not working any more
-osg_buildmachine="osg-sw-submit.chtc.wisc.edu"
+#osg_buildmachine="osg-sw-submit.chtc.wisc.edu"
+# On March 22 2025 the build host has been moved to osg-sw-submit-old
+osg_buildmachine="osg-sw-submit-old.chtc.wisc.edu"
 osg_uploaddir="/p/vdt/public/html/upstream/glideinwms/$gwms_tag"
 
 work_dir="/tmp/osgrelease.$$"

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -1111,7 +1111,7 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Sat Mar 22 2025 Marco Mambelli <marcom@fnal.gov> - 3.10.11
+* Mon Mar 24 2025 Marco Mambelli <marcom@fnal.gov> - 3.10.11
 - Glideinwms v3.10.11
 - Release Notes: http://glideinwms.fnal.gov/doc.v3_10_11/history.html
 - Release candidates 3.10.11-01.rc1 to 3.10.11-02.rc2

--- a/etc/checksum
+++ b/etc/checksum
@@ -1,11 +1,11 @@
 ###################################################################
-# GLIDEINWMS_VERSION v3_10_11_rc2
+# GLIDEINWMS_VERSION v3_10_11
 ###################################################################
 07a95cd0756d25f95de6047b1a5222a5  ./.codespell/README.md
 32b4bfc3e16d335b71c235d34a819eba  ./.codespell/ignore_lines.txt
 bf1869a9f0e22861757b16f54e1acee9  ./.codespell/ignore_words.txt
 9f56602cb12638b944332ca114507dc8  ./ACKNOWLEDGMENTS.md
-492769e5ce6ce1a492fcccd99f7e7a9b  ./CHANGELOG.md
+9f16229ef89646fd1ecb148b1c4df2e3  ./CHANGELOG.md
 9b53cfce6b337a8a5b79886c06ba86bb  ./DEVELOPMENT.md
 3b83ef96387f14655fc854ddc3c6bd57  ./LICENSE
 c846ebb396f8b174b10ded4771514fcc  ./LICENSES/Apache-2.0.txt

--- a/etc/checksum.factory
+++ b/etc/checksum.factory
@@ -1,11 +1,11 @@
 ###################################################################
-# GLIDEINWMS_VERSION v3_10_11_rc2
+# GLIDEINWMS_VERSION v3_10_11
 ###################################################################
 07a95cd0756d25f95de6047b1a5222a5  ./.codespell/README.md
 32b4bfc3e16d335b71c235d34a819eba  ./.codespell/ignore_lines.txt
 bf1869a9f0e22861757b16f54e1acee9  ./.codespell/ignore_words.txt
 9f56602cb12638b944332ca114507dc8  ./ACKNOWLEDGMENTS.md
-492769e5ce6ce1a492fcccd99f7e7a9b  ./CHANGELOG.md
+9f16229ef89646fd1ecb148b1c4df2e3  ./CHANGELOG.md
 9b53cfce6b337a8a5b79886c06ba86bb  ./DEVELOPMENT.md
 3b83ef96387f14655fc854ddc3c6bd57  ./LICENSE
 c846ebb396f8b174b10ded4771514fcc  ./LICENSES/Apache-2.0.txt

--- a/etc/checksum.frontend
+++ b/etc/checksum.frontend
@@ -1,11 +1,11 @@
 ###################################################################
-# GLIDEINWMS_VERSION v3_10_11_rc2
+# GLIDEINWMS_VERSION v3_10_11
 ###################################################################
 07a95cd0756d25f95de6047b1a5222a5  ./.codespell/README.md
 32b4bfc3e16d335b71c235d34a819eba  ./.codespell/ignore_lines.txt
 bf1869a9f0e22861757b16f54e1acee9  ./.codespell/ignore_words.txt
 9f56602cb12638b944332ca114507dc8  ./ACKNOWLEDGMENTS.md
-492769e5ce6ce1a492fcccd99f7e7a9b  ./CHANGELOG.md
+9f16229ef89646fd1ecb148b1c4df2e3  ./CHANGELOG.md
 9b53cfce6b337a8a5b79886c06ba86bb  ./DEVELOPMENT.md
 3b83ef96387f14655fc854ddc3c6bd57  ./LICENSE
 c846ebb396f8b174b10ded4771514fcc  ./LICENSES/Apache-2.0.txt


### PR DESCRIPTION
Release 3.10.11 final

Highlights:
stale_age allows to keep Glideins in queues for longer than one week.
Apptainer test now may be successful even if the default image is not available.
Check the changed defaults, including SINGULARITY_IMAGE_REQUIRED, APPTAINER_TEST_IMAGE and the redirection to https for monitoring pages.
