### PR TITLE
Retrieve and use CVMFS_MOUNT_DIR from glidein_config if not in the env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changes since the last release
 
 ### Bug Fixes
 
+-   Retrieve and use CVMFS_MOUNT_DIR from glidein_config if not in the environment (PR #552)
+
 ### Testing / Development
 
 ### Known Issues

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2618,7 +2618,7 @@ MAX_STARTD_LOG          I       10000000        +                               
                 GWMS_SINGULARITY_BIND_CVMFS is true) and some GPUs libraries (if
                 GPUs are detected). If CVMFS is mounted in a different place,
                 CVMFS_MOUNT_DIR will be set in the environment and the Glidein
-                will replace /cvms with the correct mount point
+                will replace /cvmfs with the correct mount point
                 ($CVMFS_MOUNT_DIR:/cvmfs), so that inside Singularity CVMFS will
                 always be available in /cvmfs, even if outside that is not
                 possible. The combined list is validated removing paths not

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -1065,7 +1065,7 @@ SPDX-License-Identifier: Apache-2.0
                     </blockquote>
                     If CVMFS is mounted in a different place CVMFS_MOUNT_DIR
                     will be set in the environment and the Glidein will replace
-                    /cvms with the correct mount point. If users use this
+                    /cvmfs with the correct mount point. If users use this
                     feature and if the Singularity image is not in the path
                     indicated in the CVMFS repository, the user job will error
                     out.
@@ -2373,10 +2373,10 @@ def get_credential(log: logger, group: str, entry: dict, trust_domain: str):
             </ul>
             NOTE: For all the image path specified with the methods above, if
             CVMFS is mounted in a different place CVMFS_MOUNT_DIR will be set in
-            the environment and the Glidein will replace /cvms/ at the beginning
-            of the path with the correct mount point. I.e. operators and users
-            do not have to worry about CVMFS being mounted on an unusual mount
-            point.
+            the environment and the Glidein will replace /cvmfs/ at the
+            beginning of the path with the correct mount point. I.e. operators
+            and users do not have to worry about CVMFS being mounted on an
+            unusual mount point.
           </li>
         </ol>
 


### PR DESCRIPTION
Added the `cvms_set_mount_dir` function to retrieve CVMFS_MOUNT_DIR from glidein_config if not already in the environment.
Added invocation of `cvms_set_mount_dir` when CVMFS_MOUNT_DIR is needed.

This is needed when CVMFS is mounted via cvmfsexec. The custom scripts mounting CVMFS set CVMFS_MOUNT_DIR in their environment (not available in the glidein_startup -parent- and other scripts -siblings-) and in glidein_config from where it needs to be retrieved.

This fixes #551 