### PR TITLE
Fixing Misleading Counts of Jobs Run in the Glidein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Added the ability to use a config directory for the Glidein's HTCondor
 
 ### Bug Fixes
 
+- Fixed misleading counts related to the number of jobs that run in the Glidein (PR #516, Issue #456)
+
 ### Testing / Development
 
 -   Improved docstrings in the Factory module (PR #511)

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -1129,6 +1129,8 @@ if [[ "$use_multi_monitor" -ne 1 ]]; then
     fi
     main_starter_log='log/StarterLog'
     main_condor_log='log/StartdLog'
+    new_starter_log='log/StarterLog.testing'
+    history_log='log/StartdHistoryLog'
 else
     main_starter_log='log/StarterLog.vm2'
     monitor_starter_log='log/StarterLog.vm1'
@@ -1247,7 +1249,7 @@ log_dir='log'
 
 echo "Total jobs/goodZ jobs/goodNZ jobs/badSignal jobs/badOther jobs below are normalized to 1 Core"
 echo "=== Stats of main ==="
-if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null); then
+if slotlogs=$(ls -1 ${main_starter_log}.slot* ${new_starter_log} ${history_log}); then
     echo "===NewFile===" > separator_log.txt
     listtoparse="separator_log.txt"
     for slotlog in $slotlogs
@@ -1257,7 +1259,7 @@ if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null); 
     parsed_out=$(cat $listtoparse | awk -v parallelism=${GLIDEIN_CPUS} -f "${main_stage_dir}/parse_starterlog.awk")
     echo "$parsed_out"
 
-    parsed_metrics=$(echo "$parsed_out" | awk 'BEGIN{p=0;}/^Total /{if (p==1) {if ($2=="jobs") {t="Total";n=$3;m=$5;} else {t=$2;n=$4;m=$7;} print t "JobsNr " n " " t "JobsTime " m;}}/^====/{p=1;}')
+    parsed_metrics=$(echo "$parsed_out" | awk 'BEGIN{p=0;}/^\(Normalized\) /{if ($3=="jobs") {t="Total";n=$4;m=$6;} else {t=$3;n=$5;m=$8;} print t "JobsNr " n " " t "JobsTime " m}')
     # use echo to strip newlines
     metrics+=$(echo " " $parsed_metrics)
 fi

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -1129,8 +1129,6 @@ if [[ "$use_multi_monitor" -ne 1 ]]; then
     fi
     main_starter_log='log/StarterLog'
     main_condor_log='log/StartdLog'
-    new_starter_log='log/StarterLog.testing'
-    history_log='log/StartdHistoryLog'
 else
     main_starter_log='log/StarterLog.vm2'
     monitor_starter_log='log/StarterLog.vm1'
@@ -1249,8 +1247,8 @@ log_dir='log'
 
 echo "Total jobs/goodZ jobs/goodNZ jobs/badSignal jobs/badOther jobs below are normalized to 1 Core"
 echo "=== Stats of main ==="
-# the following if block has been tested with condor version 24.0.2, where 'log/StarterLog' no longer exists and has changed to 'log/StarterLog.testing' (as confirmed by Cole Bollig of HTCondor team). If 'log/StarterLog' is included to be listed, the error message 'log'StarterLog': No such file or directory' occurs but ends up being silently redirected to `/dev/null`
-if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* ${new_starter_log} ${history_log} 2>/dev/null); then
+# the following if block has been tested with condor version 24.0.2, where 'log/StarterLog' no longer exists and has changed to 'log/StarterLog.testing' (as confirmed by Cole Bollig of HTCondor team)
+if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null); then
     echo "===NewFile===" > separator_log.txt
     listtoparse="separator_log.txt"
     for slotlog in $slotlogs
@@ -1263,6 +1261,11 @@ if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* ${new_starter_
     parsed_metrics=$(echo "$parsed_out" | awk 'BEGIN{p=0;}/^\(Normalized\) Total /{if (p==1) {if ($3=="jobs") {t="Total";n=$4;m=$6;} else {t=$3;n=$5;m=$8;} print t "JobsNr " n " " t "JobsTime " m}}/^====/{p=1;}')
     # use echo to strip newlines
     metrics+=$(echo " " $parsed_metrics)
+else
+    # when any of 'log/StarterLog' or 'log/StarterLog.slot*' files are missing
+    # since error message about the missing file(s) gets silently redirected to `/dev/null` with a non-zero exit code, report the same appropriately
+    echo "One/more HTCondor starter logs missing; skipping calculation of metrics" 1>&2
+    echo "Proceeding with rest of the condor shutdown process..." 1>&2
 fi
 echo "=== End Stats of main ==="
 

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -1248,7 +1248,8 @@ log_dir='log'
 echo "Total jobs/goodZ jobs/goodNZ jobs/badSignal jobs/badOther jobs below are normalized to 1 Core"
 echo "=== Stats of main ==="
 # the following if block has been tested with condor version 24.0.2, where 'log/StarterLog' no longer exists and has changed to 'log/StarterLog.testing' (as confirmed by Cole Bollig of HTCondor team)
-if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null); then
+slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null)
+if [[ -n "$slotlogs" ]]; then
     echo "===NewFile===" > separator_log.txt
     listtoparse="separator_log.txt"
     for slotlog in $slotlogs
@@ -1262,8 +1263,7 @@ if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* 2>/dev/null); 
     # use echo to strip newlines
     metrics+=$(echo " " $parsed_metrics)
 else
-    # when any of 'log/StarterLog' or 'log/StarterLog.slot*' files are missing
-    # since error message about the missing file(s) gets silently redirected to `/dev/null` with a non-zero exit code, report the same appropriately
+    # when all of 'log/StarterLog' or 'log/StarterLog.slot*' files are missing; report it and continue
     echo "One/more HTCondor starter logs missing; skipping calculation of metrics" 1>&2
     echo "Proceeding with rest of the condor shutdown process..." 1>&2
 fi

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -1249,7 +1249,8 @@ log_dir='log'
 
 echo "Total jobs/goodZ jobs/goodNZ jobs/badSignal jobs/badOther jobs below are normalized to 1 Core"
 echo "=== Stats of main ==="
-if slotlogs=$(ls -1 ${main_starter_log}.slot* ${new_starter_log} ${history_log}); then
+# the following if block has been tested with condor version 24.0.2, where 'log/StarterLog' no longer exists and has changed to 'log/StarterLog.testing' (as confirmed by Cole Bollig of HTCondor team). If 'log/StarterLog' is included to be listed, the error message 'log'StarterLog': No such file or directory' occurs but ends up being silently redirected to `/dev/null`
+if slotlogs=$(ls -1 ${main_starter_log} ${main_starter_log}.slot* ${new_starter_log} ${history_log} 2>/dev/null); then
     echo "===NewFile===" > separator_log.txt
     listtoparse="separator_log.txt"
     for slotlog in $slotlogs
@@ -1259,7 +1260,7 @@ if slotlogs=$(ls -1 ${main_starter_log}.slot* ${new_starter_log} ${history_log})
     parsed_out=$(cat $listtoparse | awk -v parallelism=${GLIDEIN_CPUS} -f "${main_stage_dir}/parse_starterlog.awk")
     echo "$parsed_out"
 
-    parsed_metrics=$(echo "$parsed_out" | awk 'BEGIN{p=0;}/^\(Normalized\) /{if ($3=="jobs") {t="Total";n=$4;m=$6;} else {t=$3;n=$5;m=$8;} print t "JobsNr " n " " t "JobsTime " m}')
+    parsed_metrics=$(echo "$parsed_out" | awk 'BEGIN{p=0;}/^\(Normalized\) Total /{if (p==1) {if ($3=="jobs") {t="Total";n=$4;m=$6;} else {t=$3;n=$5;m=$8;} print t "JobsNr " n " " t "JobsTime " m}}/^====/{p=1;}')
     # use echo to strip newlines
     metrics+=$(echo " " $parsed_metrics)
 fi

--- a/creation/web_base/parse_starterlog.awk
+++ b/creation/web_base/parse_starterlog.awk
@@ -166,10 +166,23 @@ END {
   if (tcnt>tj) {tgz=tgz-(tcnt-tj); tcnt=tj;}
   # please notice that the percentages will still be accurate
 
+  # uncomment the following block of code in case reporting of real numbers are requested in the future. when uncommented, move this code block after the "=================" below
+  # historically, the reporting has/is been based on normalized numbers, so was decided to retain this form of reporting unless operators request for reporting metrics based off of real totals
+  #print "(Real) Total goodZ jobs",goodjobsZ, " (" percent(goodjobsZ,ended_jobs) "%)","utilization",int(goodputZ) " (" percent(goodputZ,total_used) "%)";
+  #print "(Real) Total goodNZ jobs",goodjobsNZ, " (" percent(goodjobsNZ,ended_jobs) "%)","utilization",int(goodputNZ) " (" percent(goodputNZ,total_used) "%)";
+  #print "(Real) Total badSignal jobs",badjobsSignal, " (" percent(badjobsSignal,ended_jobs) "%)","utilization",int(badputSignal) " (" percent(badputSignal,total_used) "%)";
+  #print "(Real) Total badOther jobs",badjobsOther, " (" percent(badjobsOther,ended_jobs) "%)","utilization",int(badputOther) " (" percent(badputOther,total_used) "%)";
+  # end of comment block
+
   print "=================";
-  print "Total jobs",tj,"utilization",int(total_used/parallelism);
-  print "Total goodZ jobs",tgz, " (" percent(goodjobsZ,ended_jobs) "%)","utilization",int(goodputZ/parallelism) " (" percent(goodputZ,total_used) "%)";
-  print "Total goodNZ jobs",tgnz, " (" percent(goodjobsNZ,ended_jobs) "%)","utilization",int(goodputNZ/parallelism) " (" percent(goodputNZ,total_used) "%)";
-  print "Total badSignal jobs",tbjs, " (" percent(badjobsSignal,ended_jobs) "%)","utilization",int(badputSignal/parallelism) " (" percent(badputSignal,total_used) "%)";
-  print "Total badOther jobs",tbjo, " (" percent(badjobsOther,ended_jobs) "%)","utilization",int(badputOther/parallelism) " (" percent(badputOther,total_used) "%)";
+  print "Normalization [parallelism] factor",parallelism;
+  # printing real numbers (without normalization)
+  print "(Real) Total jobs",ended_jobs,"utilization",int(total_used);
+
+  # printing below normalized numbers for metrics reporting (historically, this form of reporting has been used)
+  print "(Normalized) Total jobs",tj,"utilization",int(total_used/parallelism);
+  print "(Normalized) Total goodZ jobs",tgz, " (" percent(goodjobsZ,ended_jobs) "%)","utilization",int(goodputZ/parallelism) " (" percent(goodputZ,total_used) "%)";
+  print "(Normalized) Total goodNZ jobs",tgnz, " (" percent(goodjobsNZ,ended_jobs) "%)","utilization",int(goodputNZ/parallelism) " (" percent(goodputNZ,total_used) "%)";
+  print "(Normalized) Total badSignal jobs",tbjs, " (" percent(badjobsSignal,ended_jobs) "%)","utilization",int(badputSignal/parallelism) " (" percent(badputSignal,total_used) "%)";
+  print "(Normalized) Total badOther jobs",tbjo, " (" percent(badjobsOther,ended_jobs) "%)","utilization",int(badputOther/parallelism) " (" percent(badputOther,total_used) "%)";
 }

--- a/creation/web_base/parse_starterlog.awk
+++ b/creation/web_base/parse_starterlog.awk
@@ -172,10 +172,10 @@ END {
   print "(Real) Total jobs", ended_jobs, "utilization", int(total_used);
   # uncomment the following block of code in case reporting of real numbers are requested in the future.
   # historically, the reporting has/is been based on normalized numbers, so was decided to retain this form of reporting unless operators request for reporting metrics based off of real totals
-  #print "(Real) Total goodZ jobs", goodjobsZ, "(" percent(goodjobsZ,ended_jobs) "%)", "utilization", int(goodputZ) "(" percent(goodputZ,total_used) "%)";
-  #print "(Real) Total goodNZ jobs", goodjobsNZ, "(" percent(goodjobsNZ,ended_jobs) "%)", "utilization", int(goodputNZ) "(" percent(goodputNZ,total_used) "%)";
-  #print "(Real) Total badSignal jobs", badjobsSignal, "(" percent(badjobsSignal,ended_jobs) "%)", "utilization", int(badputSignal) "(" percent(badputSignal,total_used) "%)";
-  #print "(Real) Total badOther jobs", badjobsOther, "(" percent(badjobsOther,ended_jobs) "%)", "utilization", int(badputOther) "(" percent(badputOther,total_used) "%)";
+  #print "(Real) Total goodZ jobs", goodjobsZ, "(" percent(goodjobsZ,ended_jobs) "%)", "utilization", int(goodputZ), "(" percent(goodputZ,total_used) "%)";
+  #print "(Real) Total goodNZ jobs", goodjobsNZ, "(" percent(goodjobsNZ,ended_jobs) "%)", "utilization", int(goodputNZ), "(" percent(goodputNZ,total_used) "%)";
+  #print "(Real) Total badSignal jobs", badjobsSignal, "(" percent(badjobsSignal,ended_jobs) "%)", "utilization", int(badputSignal), "(" percent(badputSignal,total_used) "%)";
+  #print "(Real) Total badOther jobs", badjobsOther, "(" percent(badjobsOther,ended_jobs) "%)", "utilization", int(badputOther), "(" percent(badputOther,total_used) "%)";
   # end of comment block
 
   # printing below normalized numbers for metrics reporting (historically, this form of reporting has been used)

--- a/creation/web_base/parse_starterlog.awk
+++ b/creation/web_base/parse_starterlog.awk
@@ -166,23 +166,22 @@ END {
   if (tcnt>tj) {tgz=tgz-(tcnt-tj); tcnt=tj;}
   # please notice that the percentages will still be accurate
 
-  # uncomment the following block of code in case reporting of real numbers are requested in the future. when uncommented, move this code block after the "=================" below
-  # historically, the reporting has/is been based on normalized numbers, so was decided to retain this form of reporting unless operators request for reporting metrics based off of real totals
-  #print "(Real) Total goodZ jobs",goodjobsZ, " (" percent(goodjobsZ,ended_jobs) "%)","utilization",int(goodputZ) " (" percent(goodputZ,total_used) "%)";
-  #print "(Real) Total goodNZ jobs",goodjobsNZ, " (" percent(goodjobsNZ,ended_jobs) "%)","utilization",int(goodputNZ) " (" percent(goodputNZ,total_used) "%)";
-  #print "(Real) Total badSignal jobs",badjobsSignal, " (" percent(badjobsSignal,ended_jobs) "%)","utilization",int(badputSignal) " (" percent(badputSignal,total_used) "%)";
-  #print "(Real) Total badOther jobs",badjobsOther, " (" percent(badjobsOther,ended_jobs) "%)","utilization",int(badputOther) " (" percent(badputOther,total_used) "%)";
-  # end of comment block
-
   print "=================";
   print "Normalization [parallelism] factor",parallelism;
   # printing real numbers (without normalization)
-  print "(Real) Total jobs",ended_jobs,"utilization",int(total_used);
+  print "(Real) Total jobs", ended_jobs, "utilization", int(total_used);
+  # uncomment the following block of code in case reporting of real numbers are requested in the future.
+  # historically, the reporting has/is been based on normalized numbers, so was decided to retain this form of reporting unless operators request for reporting metrics based off of real totals
+  #print "(Real) Total goodZ jobs", goodjobsZ, "(" percent(goodjobsZ,ended_jobs) "%)", "utilization", int(goodputZ) "(" percent(goodputZ,total_used) "%)";
+  #print "(Real) Total goodNZ jobs", goodjobsNZ, "(" percent(goodjobsNZ,ended_jobs) "%)", "utilization", int(goodputNZ) "(" percent(goodputNZ,total_used) "%)";
+  #print "(Real) Total badSignal jobs", badjobsSignal, "(" percent(badjobsSignal,ended_jobs) "%)", "utilization", int(badputSignal) "(" percent(badputSignal,total_used) "%)";
+  #print "(Real) Total badOther jobs", badjobsOther, "(" percent(badjobsOther,ended_jobs) "%)", "utilization", int(badputOther) "(" percent(badputOther,total_used) "%)";
+  # end of comment block
 
   # printing below normalized numbers for metrics reporting (historically, this form of reporting has been used)
-  print "(Normalized) Total jobs",tj,"utilization",int(total_used/parallelism);
-  print "(Normalized) Total goodZ jobs",tgz, " (" percent(goodjobsZ,ended_jobs) "%)","utilization",int(goodputZ/parallelism) " (" percent(goodputZ,total_used) "%)";
-  print "(Normalized) Total goodNZ jobs",tgnz, " (" percent(goodjobsNZ,ended_jobs) "%)","utilization",int(goodputNZ/parallelism) " (" percent(goodputNZ,total_used) "%)";
-  print "(Normalized) Total badSignal jobs",tbjs, " (" percent(badjobsSignal,ended_jobs) "%)","utilization",int(badputSignal/parallelism) " (" percent(badputSignal,total_used) "%)";
-  print "(Normalized) Total badOther jobs",tbjo, " (" percent(badjobsOther,ended_jobs) "%)","utilization",int(badputOther/parallelism) " (" percent(badputOther,total_used) "%)";
+  print "(Normalized) Total jobs", tj, "utilization", int(total_used/parallelism);
+  print "(Normalized) Total goodZ jobs", tgz, "(" percent(goodjobsZ,ended_jobs) "%)", "utilization", int(goodputZ/parallelism), "(" percent(goodputZ,total_used) "%)";
+  print "(Normalized) Total goodNZ jobs", tgnz, "(" percent(goodjobsNZ,ended_jobs) "%)", "utilization", int(goodputNZ/parallelism), "(" percent(goodputNZ,total_used) "%)";
+  print "(Normalized) Total badSignal jobs", tbjs, "(" percent(badjobsSignal,ended_jobs) "%)", "utilization", int(badputSignal/parallelism), "(" percent(badputSignal,total_used) "%)";
+  print "(Normalized) Total badOther jobs", tbjo, "(" percent(badjobsOther,ended_jobs) "%)", "utilization", int(badputOther/parallelism), "(" percent(badputOther,total_used) "%)";
 }


### PR DESCRIPTION
This PR closes #456 with some changes to the information lines that gets reported right before the summary metric XML section of the glidein standard output log.

Since the factory and frontend operators informed via email that they are typically interested in knowing whether the glideins did run something as opposed to what the actual number of jobs that were run in the glideins, the GWMS team decided to retain the original reporting logic and add improvements to the same. This decision was also driven by keeping changes minimal since the current version of the code generates metrics that are being used in factory monitoring pages and changing the logic behind the reporting of the existing metrics would require a thorough round of code changes with respect to the monitoring parts of the codebase. 

These improvements introduced by this PR directly address the concern raised in the corresponding issue, the summary metric was reporting numbers that are misleading when partitionable slots are used. Improvements include more clear wording of information lines for easy identification of the numbers being reported (now includes real total and normalized totals) and including an extra bit of detail about the parallelism (aka normalization) factor. 

Additionally, it was identified that there may be a point of time in the future where reporting using real numbers (with normalization factor not considered) may be requested/useful. As there was a near-thorough investigation conducted during the investigation of the issue, a block of code has been added to `parse_starterlog.awk` file that caters to reporting of metrics using the real totals only, thereby helping avoid a redundant round of investigation again.