### PR TITLE
Added GLIDEIN_Name and GLIDEIN_UUID to the Glidein environment, to be visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
+
+Changes since the last release
+
+### New features / functionalities
+
+-   Exporting GLIDEIN_Name and GLIDEIN_UUID to the Glidein environment, for all scripts running inside the Glidein (PR #512)
+-   item N
+
+### Changed defaults / behaviours
+
+### Deprecated / removed options and commands
+
+### Security Related Fixes
+
+### Bug Fixes
+
+### Testing / Development
+
+### Known Issues
+
 ## v3.10.11 \[2025-03-24\]
 
 stale_age allows to keep Glideins in queues for longer than one week.

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -1842,6 +1842,10 @@ if ! {
 } >> "${glidein_config}"; then
     early_glidein_failure "Failed in updating '${glidein_config}'"
 fi
+# Export these variables to these are available in the environment for the Glidein and invoked scripts
+export GLIDEIN_Name="${glidein_name}"
+export GLIDEIN_UUID="${glidein_uuid}"
+
 # shellcheck disable=SC2086
 params2file ${params}
 
@@ -2046,7 +2050,7 @@ glog_write "glidein_startup.sh" "file" "${glidein_config}" "debug"
 if ! glog_send; then          # checkpoint
     echo "Failed to checkpoint Glidein Logging"
 fi
-echo "# --- Last Script values ---" >> glidein_config
+echo "# --- Last Script values ---" >> "${glidein_config}"
 last_startup_time=$(date +%s)
 ((validation_time=last_startup_time-startup_time)) || true
 echo "=== Last script starting $(date) (${last_startup_time}) after validating for ${validation_time} ==="


### PR DESCRIPTION
Added GLIDEIN_Name and GLIDEIN_UUID to the Glidein environment, so these are exported to all scripts running inside the Glidein.
This is a feature requested by CMS.