### PR TITLE
Hardening the httpd server by disabling version headers and trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
+-   Added httpd configuration to enhance security by disabling version headers and trace (PR #578)
+
 ### Deprecated / removed options and commands
 
 ### Security Related Fixes
@@ -62,7 +64,7 @@ Adds `precvmfs_file_list` priority to `*_file_list` priorities when using on-dem
 -   Added support for Ubuntu 24 workers (PR #529)
 -   Add keyword ALL to query all schedulers known to the collector without listing them explicitly (Issue #510, PR #532)
 -   Add keyword usertrace to the GLIDEIN_DEBUG_OPTIONS custom variable to enable shell tracing in user jobs and wrapper (PR #540)
--   Glideins can start containers with Busybox and no Bash, e.g Alpine Linux. The Glidein itself still requires Bash (Issue #538, PR #540)
+-   Glideins can start containers with Busybox and no Bash, e.g. Alpine Linux. The Glidein itself still requires Bash (Issue #538, PR #540)
 
 ### Changed defaults / behaviours
 
@@ -153,7 +155,7 @@ Check the changed defaults, including SINGULARITY_IMAGE_REQUIRED, APPTAINER_TEST
     The image must be provided by the job or a future custom script in order not to fail. (PR #482)
 -   APPTAINER_TEST_IMAGE can be set to an always available Singularity/Apptainer image to use for testing.
     Defaults to oras://ghcr.io/apptainer/alpine:latest (PR #482)
--   Monitoring pages are now redirecting to https if available, i.e. mod_ssl is installed and mod_ssl.conf is present. This behavior was present in the past but had been lost and now it has been reinstated. (PR #492, PR #502)
+-   Monitoring pages are now redirecting to https if available, i.e. mod_ssl is installed and mod_ssl.conf is present. This behavior was present in the past but had been lost, and now it has been reinstated. (PR #492, PR #502)
 -   The default Frontend tokens key is now variable, $HOME/passwords.d/UPPERCASE_USERNAME. There is no actual change since this is /var/lib/gwms-frontend/passwords.d/FRONTEND for normal RPM installations. (PR #504)
 
 ### Deprecated / removed options and commands
@@ -420,7 +422,7 @@ This release provides full functionality in EL9 and Python 3.9. Changes since v3
 ### Known Issues
 
 -   When generating cvmfsexec distribution for EL9 machine type on an EL7 machine, the factory reconfig and/or upgrade fails as a result of an error in `create_cvmfsexec_distros.sh`. This is possibly due to the tools for EL7 being unable to handle EL9 files (as per Dave Dykstra). Please exercise caution if using `rhel9-x86_64` in the `mtypes` list for the `cvmfsexec_distro` tag in factory configuration.
-    -   Our workaround is to remove the EL9 machine type from the default list of machine types supported by the custom distros creation script. Add it back if you are running on an EL9 system and want an EL9 cvmfsexec distrinution. (PR #312)
+    -   Our workaround is to remove the EL9 machine type from the default list of machine types supported by the custom distros creation script. Add it back if you are running on an EL9 system and want an EL9 cvmfsexec distribution. (PR #312)
 
 ## v3.10.2 \[2023-5-10\]
 

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -156,6 +156,7 @@ This subpackage includes the Glidein components for the Frontend.
 Summary: The Apache http configuration for GlideinWMS Frontend.
 Requires: httpd
 Requires: mod_ssl
+Requires: glideinwms-httpd = %{version}-%{release}
 %description vofrontend-httpd
 This subpackage includes the minimal configuration to start Apache to
 serve the Frontend files to the pilot and the monitoring pages.
@@ -181,6 +182,13 @@ Requires: glideinwms-glidecondor-tools = %{version}-%{release}
 %description userschedd
 This is a package for a glideinwms submit host.
 
+
+%package httpd
+Summary: Common Apache http configuration for GlideinWMS.
+Requires: httpd
+%description httpd
+This subpackage includes the Apache configuration cecommended to
+harden the GlideinWMS Web servers for safer production use.
 
 %package libs
 Summary: The GlideinWMS common libraries.
@@ -286,6 +294,7 @@ Factory. Created to separate out the httpd server.
 Summary: The Apache httpd configuration for the GlideinWMS Factory
 Requires: httpd
 Requires: mod_ssl
+Requires: glideinwms-httpd = %{version}-%{release}
 %description factory-httpd
 This subpackage includes the minimal configuration to start Apache to
 serve the Factory files to the pilot and the monitoring pages.
@@ -308,6 +317,7 @@ Requires: mod_ssl
 Requires: php
 Requires: php-fpm
 Requires: composer
+Requires: glideinwms-httpd = %{version}-%{release}
 %description logserver
 This subpackage includes an example of the files and Apache configuration
 to implement a simple server to receive Glidein logs.
@@ -611,6 +621,7 @@ install -m 0644 etc/checksum.factory $RPM_BUILD_ROOT%{factory_dir}/checksum.fact
 
 # Install web area conf
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d
+install -m 0644 install/config/gwms-hardening.conf.httpd $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/gwms-hardening.conf
 install -m 0644 install/config/gwms-frontend.conf.httpd $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/gwms-frontend.conf
 install -m 0644 install/config/gwms-factory.conf.httpd $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/gwms-factory.conf
 install -m 0644 install/config/gwms-logserver.conf.httpd $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/gwms-logserver.conf
@@ -680,6 +691,10 @@ fi
 #  openssl rand -base64 64 | /usr/sbin/condor_store_cred -u "frontend@${fqdn_hostname}" -f "/etc/condor/passwords.d/FRONTEND" add > /dev/null 2>&1
 #  /bin/cp /etc/condor/passwords.d/FRONTEND /var/lib/gwms-frontend/passwords.d/FRONTEND
 #  chown frontend.frontend /var/lib/gwms-frontend/passwords.d/FRONTEND
+
+%post httpd
+# Protecting from failure in case it is not running/installed
+/sbin/service httpd reload > /dev/null 2>&1 || true
 
 %post vofrontend-httpd
 # Protecting from failure in case it is not running/installed
@@ -782,6 +797,10 @@ if [ "$1" = "0" ]; then
     rm -f %{factory_dir}/monitor
 fi
 
+
+%postun httpd
+# Protecting from failure in case it is not running/installed
+/sbin/service httpd reload > /dev/null 2>&1 || true
 
 %postun vofrontend-httpd
 # Protecting from failure in case it is not running/installed
@@ -1048,6 +1067,9 @@ rm -rf $RPM_BUILD_ROOT
 %{web_dir}/monitor
 %{web_dir}/stage
 %{web_base}/factoryRRDBrowse.html
+
+%files httpd
+%config(noreplace) %{_sysconfdir}/httpd/conf.d/gwms-hardening.conf
 
 %files factory-httpd
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/gwms-factory.conf

--- a/install/config/gwms-hardening.conf.httpd
+++ b/install/config/gwms-hardening.conf.httpd
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Some hardening configuration recommended by Fermilab and Cloudflare
+# https://cloudinfrastructureservices.co.uk/apache-web-server-security-and-hardening-best-practices-checklist/
+# Remove version from headers not to expose vulnerabilities
+ServerTokens Prod
+ServerSignature Off
+# Disable tracing
+TraceEnable Off


### PR DESCRIPTION
Hardening the httpd server by disabling version headers and trace
This is recommended for production servers and required by Fermilab