### PR TITLE
Fixed incorrect glog_get_logfile_path_relative call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes since the last release
 
 ### Bug Fixes
 
+-   Fixed incorrect glog_get_logfile_path_relative call in condor_startup.sh (PR #579)
+-   Fixed Frontend reconfiguration failure when using "ALL" schedd (Issue #575, PR #580)
+
 ### Testing / Development
 
 ### Known Issues

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -1283,25 +1283,26 @@ slotlogs=$(ls -1 ${main_starter_log}.slot* 2>/dev/null)
 for slotlog in $slotlogs
 do
     slotname=$(echo $slotlog | awk -F"${main_starter_log}." '{print $2}')
-    cond_print_log StarterLog.${slotname} $slotlog
+    cond_print_log "StarterLog.${slotname}" "$slotlog"
 done
 
 if [[ "$use_multi_monitor" -ne 1 ]]; then
     if [[ "$GLIDEIN_Monitoring_Enabled" == "True" ]]; then
         cond_print_log MasterLog.monitor monitor/log/MasterLog
         cond_print_log StartdLog.monitor monitor/log/StartdLog
-        cond_print_log StarterLog.monitor ${monitor_starter_log}
+        cond_print_log StarterLog.monitor "${monitor_starter_log}"
     fi
 else
-    cond_print_log StarterLog.monitor ${monitor_starter_log}
+    cond_print_log StarterLog.monitor "${monitor_starter_log}"
 fi
 cond_print_log StartdHistoryLog log/StartdHistoryLog
 
 
 append_glidein_log=true   # TODO: this should be a configurable option
-logfile_path=$(get_logfile_path_relative)
 if [[ $append_glidein_log = true ]]; then
-    cond_print_log "GlideinLog" "${logfile_path}"
+    if logfile_path=$(glog_get_logfile_path_relative); then
+        cond_print_log "GlideinLog" "${logfile_path}"
+    fi
 fi
 
 ## kill the master (which will kill the startd)

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -270,11 +270,11 @@ _glog_json_escape() {
 }
 
 
-_glog_get_logfile_path_relative() {
+glog_get_logfile_path_relative() {
     # Get the relative path of the logfile w.r.t. the work dir
 
     if [ "${log_ready}" != 1 ]; then
-        warn_ready "get_logfile_path_relative: missing logging configuration in (${0}); perhaps forgot to call log_setup before?"
+        warn_ready "glog_get_logfile_path_relative: missing logging configuration in (${0}); perhaps forgot to call glog_setup before?"
         return 1
     fi
     echo "${logdir}/${log_logfile}"


### PR DESCRIPTION
Fixed incorrect `glog_get_logfile_path_relative` call in `condor_startup.sh` and added function to glog public API

Added also some quotes on file names and parameters in condor_startup.sh