### PR TITLE
Added a warning when user job wrapper scripts requires bash or contain exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Added support for HTCondor v2 Python bindings and other small features and fixes
 -   Recognize EL/CentOS 10 worker nodes to select the correct HTCondor tarball (PR #600)
 -   Factory monitoring now showing Client Requested Idle Glideins; only keeping track of Factory adjusted Idle (PR# #606, Issue #520)
 -   Added support for HTCondor Python bindings v2. If available, v1 is still preferred (PR #608)
+-   Added a reconfig/upgrade warning when user job wrapper scripts require more than sh or contain an exec statement (Issue #584, PR #610)
 
 ### Changed defaults / behaviours
 

--- a/creation/lib/cvWParamDict.py
+++ b/creation/lib/cvWParamDict.py
@@ -646,12 +646,14 @@ class frontendGroupDicts(cvWDictFile.frontendGroupDicts):
         )
 
     def reuse(self, other):
-        """
-        Reuse as much of the other as possible
-        other must be of the same class
+        """Reuse as much of the `other` as possible `other` must be of the same class
 
-        @type other: frontendGroupDicts
-        @param other: Object to reuse
+        Args:
+            other (frontendGroupDicts): Object to reuse
+
+        Returns:
+            frontendGroupDicts: Reused object
+
         """
         if self.monitor_dir != other.monitor_dir:
             print(


### PR DESCRIPTION
Added a reconfig/upgrade warning when user job wrapper scripts require more than sh (bash is used when possible but not guaranteed, other shells are not supported) or contain an exec statement.
Wrapper scripts are supposed to be snippets that are concatenated one after the other. The glidein takes care of adding the shebang at the beginning and exec at the end.