### PR TITLE
Check OSG_BatchSystem and set work_dir="Condor" if it's CONDOR

### DIFF
--- a/unittests/test_OSG_autoconf.py
+++ b/unittests/test_OSG_autoconf.py
@@ -64,9 +64,26 @@ class TestOSGAutoconf(unittest.TestCase):
                 }
             }
         }
+        self.res = {
+            "gridtype": "condor",
+            "attrs": {
+                "GLIDEIN_Site": {"value": "AMNH"},
+                "GLIDEIN_ResourceName": {
+                    "value": {
+                        "Name": "hosted-ce36.opensciencegrid.org",
+                        "OSG_Resource": "AMNH-HEL",
+                        "OSG_ResourceGroup": "AMNH",
+                        "OSG_ResourceCatalog": [{"Memory": 65536, "MaxWallTime": 2880, "CPUs": 8}],
+                    }
+                },
+            },
+            "submit_attrs": {},
+        }
 
     def test_get_pilot(self):
-        print(get_pilot("AMNH", self.input_info, self.out_data))
+        self.assertEqual(get_pilot("AMNH", self.input_info, "SLURM", self.out_data), self.res)
+        self.res["work_dir"] = "Condor"
+        self.assertEqual(get_pilot("AMNH", self.input_info, "CONDOR", self.out_data), self.res)
 
     def test_get_information_internal(self):
         # The infotmation as retrieved from the OSG_Collector


### PR DESCRIPTION
This commit updates the pilot generation logic to check the OSG_BatchSystem attribute from the OSG collector. If the batch system is set to "CONDOR", the resulting pilot entry will have work_dir set to "Condor".

Fixes Issue #557