### PR TITLE
Added support for the HTCondor LOCAL_CONFIG_DIR in Glideins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
-## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
+## v3.10.12 \[2025-04-25\]
 
-Changes since the last release
+Added the ability to use a config directory for the Glidein's HTCondor
 
 ### New features / functionalities
 
 -   Exporting GLIDEIN_Name and GLIDEIN_UUID to the Glidein environment, for all scripts running inside the Glidein (PR #512)
--   item N
+-   HTCondor LOCAL_CONFIG_DIR support for the Glidein HTCondor demons (PR #515)
 
 ### Changed defaults / behaviours
 
@@ -21,6 +21,8 @@ Changes since the last release
 ### Bug Fixes
 
 ### Testing / Development
+
+-   Improved docstrings in the Factory module (PR #511)
 
 ### Known Issues
 

--- a/creation/lib/cWDictFile.py
+++ b/creation/lib/cWDictFile.py
@@ -503,12 +503,12 @@ class DictFileTwoKeys(DictFile):
     def __init__(self, dir, fname, sort_keys=False, order_matters=False, fname_idx=None):
         """constructor
 
-        :param dir: directory
-        :param fname: file name
-        :param sort_keys: should the keys be sorted? (Default: False)
-        :param order_matters: order is important (Default: False)
-        :param fname_idx: fname ID, use fname if None (Default: None)
-        :return:
+        Args:
+            dir: directory
+            fname (str): file name
+            sort_keys (bool): should the keys be sorted? (Default: False)
+            order_matters (bool): order is important (Default: False)
+            fname_idx (str): fname ID, use fname if None (Default: None)
         """
         DictFile.__init__(self, dir, fname, sort_keys, order_matters, fname_idx)
         self.keys2 = []
@@ -517,16 +517,22 @@ class DictFileTwoKeys(DictFile):
     def has_key2(self, key):
         """Check reverse dictionary keys
 
-        :param key: reverse key (value)
-        :return: reverse key in value list
+        Args:
+            key: reverse key (value)
+
+        Returns:
+            str: reverse key in value list
         """
         return key in self.keys2
 
     def get_val2(self, key):
         """Retrieve value associated with reverse key
 
-        :param key: reverse key (value)
-        :return: value associated with reverse key (key)
+        Args:
+            key: reverse key (value)
+
+        Returns:
+            str: value associated with reverse key (key)
         """
         return self.vals2[key]
 
@@ -536,7 +542,7 @@ class DictFileTwoKeys(DictFile):
         self.vals2 = {}
 
     def add(self, key, val, allow_overwrite=False):
-        """
+        """Add a value to the dictionary
 
         Args:
             key:
@@ -545,7 +551,6 @@ class DictFileTwoKeys(DictFile):
 
         Raises:
             DictFileError
-
         """
         if key in self.keys:
             if self.vals[key] == val:
@@ -586,7 +591,7 @@ class DictFileTwoKeys(DictFile):
         self.changed = True
 
     def remove(self, key, fail_if_missing=False):
-        """
+        """Remove a value from the dictionary
 
         Args:
             key:
@@ -594,7 +599,6 @@ class DictFileTwoKeys(DictFile):
 
         Raises:
             DictFileError: KeyError, the key does not exist
-
         """
         if key not in self.keys:
             if fail_if_missing:
@@ -611,13 +615,17 @@ class DictFileTwoKeys(DictFile):
         self.changed = True
 
     def is_equal(self, other, compare_dir=False, compare_fname=False, compare_keys=None):
-        """Compare two DictFileDoubleKey objects (and optionally their file)
+        """Compares two `DictFileDoubleKey` objects, optionally comparing also the file attributes.
 
-        :param other: other dictionary, object of the same class
-        :param compare_dir: if True compare also the file directory (Default: False)
-        :param compare_fname: if True compare also the file name (Default: False)
-        :param compare_keys: if True compare also the keys lists. If None, use order_matters (Default: False)
-        :return:
+        Args:
+            other (DictFileDoubleKey): Another object of the same class to compare with.
+            compare_dir (bool, optional): If True, also compares the file directory. Defaults to False.
+            compare_fname (bool, optional): If True, also compares the file name. Defaults to False.
+            compare_keys (bool or None, optional): If True, compares the key lists (`keys` and `keys2`).
+                If None, uses the value of `self.order_matters`. Defaults to None.
+
+        Returns:
+            bool: True if the objects are considered equal based on the comparison criteria, False otherwise.
         """
         if compare_dir and (self.dir != other.dir):
             return False
@@ -659,7 +667,7 @@ class DescriptionDictFile(DictFileTwoKeys):
 
 
 class GridMapDict(DictFileTwoKeys):
-    """Dictionary file (:class:DictFile) with the GrigMap file information
+    """Dictionary file (`:class:DictFile`) with the GridMap file information
 
     The dictionary is keyed both by DN and user
     """
@@ -692,7 +700,7 @@ class GridMapDict(DictFileTwoKeys):
 
 
 class SHA1DictFile(DictFile):
-    """Dictionary file (:class:DictFile) with SHA1 signatures of files
+    """Dictionary file (`:class:DictFile`) with SHA1 signatures of files
 
     This is used to send to the Glidein files checksums.
     Saved as "SHA1   FNAME" lines
@@ -747,7 +755,7 @@ class SHA1DictFile(DictFile):
 
 
 class SummarySHA1DictFile(DictFile):
-    """Dictionary file (:class:DictFile) with a Summary w/ SHA1 signatures
+    """Dictionary file (`:class:DictFile`) with a Summary w/ SHA1 signatures
 
     Values are (sha1, fname2)
     Saved as "SHA1   FNAME2   FNAME" lines
@@ -822,7 +830,7 @@ class SummarySHA1DictFile(DictFile):
 
 
 class SimpleFileDictFile(DictFile):
-    """Dictionary (:class:DictFile) of files that holds also the content of the file as the last element in the values.
+    """Dictionary (`:class:DictFile`) of files that holds also the content of the file as the last element in the values.
 
     Value is a tuple.
     The dictionary is serialized using a file (dictionary file), one item per line.
@@ -1013,14 +1021,18 @@ class FileDictFile(SimpleFileDictFile):
     the key is used as key for the dictionary and the data (file content) is added reading the file.
     Here the attributes stored as tuple in the dictionary value:
     1. real_fname, i.e file name
-    2. cache/exec/... keyword identifying the file type: regular, nocache, exec (:s modifier to run in singularity), untar, wrapper
-    3. period period in seconds at which an executable is re-invoked (only for periodic executables, 0 otherwise)
-    4. prefix startd_cron variables prefix (default is GLIDEIN_PS_)
+    2. cache/exec/... keyword identifying the file type: regular, nocache, exec (:s modifier to run in singularity),
+        config (:c_type with config type, e.g. :condor), untar, wrapper
+    3. period - period in seconds at which an executable is re-invoked (only for periodic executables, 0 otherwise)
+    4. prefix - startd_cron variables prefix (default is GLIDEIN_PS_)
     5. cond_download has a special value of TRUE
     6. config_out has a special value of FALSE
     7. data - String containing the data extracted from the file (real_fname) (not in the serialized dictionary)
     For placeholders, the real_name is empty (and the tuple starts w/ an empty string). Placeholders cannot be
     serialized (saved into file). Empty strings would cause error when parsed back.
+
+    TODO: the period will become "time", a comma-separated list of execution-time names (with optional qualifiers)
+        for custom scripts
     """
 
     DATA_LENGTH = 7  # Length of value (attributes + data)
@@ -1035,18 +1047,25 @@ class FileDictFile(SimpleFileDictFile):
 
     @staticmethod
     def make_val_tuple(file_name, file_type, period=0, prefix="GLIDEIN_PS_", cond_download="TRUE", config_out="FALSE"):
-        """Make a tuple with the DATA_LENGTH-1 attributes in the correct order using the defaults
+        """Creates a tuple with the DATA_LENGTH-1 attributes in the correct order using default values.
 
-        :param file_name: name of the file (aka real_fname)
-        :param file_type: type of the file (regular, nocache, exec, untar, wrapper). 'exec allows modifiers like ':s'
-        :param period: period for periodic executables (ignored otherwise, default: 0)
-        :param prefix: prefix for periodic executables (ignored otherwise, default: GLIDEIN_PS_)
-        :param cond_download: conditional download (default: 'TRUE')
-        :param config_out: config out (default: 'FALSE')
-        :return: tuple with the DATA_LENGTH-1 attributes
-        See class definition for more information about the attributes
+        Args:
+            file_name (str): Name of the file (also known as real_fname).
+            file_type (str): Type of the file. Options include 'regular', 'nocache', 'exec', 'config', 'untar',
+                or 'wrapper'. 'exec' and 'config' allow modifiers like ':s', or ':condor'.
+            period (int, optional): Period for periodic executables. Ignored for other types. Defaults to 0.
+            prefix (str, optional): Prefix for periodic executables. Ignored for other types. Defaults to "GLIDEIN_PS_".
+            cond_download (str, optional): Conditional download flag. Defaults to "TRUE".
+            config_out (str, optional): Config output flag. Defaults to "FALSE".
+
+        Returns:
+            tuple: A tuple containing the DATA_LENGTH-1 attributes in the specified order.
+
+        Note:
+            See the class definition for more details about the attributes.
         """
         # TODO: should it do some value checking? valid constant, int, ...
+        # TODO(time): period will become time, a comma-separated lis
         return file_name, file_type, period, prefix, cond_download, config_out  # python constructs the tuple
 
     @staticmethod
@@ -1196,16 +1215,9 @@ class FileDictFile(SimpleFileDictFile):
             return  # empty key
 
         if len(arr) != self.DATA_LENGTH:
-            # compatibility w/ old formats
+            # Removed compatibility code for 3.2.x
             # 3.2.13 (no prefix): key, fname, type, period, cond_download, config_out
             # 3.2.10 (no period, prefix): key, fname, type, cond_download, config_out
-            # TODO: remove in 3.3 or after a few version (will break upgrade)
-            if len(arr) == self.DATA_LENGTH - 1:
-                # For upgrade from 3.2.13 to 3.2.11
-                return self.add(arr[0], [arr[1], arr[2], arr[3], "GLIDEIN_PS_", arr[4], arr[5]])
-            elif len(arr) == self.DATA_LENGTH - 2:
-                # For upgrade from 3.2.10 or earlier
-                return self.add(arr[0], [arr[1], arr[2], 0, "GLIDEIN_PS_", arr[3], arr[4]])
             raise RuntimeError(
                 "Not a valid file line (expected %i, found %i elements): '%s'" % (self.DATA_LENGTH, len(arr), line)
             )

--- a/creation/lib/cWParamDict.py
+++ b/creation/lib/cWParamDict.py
@@ -37,14 +37,25 @@ def has_file_wrapper_params(file_params):
 
 
 def add_file_unparsed(user_file, dicts, is_factory):
-    """Add a user file residing in the stage area
-    file as described by Params.file_defaults
-    :param user_file: file from the config files "files" sections
-    :param dicts: parameters dictionaries
-    :param is_factory: True if invoked for the factory (cgWParamDict.py), false for the frontend (cvWParamDict.py)
-    :return: None (dictionaries are modified)
-    """
+    """Adds a user file residing in the staging area to the appropriate internal dictionary.
 
+    This function processes a file element defined in the configuration, categorizes it
+    (e.g., executable, wrapper, untar, regular), and inserts it into the correct section of
+    the parameter dictionaries. It handles both Factory and Frontend (client) contexts.
+
+    Args:
+        user_file (object): A file configuration object from the "files" section of the XML config.
+        dicts (dict): A set of internal parameter dictionaries that will be modified by this function.
+        is_factory (bool): True if invoked in the Factory context (e.g., `cgWParamDict.py`),
+            False if invoked in the Frontend (client) context (e.g., `cvWParamDict.py`).
+
+    Returns:
+        None: The function modifies the provided `dicts` in place.
+
+    Raises:
+        RuntimeError: If the file configuration is invalid (e.g., missing paths, conflicting flags, or
+            incompatible type combinations such as an executable tar file or a wrapper marked non-constant).
+    """
     absfname = user_file.absfname
     if absfname is None:
         raise RuntimeError("Found a file element without an absname: %s" % user_file)
@@ -57,6 +68,9 @@ def add_file_unparsed(user_file, dicts, is_factory):
 
     is_const = is_true(user_file.const)
     is_executable = is_true(user_file.executable)
+    is_config = False
+    if user_file.type:
+        is_config = user_file.type.startswith("config")
     is_wrapper = is_true(user_file.wrapper)
     do_untar = is_true(user_file.untar)
     try:
@@ -109,7 +123,9 @@ def add_file_unparsed(user_file, dicts, is_factory):
             ),
             absfname,
         )
-
+    elif is_config:  # a configuration file (e.g. HTCondor config)
+        if user_file.type == "config:condor" or user_file.type == "config":
+            file_type = "config:c"
     elif is_wrapper:  # a source-able script for the wrapper
         if not is_const:
             raise RuntimeError("A file cannot be a wrapper if it is not constant: %s" % user_file)

--- a/creation/lib/cWParams.py
+++ b/creation/lib/cWParams.py
@@ -491,11 +491,17 @@ class CommonParams(Params):
         self.file_defaults["type"] = (
             None,
             "string",
-            'File type (regular,run,source). Allows modifiers like ":singularity" to run in singularity.',
+            'File type (regular,run,source,config,wrapper,tarball). Allows modifiers like ":singularity" to run in singularity or ":condor" for condor configuration files.',
             None,
         )
         # TODO: consider adding "time" setup, prejob, postjob, cleanup, periodic. setup & cleanup w/ qualifier :bebg-aeag before/after entry + before/after group og na (group positioning does not apply to factory files)
         # to add check scripts around jobs: self.file_defaults["job_wrap"]=("no","pre|post|no",'Run the executable before (pre) or after (post) each job.',None)
+        self.file_defaults["time"] = (
+            "setup",
+            "string",
+            "Comma separated list of when to run an executable (setup, prejob, postjob, cleanup, periodic). Allows modifiers for setup and cleanup, :QeQg for e/g entry/group Q is b/a/o/n before/after/on/NA (group positioning does not apply to Factory files)",
+            None,
+        )
 
         untar_defaults = CommentedOrderedDict()
         untar_defaults["cond_attr"] = (

--- a/creation/lib/factory_defaults.xml
+++ b/creation/lib/factory_defaults.xml
@@ -66,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
           </attrs>
           <files>
              <!-- required: absfname; optional: relfname -->
-             <file const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False">
+             <file const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False" type="regular" time="setup">
                 <!-- optional: dir, absdir_outattr -->
                 <untar_options cond_attr="TRUE"/>
              </file>
@@ -117,7 +117,7 @@ SPDX-License-Identifier: Apache-2.0
          </attrs>
          <files>
             <!-- required: absfname; optional: relfname -->
-            <file const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False">
+            <file const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False" type="regular" time="setup">
                <!-- optional: dir, absdir_outattr -->
                <untar_options cond_attr="TRUE"/>
             </file>
@@ -147,7 +147,7 @@ SPDX-License-Identifier: Apache-2.0
    <files>
       <!-- required: absfname; optional: relfname -->
       <!-- global file has additional after_entry field -->
-      <file after_entry="False" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False">
+      <file after_entry="False" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" wrapper="False" untar="False" type="regular" time="setup">
          <!-- optional: dir, absdir_outattr -->
          <untar_options cond_attr="TRUE"/>
       </file>

--- a/creation/web_base/condor_config
+++ b/creation/web_base/condor_config
@@ -11,6 +11,8 @@
 
 LOG = $(WORK_DIR)/log
 EXECUTE = $(WORK_DIR)/execute
+# Optional configuration files. This directory is created and populated in glidein_startup.sh
+LOCAL_CONFIG_DIR = $(WORK_DIR)/condor_config.d
 COLLECTOR_HOST = $(HEAD_NODE),$(GLIDEIN_Site_Collector)
 FILESYSTEM_DOMAIN = $(HOSTNAME)
 UID_DOMAIN = $(HOSTNAME)

--- a/doc/factory/configuration.html
+++ b/doc/factory/configuration.html
@@ -2816,11 +2816,33 @@ export _CONDOR_CONDOR_VIEW_HOST=localhost:9618</pre
             <td>
               <p>
                 File type, must be one of the valid types (regular, run, source,
-                wrapper, untar). Can have qualifiers depending on the type after
-                a colon (":"). Valid qualifier for <i>run</i> is "singularity"
-                causes setup scripts to run in Singularity. Currently
-                <i>type</i> is ignored for non executables and the only values
-                used are "run" or "run:singularity". Default is empty
+                config, wrapper, untar). Can have qualifiers depending on the
+                type after a colon (":"). Valid qualifier for <i>run</i> is
+                "singularity" causes setup scripts to run in Singularity. Valid
+                qualifier for <i>config</i> is "condor", for HTCondor
+                configuration files. Currently, <i>type</i> is ignored for non
+                executables and non config files. The only values used are
+                "run", "run:singularity", "config", or "config:condor". Default
+                is "regular".
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p><b>time</b></p>
+            </td>
+            <td>
+              <p>
+                NOT IMPLEMENTED - will replace after_group and pre_entry. File
+                time, must be one of the valid timing names (setup, prejob,
+                postjob, cleanup, periodic). Can have qualifiers depending on
+                the type after a colon (":"). Valid qualifier for
+                <i>setup</i> and <i>cleanup</i> are strings like QeQg specifying
+                the order respect the entry (e) or group (g). "singularity" Q
+                specifies the positioning using any of b/a/o/n
+                before/after/on/NA (group positioning does not apply to Factory
+                files). <i>periodic</i> can have the period as qualifier.
+                Currently <i>time</i> is ignored. Default is "setup"
               </p>
             </td>
           </tr>


### PR DESCRIPTION
Added support for the HTCondor LOCAL_CONFIG_DIR for the Glidein HTCondor demons configuration via custom files "config files".
The config file type in the custom file is more general and can allow expansion to additional config file types in the future.

Also added initial support for custom scripts' timing management.