### PR TITLE
add staticextra resource type to condor_startup.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bug fix release. Mostly cvmfs and condor job wrapper related.
 
 ### New features / functionalities
 
+- Added new staticextra resource type – behaves like static (creates one dedicated slot per instance with a virtual CPU each), but instead of subtracting memory from the main partitionable slot, it adds memory to it (Issue #590)
 -   create_cvmfsexec_distros.sh updated adding EL9 to platforms and improved command syntax (PR #582)
 
 ### Changed defaults / behaviours

--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -826,8 +826,10 @@ EOF
 NEW_RESOURCES_LIST =
 EXTRA_SLOTS_NUM = 0
 EXTRA_CPUS_NUM = 0
+EXTRA_MEMORY_MB = 0
 EXTRA_SLOTS_START = True
 NUM_CPUS = \$(GLIDEIN_CPUS)+\$(EXTRA_SLOTS_NUM)+\$(EXTRA_CPUS_NUM)
+MEMORY = \$(GLIDEIN_MaxMemMBs)+\$(EXTRA_MEMORY_MB)
 
 # Slot 1 definition done before (fixed/partitionable)
 #SLOT_TYPE_1_PARTITIONABLE = FALSE
@@ -917,8 +919,10 @@ EOF
                     # Decided not to add type "mainextra" with resources added to main slot and CPUs incremented
                     # It can be obtained with more control by setting GLIDEIN_CPUS
                 else
-                    if [[ "$res_num" -eq 1 || "$res_opt" == "static" ]]; then
-                        res_opt=static
+                    if [[ "$res_num" -eq 1 || "$res_opt" == "static" || "$res_opt" == "staticextra" ]]; then
+                        if [[ "$res_opt" == "partitionable" ]]; then
+                            res_opt=static
+                        fi
                         res_ram=$(unit_division "${res_ram}" ${res_num})
                         if [[ -n "$res_disk" ]]; then
                             res_disk=$(unit_division "${res_disk}" ${res_num})
@@ -945,6 +949,9 @@ SLOT_TYPE_${slott_ctr}_PARTITIONABLE = TRUE
 NUM_SLOTS_TYPE_${slott_ctr} = 1
 EOF
                     else
+                        if [[ "$res_opt" == "staticextra" ]]; then
+                            echo "EXTRA_MEMORY_MB = \$(EXTRA_MEMORY_MB)+${res_ram}" >> "$CONDOR_CONFIG"
+                        fi
                         cat >> "$CONDOR_CONFIG" <<EOF
 SLOT_TYPE_${slott_ctr} = cpus=1, ${res_name}=1, ram=${res_ram}${res_disk_specification}
 SLOT_TYPE_${slott_ctr}_PARTITIONABLE = FALSE

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -586,7 +586,16 @@ MAX_STARTD_LOG          I       10000000        +                               
                 </li>
                 <li>
                   <b>static</b> - the resource has many dedicated slots (one per
-                  instance) with a virtual CPU each
+                  instance) with a virtual CPU each. Memory is taken from the
+                  main partitionable slot.
+                </li>
+                <li>
+                  <b>staticextra</b> - like <tt>static</tt>, but memory is
+                  <i>added</i> to the main partitionable slot instead of
+                  subtracted from it. Useful when you want dedicated static
+                  slots that also increase the overall memory available to the
+                  glidein. Memory defined in multiple <b>staticextra</b> slots
+                  will cumulate.
                 </li>
               </ul>
               <p>
@@ -605,8 +614,9 @@ MAX_STARTD_LOG          I       10000000        +                               
                 otherwise the startd may fail due to impossible configuration.
                 When adding resources to the main slots, regular jobs (not using
                 the resource) may use all memory and CPUs (including the virtual
-                ones). Only separate slots (type is <tt>partitionable</tt> or
-                <tt>static</tt>) reserve CPUs and memory.
+                ones). Only separate slots (type is <tt>partitionable</tt>,
+                <tt>static</tt>, or <tt>staticextra</tt>) reserve CPUs and
+                memory.
                 <!--,
         e.g. when you add 3 units of a resource to a node with 8 CPUs divided statically in 8 main slots, the first 3 of them will have also your resource.
         -->
@@ -648,6 +658,11 @@ MAX_STARTD_LOG          I       10000000        +                               
                   partitioned 2 ioslot resources with 100MB memory each.
                 </li>
                 <li>
+                  <b>value="ioslot,2,200,staticextra"</b> creates statically
+                  partitioned 2 ioslot resources with 100MB memory each, and
+                  this memory is added to the main slot instead of subtracted.
+                </li>
+                <li>
                   <b>value="ioslot"</b> creates 1 ioslot resource with 128MB
                 </li>
                 <li>
@@ -673,7 +688,7 @@ MAX_STARTD_LOG          I       10000000        +                               
                 special attributes about the GPUs. If no number is specified and
                 the auto-discovery fails 0 GPUs are assumed. Since you don't
                 know the number of GPUs that will be added to the main slot, the
-                slot_layout must be partitionable. We do recommend to lec
+                slot_layout must be partitionable. We do recommend to let
                 HTCondor discover the number of GPUs by specifying no number. If
                 you specify a number and is different from what HTCondor
                 detects, there may be problems if you are using the HTCondor


### PR DESCRIPTION
Fixes #590

Introduce a new resource type `staticextra`, similar to `static`, that creates one dedicated slot per instance. Unlike `static`, the memory is not subtracted from the main partitionable slot but instead added to it.

Implementation details:

* Added `EXTRA_MEMORY_MB` knob and updated `MEMORY` expression.
* When `staticextra` is configured, memory for the slot is accumulated into `EXTRA_MEMORY_MB`.
* Keeps CPU handling unchanged (one vCPU per slot).

This allows deployments to dedicate resources with extra memory while preserving the full main slot capacity.