### PR TITLE
Enhance RSAPrivateKey decryption to support legacy padding schemes

### DIFF
--- a/lib/generators/generators.py
+++ b/lib/generators/generators.py
@@ -321,7 +321,7 @@ def load_generator(module: str, context: Optional[Mapping] = None) -> Generator:
 
 
 def export_generator(generator: Type[Generator]):
-    """Make a Generator object available to the genearators module"""
+    """Make a Generator object available to the generators module"""
 
     if not issubclass(generator, Generator):
         raise TypeError("generator must be a Generator object")

--- a/plugins/LegacyGenerator.py
+++ b/plugins/LegacyGenerator.py
@@ -3,8 +3,7 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""This module contains the LegacyGenerator class.
-"""
+"""This module contains the LegacyGenerator class."""
 
 from typing import Any
 


### PR DESCRIPTION
This pull request introduces enhancements to the RSA decryption methods to enhance compatibility with legacy padding schemes. It addresses an issue that caused 3.11 Factories to fail to decrypt requests from 3.10 frontends. Additionally, the decoding logic in the `decrypt_base64` and `decrypt_hex` methods has been corrected. The most significant changes are presented below:

### Enhancements to decryption logic:
* Updated the `decrypt` method to attempt decryption using multiple padding schemes (`SHA256` and `SHA1`) for better compatibility. If one padding scheme fails, it falls back to the next.

### Fixes to decoding logic:
* Modified the `decrypt_base64` method to correctly decode the input data from base64 before decrypting it.
* Modified the `decrypt_hex` method to correctly decode the input data from hex before decrypting it.