### PR TITLE
Fix frontend reconfiguration failure when using "ALL" schedd (issue #575)

### DIFF
--- a/creation/lib/cvWParamDict.py
+++ b/creation/lib/cvWParamDict.py
@@ -1005,8 +1005,8 @@ def validate_schedds(main_list, group_list):
     Raises:
         RuntimeError: If 'ALL' is used incorrectly (e.g. mixed with other schedds or with a non-empty group list).
     """
-    main_items = main_list.split(",")
-    group_items = group_list.split(",")
+    main_items = main_list.split(",") if main_list else []
+    group_items = group_list.split(",") if group_list else []
 
     if "ALL" in main_items or "ALL" in group_items:
         if main_items != ["ALL"] or group_items:


### PR DESCRIPTION
**Problem**
Frontend reconfiguration was failing when using `<scheddDN="ALL" fullname="ALL">`, even though the global schedd configuration was `'ALL'` and the group configuration appeared empty. The failure stemmed from a subtle Python behavior:

* `''.split(",")` returns `['']` — a list with one empty string.`
*  `''.split()` returns `[]` — an actual empty list.`

This caused the group configuration to be interpreted as non-empty, violating the requirement that 'ALL' must be used exclusively and only when group schedds are truly empty.

**Fix**
Updated the parsing logic to explicitly handle empty strings:

```
main_items = main_list.split(",") if main_list else []
group_items = group_list.split(",") if group_list else []
```