### PR TITLE
Fix issues identified during the 3_11_1 hackathon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## v3.11.2 \[2025-08-06\]
+
+Release to address the issues found during the GlideinWMS 3.11.1 hackathon.
+
+### New features / functionalities
+
+### Changed defaults / behaviours
+
+-   When using credential generators, glideclient classads are now identified by the generated credential ID.
+
+### Deprecated / removed options and commands
+
+### Security Related Fixes
+
+### Bug Fixes
+
+-   Fixed monitoring that had broken due to inconsistent credential IDs used in Glideins.
+-   Fixed an issue that would cause the Credentials library to use the wrong timezones when validating X509 certificates.
+-   Fixed a bug that would cause CachedGenerator to fail if `cache_dir` wasn't provided in the context.
+
+### Testing / Development
+
+### Known Issues
+
 ## v3.11.1 \[2025-07-21\]
 
 Improvement and hardening of the refactored credentials.

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -1144,7 +1144,7 @@ class MultiAdvertiseWork:
         auth_set = factory_auth.match(self.descript_obj.credentials_plugin.security_bundle)
         if not auth_set:
             logSupport.log.debug(
-                f"The available credentials do not match the requirements of factory pool {factory_pool}. Not advertising request. "
+                f'The available credentials do not match the requirements of factory entry "{params_obj.request_name}". Not advertising request. '
                 f"Available credentials: {str(self.descript_obj.credentials_plugin.security_bundle)} "
                 f"Required credentials: {str(factory_auth)}"
             )
@@ -1184,15 +1184,14 @@ class MultiAdvertiseWork:
         self.descript_obj.credentials_plugin.assign_work(self.request_credentials, params_obj, auth_set)
 
         for request_cred in self.request_credentials:
+            cred = self.descript_obj.credentials_plugin.get_credential(request_cred.credential.id, snapshot=entry_name)
             if not request_cred.advertise:
-                logSupport.log.debug(
-                    f"Skipping credential with 'advertise' set to False. ({request_cred.credential.id})"
-                )
+                logSupport.log.debug(f"Skipping credential with 'advertise' set to False. ({cred.id})")
                 continue  # We already determined it cannot be used
-            if (request_cred.credential.trust_domain != factory_trust) and (factory_trust != "Any"):
+            if (cred.trust_domain != factory_trust) and (factory_trust != "Any"):
                 logSupport.log.warning(
-                    f"Skipping credential with trust_domain {request_cred.credential.trust_domain}. "
-                    f"Factory requires {factory_trust}. ({request_cred.credential.id})"
+                    f"Skipping credential with trust_domain {cred.trust_domain}. "
+                    f"Factory requires {factory_trust}. ({cred.id})"
                 )
                 continue  # Skip credentials that don't match the trust domain
             # NOTE: Up to GWMS 3.10.x glideclient was always advertised. This is a new behavior.
@@ -1200,26 +1199,22 @@ class MultiAdvertiseWork:
             if (
                 request_cred.req_idle == 0
                 and request_cred.req_max_run == 0
-                and params_obj.glidein_monitors_per_cred[request_cred.credential.id]["GlideinsTotal"] == 0
+                and params_obj.glidein_monitors_per_cred[cred.id]["GlideinsTotal"] == 0
             ):
-                logSupport.log.debug(
-                    f"Skipping credential with no work assigned or active glideins. ({request_cred.credential.id})"
-                )
+                logSupport.log.debug(f"Skipping credential with no work assigned or active glideins. ({cred.id})")
                 continue  # Skip credentials with no work assigned or active glideins
 
-            classad_name = f"{request_cred.credential.id}_{params_obj.request_name}@{self.descript_obj.my_name}"
+            classad_name = f"{cred.id}_{params_obj.request_name}@{self.descript_obj.my_name}"
 
             glidein_params_to_encrypt = {}
             if params_obj.glidein_params_to_encrypt:
                 glidein_params_to_encrypt = copy.deepcopy(params_obj.glidein_params_to_encrypt)
 
             # Add request specific parameters
-            glidein_params_to_encrypt["RequestCredentials"] = pickle.dumps(
-                [self.descript_obj.credentials_plugin.get_credential(request_cred.credential.id, snapshot=entry_name)]
-            )
+            glidein_params_to_encrypt["RequestCredentials"] = pickle.dumps([cred])
 
             # Convert the security class to a string so the Factory can interpret the value correctly
-            glidein_params_to_encrypt["SecurityClass"] = str(request_cred.credential.security_class)
+            glidein_params_to_encrypt["SecurityClass"] = str(cred.security_class)
             if params_obj.security_name is not None:
                 glidein_params_to_encrypt["SecurityName"] = params_obj.security_name
 
@@ -1240,7 +1235,7 @@ class MultiAdvertiseWork:
 
             # Get the glidein monitors for this credential
             glidein_monitors_this_cred = params_obj.glidein_monitors_per_cred.get(
-                request_cred.credential.id, {}  # type: ignore[attr-defined]
+                cred.id, {}  # type: ignore[attr-defined]
             )
 
             # Update Sequence number information
@@ -1310,7 +1305,7 @@ class MultiAdvertiseWork:
             cred_filename_arr.append(fname)
 
             logSupport.log.debug(
-                f"Advertising credential {request_cred.credential.path} "  # type: ignore[attr-defined]
+                f"Advertising credential {cred.path} "  # type: ignore[attr-defined]
                 f"with ({request_cred.req_idle} idle, {request_cred.req_max_run} max run) for request {params_obj.request_name}"
             )
 

--- a/frontend/glideinFrontendLib.py
+++ b/frontend/glideinFrontendLib.py
@@ -1253,6 +1253,30 @@ def getCondorStatusSchedds(collector_names, constraint=None, format_list=None, w
     )
 
 
+def getClientCondorStatusCredIds(status_dict):
+    """Return a set of credential IDs from the condorStatus dictionary
+
+    Use the output of getCondorStatus
+
+    Args:
+        status_dict (dict): output of getCondorStatus
+
+    Returns:
+        set: set of credential IDs found in the condorStatus
+    """
+
+    out = set()
+    for _, collector_status in status_dict.items():
+        sq = condorMonitor.SubQuery(
+            collector_status,
+            lambda el: ("GLIDEIN_CredentialIdentifier" in el),
+        )
+        sq.load()
+        for el in sq.fetchStored().values():
+            out.add(el["GLIDEIN_CredentialIdentifier"])
+    return out
+
+
 ############################################################
 #
 # I N T E R N A L - Do not use

--- a/lib/generators/generators.py
+++ b/lib/generators/generators.py
@@ -149,7 +149,8 @@ class CachedGenerator(Generator[T]):
                 "cache_file": (
                     str,
                     os.path.join(
-                        self.context["cache_dir"], f"{self.__class__.__name__}_{self.instance_id}.{file_type}"
+                        self.context.get("cache_dir", CACHE_DIR),
+                        f"{self.__class__.__name__}_{self.instance_id}.{file_type}",
                     ),
                 ),
                 "cache_discriminator": (str, "snapshot"),


### PR DESCRIPTION
This pull request addresses the issues found during the GlideinWMS 3.11.1 hackathon.

Main changes:
- When using credential generators, glideclient classads are now identified by the generated credential ID.
- Fixed monitoring that had broken due to inconsistent credential IDs used in Glideins.
- Fixed an issue that would cause the Credentials library to use the wrong timezones when validating X509 certificates.
- Fixed a bug that would cause CachedGenerator to fail if `cache_dir` wasn't provided in the context.