### PR TITLE
Adding new priority for execution of `cvmfs_setup.sh` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
 
-Changes since the last release
+Adds `precvmfs_file_list` priority to `*_file_list` priorities when using on-demand CVMFS setup.
 
 ### New features / functionalities
 
 -   Added support for Ubuntu 24 workers (PR #529)
 
 ### Changed defaults / behaviours
+
+-   Updated download/execution order of `cvmfs_setup.sh` during glidein startup using a new priority `precvmfs_file_list` (PR #528).
 
 ### Deprecated / removed options and commands
 

--- a/creation/lib/cgWConsts.py
+++ b/creation/lib/cgWConsts.py
@@ -9,8 +9,9 @@ import os.path
 from . import cWConsts
 
 # these are in the stage dir, so they need to be renamed if changed
-AFTER_FILE_LISTFILE = "after_%s" % cWConsts.FILE_LISTFILE
-AT_FILE_LISTFILE = "at_%s" % cWConsts.FILE_LISTFILE
+AFTER_FILE_LISTFILE = f"after_{cWConsts.FILE_LISTFILE}"
+AT_FILE_LISTFILE = f"at_{cWConsts.FILE_LISTFILE}"
+PRECVMFS_FILE_LISTFILE = f"precvmfs_{cWConsts.FILE_LISTFILE}"
 
 CONDOR_FILE = "condor_bin_%s.tgz"
 CONDOR_DIR = "condor"
@@ -23,6 +24,8 @@ CVMFSEXEC_DISTRO_FILE = "cvmfsexec_dist_%s.tgz"
 CVMFSEXEC_DIR = "cvmfsexec"
 CVMFSEXEC_ATTR = "CVMFSEXEC_DIR"
 
+# constant defining the priorities of file lists used by the factory/glidein
+FILE_LISTS_PRIORITIES = ("file_list", "precvmfs_file_list", "at_file_list", "after_file_list")
 
 # these are in the submit dir, so they can be changed
 SUBMIT_ATTRS_FILE = "submit_attrs.cfg"

--- a/creation/lib/cgWDictFile.py
+++ b/creation/lib/cgWDictFile.py
@@ -302,6 +302,9 @@ def get_main_dicts(submit_dir, stage_dir):
     main_dicts["gridmap"] = cWDictFile.GridMapDict(
         stage_dir, cWConsts.insert_timestr(cWConsts.GRIDMAP_FILE)
     )  # TODO: versioned but no fname_idx?
+    main_dicts["precvmfs_file_list"] = cWDictFile.FileDictFile(
+        stage_dir, cWConsts.insert_timestr(cgWConsts.PRECVMFS_FILE_LISTFILE), fname_idx=cgWConsts.PRECVMFS_FILE_LISTFILE
+    )
     main_dicts["at_file_list"] = cWDictFile.FileDictFile(
         stage_dir, cWConsts.insert_timestr(cgWConsts.AT_FILE_LISTFILE), fname_idx=cgWConsts.AT_FILE_LISTFILE
     )
@@ -383,9 +386,14 @@ def load_main_dicts(main_dicts):  # update in place
     # print "\ndebug %s dir(main_dicts['description']) = %s" % (__file__, dir(main_dicts['description']))
     # TODO: To remove if upgrade from older versions is not a problem
     try:
+        main_dicts["precvmfs_file_list"].load(fname=main_dicts["description"].vals2["precvmfs_file_list"])
+    except KeyError:
+        # when upgrading from older version the new precvmfs_file_list may not be in the description
+        main_dicts["precvmfs_file_list"].load()
+    try:
         main_dicts["at_file_list"].load(fname=main_dicts["description"].vals2["at_file_list"])
     except KeyError:
-        # when upgrading form older version the new at_file_list may not be in the description
+        # when upgrading from older version the new at_file_list may not be in the description
         main_dicts["at_file_list"].load()
     main_dicts["after_file_list"].load(fname=main_dicts["description"].vals2["after_file_list"])
     load_common_dicts(main_dicts, main_dicts["description"])
@@ -421,7 +429,7 @@ def load_entry_dicts(entry_dicts, entry_name, summary_signature):  # update in p
 def refresh_description(dicts):  # update in place
     description_dict = dicts["description"]
     description_dict.add(dicts["signature"].get_fname(), "signature", allow_overwrite=True)
-    for k in ("file_list", "at_file_list", "after_file_list"):
+    for k in cgWConsts.FILE_LISTS_PRIORITIES:
         if k in dicts:
             description_dict.add(dicts[k].get_fname(), k, allow_overwrite=True)
 
@@ -467,11 +475,11 @@ def refresh_file_list(dicts, is_main, files_set_readonly=True, files_reset_chang
 # dictionaries must have been written to disk before using this
 def refresh_signature(dicts):  # update in place
     signature_dict = dicts["signature"]
-    for k in ("consts", "vars", "untar_cfg", "gridmap", "file_list", "at_file_list", "after_file_list", "description"):
+    for k in ("consts", "vars", "untar_cfg", "gridmap") + cgWConsts.FILE_LISTS_PRIORITIES + ("description",):
         if k in dicts:
             signature_dict.add_from_file(dicts[k].get_filepath(), allow_overwrite=True)
     # add signatures of all the files linked in the lists
-    for k in ("file_list", "at_file_list", "after_file_list"):
+    for k in cgWConsts.FILE_LISTS_PRIORITIES:
         if k in dicts:
             filedict = dicts[k]
             for fname in filedict.get_immutable_files():
@@ -505,11 +513,11 @@ def save_common_dicts(dicts, is_main, set_readonly=True):
     # 'consts','untar_cfg','vars' will be loaded
     refresh_file_list(dicts, is_main)
     # save files in the file lists
-    for k in ("file_list", "at_file_list", "after_file_list"):
+    for k in cgWConsts.FILE_LISTS_PRIORITIES:
         if k in dicts:
             dicts[k].save_files(allow_overwrite=True)
     # then save the lists
-    for k in ("file_list", "at_file_list", "after_file_list"):
+    for k in cgWConsts.FILE_LISTS_PRIORITIES:
         if k in dicts:
             dicts[k].save(set_readonly=set_readonly)
     # calc and save the signatures
@@ -604,7 +612,7 @@ def reuse_common_dicts(dicts, other_dicts, is_main, all_reused):
     # since the file names may have changed, refresh the file_list
     refresh_file_list(dicts, is_main)
     # check file-based dictionaries
-    for k in ("file_list", "at_file_list", "after_file_list"):
+    for k in cgWConsts.FILE_LISTS_PRIORITIES:
         if k in dicts:
             all_reused = reuse_file_dict(dicts, other_dicts, k) and all_reused
 

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -10,6 +10,8 @@ import os
 import os.path
 import shutil
 
+from collections import Counter
+
 from glideinwms.lib import pubCrypto, subprocessSupport
 from glideinwms.lib.util import str2bool
 
@@ -219,6 +221,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             self.dicts["params"].add("GLIDEIN_Factory_Collector", str(factory_monitoring_collector))
         populate_gridmap(self.conf, self.dicts["gridmap"])
 
+        # the following list will be a megalist containing all the scripts; used for duplication check logic subsequently
+        all_scripts = []
         # NOTE that all the files in these _scripts lists are added as executables (i.e. must report with error_gen)
         file_list_scripts = [
             "collector_setup.sh",
@@ -226,8 +230,17 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             "gwms-python",
             cgWConsts.CONDOR_STARTUP_FILE,
         ]
+        # add the above list to the megalist created before
+        all_scripts.extend(file_list_scripts)
+
+        # singularity_setup should be performed after cvmfs_setup; condor_chirp's order does not matter
+        precvmfs_file_list_scripts = ["cvmfs_setup.sh"]
+        all_scripts.extend(precvmfs_file_list_scripts)  # add this list to the megalist
+
         # These are right after the entry, before some VO scripts. The order in the following list is important
         at_file_list_scripts = ["singularity_setup.sh", "condor_chirp", "gconfig.py"]
+        all_scripts.extend(at_file_list_scripts)  # adding the above list to the megalist as before
+
         # The order in the following list is important
         after_file_list_scripts = [
             "check_proxy.sh",
@@ -240,15 +253,14 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             "glidein_sitewms_setup.sh",
             "script_wrapper.sh",
             "smart_partitionable.sh",
-            "cvmfs_setup.sh",
             "cvmfs_umount.sh",
         ]
-        # Only execute scripts once
-        duplicate_scripts = list(set(file_list_scripts).intersection(after_file_list_scripts))
-        duplicate_scripts += list(set(file_list_scripts).intersection(at_file_list_scripts))
-        duplicate_scripts += list(set(at_file_list_scripts).intersection(after_file_list_scripts))
+        all_scripts.extend(after_file_list_scripts)  # adding the above list to the megalist as before
+        # Scripts need to be only executed once, so check for duplicates
+        count_duplicates = Counter(all_scripts)
+        duplicate_scripts = [scr for scr, cnt in count_duplicates.items() if cnt > 1]
         if duplicate_scripts:
-            raise RuntimeError("Duplicates found in the list of files to execute '%s'" % ",".join(duplicate_scripts))
+            raise RuntimeError(f"Duplicates found in the list of files to execute: {', '.join(duplicate_scripts)}")
 
         # Load more system scripts
         for script_name in file_list_scripts:
@@ -416,6 +428,12 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                     )
 
         # add additional system scripts
+        for script_name in precvmfs_file_list_scripts:
+            self.dicts["precvmfs_file_list"].add_from_file(
+                script_name,
+                cWDictFile.FileDictFile.make_val_tuple(cWConsts.insert_timestr(script_name), "exec"),
+                os.path.join(cgWConsts.WEB_BASE_DIR, script_name),
+            )
         for script_name in at_file_list_scripts:
             self.dicts["at_file_list"].add_from_file(
                 script_name,

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -175,7 +175,7 @@ perform_system_check() {
 	unshare -U true &>/dev/null
 	GWMS_IS_UNPRIV_USERNS_ENABLED=$?
 
-	[[ $GWMS_OS_VERSION_MAJOR -ge 9 ]] && dnf list installed fuse3* &>/dev/null || yum list installed fuse &>/dev/null
+	[[ $GWMS_OS_VERSION_MAJOR -ge 9 ]] && dnf list installed fuse3 &>/dev/null || yum list installed fuse &>/dev/null
 	GWMS_IS_FUSE_INSTALLED=$?
 
 	[[ $GWMS_OS_VERSION_MAJOR -ge 9 ]] && fusermount3 -V &>/dev/null || fusermount -V &>/dev/null

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -2007,7 +2007,7 @@ line_read_wrapper() {
     true
 }
 
-for gs_file_id in "main file_list" "client preentry_file_list" "client_group preentry_file_list" "client aftergroup_preentry_file_list" "entry file_list" "main at_file_list" "client file_list" "client_group file_list" "client aftergroup_file_list" "main after_file_list"
+for gs_file_id in "main file_list" "client preentry_file_list" "client_group preentry_file_list" "client aftergroup_preentry_file_list" "entry file_list" "main precvmfs_file_list" "main at_file_list" "client file_list" "client_group file_list" "client aftergroup_file_list" "main after_file_list"
 do
     gs_id="$(echo "${gs_file_id}" |awk '{print $1}')"
 


### PR DESCRIPTION
We received the following via email from Marco Mascheroni (CMS Factory Ops) about testing of `cvmfsexec` on an ARM site:
```
Hi Marco/Narmratha,
I'm currently testing cvmfsexec on an ARM site together with Saqib. This is the first time we’re using the tool in SI.
We’re encountering an issue related to a validation script defined in the frontend:
<file absfname="/data/gwms-frontend/repos/cms-validation-scripts/test_squid/test_squid.sh"
      after_entry="True" after_group="True" const="True" executable="True" period="0"
      prefix="GLIDEIN_PS_" untar="False" wrapper="False">
    <untar_options cond_attr="TRUE"/>
</file>
 
This script requires CVMFS to be available in order to run, but it appears that cvmfs_setup.sh is being executed after the validation script, causing problems.
Is there a way to ensure that cvmfs_setup.sh runs before the frontend validation script? Given the current attributes (after_entry="True" and after_group="True"), I’m not sure where best to hook it in.
Thanks!
Best regards,
Marco Mascheroni
```


Rather than waiting for the development version (3.11.2) to be released with the change concerning the priority of `cvmfs_setup.sh` download and execution, the GlideinWMS team decided to release a set of minimal changes pertaining to the addition of a new priority setting `precvmfs_file_list` for `cvmfs_setup.sh`. This was decided upon to ensure that `cvmfs_setup.sh` executes before the other custom scripts that may depend on CVMFS being available (Marco Mascheroni's use case being an example). 

This PR also includes a minor update regarding the fuse requirement for operating systems whose major version is greater than or equal to 9. The current version of the code resulted in a false positive outcome upon checking for fuse3 requirement on EL9. If `fuse3-libs` is found to be installed but not `fuse3`, the result from the corresponding check would be that fuse is installed, when in actual it is not available.