### PR TITLE
Fix IDENTITY_CREDENTIALS v3_10_x environment setup

### DIFF
--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -2171,6 +2171,8 @@ def get_submit_environment(
             # TODO: this ends up transferring an empty file called 'null' in the Glidein start dir. Find a better way
             exe_env.append("IDTOKENS_FILE=/dev/null")
 
+        exe_env.append(f"IDENTITY_CREDENTIALS={','.join(id_cred_paths)}")
+
         # The parameter list to be added to the arguments for glidein_startup.sh
         params_str = ""
         # if client_web has been provided, get the arguments and add them to the string
@@ -2409,8 +2411,6 @@ email_logs = False
                 exe_env.append("GLIDEIN_PROJECT_ID=%s" % submit_credentials.identity_credentials["ProjectId"])
 
             exe_env.append("GLIDEIN_RSL=%s" % glidein_rsl)
-
-            exe_env.append(f"IDENTITY_CREDENTIALS={','.join(id_cred_paths)}")
 
         return exe_env
     except Exception as e:


### PR DESCRIPTION
This pull request makes a small adjustment to how the `IDENTITY_CREDENTIALS` environment variable is set in the `get_submit_environment` function. The change moves the line that sets `IDENTITY_CREDENTIALS` earlier in the function, ensuring it is included in the environment setup before additional parameters are processed. No other significant changes are present.

This PR fixes #581