### PR TITLE
Credential context improvement

### DIFF
--- a/lib/credentials/dynamic.py
+++ b/lib/credentials/dynamic.py
@@ -86,6 +86,15 @@ class DynamicCredential(Credential[Generator]):
 
     @staticmethod
     def decode(string: Union[str, bytes], context: Optional[Mapping] = None) -> Generator:
+        """Load the credential generator module and return it.
+
+        Args:
+            string: Generator module name or path. Can be in bytes.
+            context: Context for the generator.
+
+        Returns:
+            Generator: contextualized generator object. This is a generator instance based on the context.
+        """
         if isinstance(string, bytes):
             string = string.decode()
         return load_generator(string, context)
@@ -134,7 +143,7 @@ class DynamicCredential(Credential[Generator]):
         continue_if_no_path=False,
     ) -> None:
         if not self._generated_credential:
-            raise CredentialError("Credential not generated.")
+            raise CredentialError("Could not save. Credential not generated.")
         self._generated_credential.save_to_file(
             path=path,
             permissions=permissions,

--- a/lib/credentials/x509.py
+++ b/lib/credentials/x509.py
@@ -75,6 +75,7 @@ class X509Cert(Credential[x509.Certificate]):
             return "Certificate expired."
         if (self.not_after_time - datetime.now(self.not_after_time.tzinfo)).total_seconds() < self.minimum_lifetime:
             return "Certificate lifetime too short."
+        return "Cannot determine specific reason for the invalid certificate."
 
 
 class X509Pair(CredentialPair, X509Cert):

--- a/plugins/SciTokenGenerator.py
+++ b/plugins/SciTokenGenerator.py
@@ -19,10 +19,10 @@ class SciTokenGenerator(CredentialGenerator):
 
     This generator creates a SciToken based on the provided context.
     The context supports the following parameters:
-        - key_file: Path to the private key file
-        - key_id: Identifier for the key
-        - issuer: Issuer of the token
-        - scope: Scope of the token
+        - key_file: Path to the private key file to sign the token (mandatory)
+        - key_id: Identifier for the key, `kid` in the JWT
+        - issuer: Issuer of the token, `iss` in the JWT (mandatory)
+        - scope: Scope of the token, `scope` in the JWT (mandatory)
         - key_pass: Password for the private key (if encrypted)
         - algorithm: Signing algorithm to use (default: RS256)
         - wlcg_ver: WLCG version (default: 1.0)
@@ -30,20 +30,21 @@ class SciTokenGenerator(CredentialGenerator):
         - tkn_dir: Directory to store the generated tokens (default: /var/lib/gwms-frontend/tokens.d)
     """
 
+    CONTEXT_VALIDATION = {
+        "key_file": (str,),
+        "key_id": (str, None),
+        "issuer": (str,),
+        "scope": (str,),
+        "key_pass": (str, ""),
+        "algorithm": (str, "RS256"),
+        "wlcg_ver": (str, "1.0"),
+        "tkn_lifetime": (int, 7200),
+        "tkn_dir": (str, "/var/lib/gwms-frontend/tokens.d"),
+    }
+
     def _setup(self):
-        self.context.validate(
-            {
-                "key_file": (str, None),
-                "key_id": (str, None),
-                "issuer": (str, None),
-                "scope": (str, None),
-                "key_pass": (str, ""),
-                "algorithm": (str, "RS256"),
-                "wlcg_ver": (str, "1.0"),
-                "tkn_lifetime": (int, 7200),
-                "tkn_dir": (str, "/var/lib/gwms-frontend/tokens.d"),
-            }
-        )
+        self.context.validate(self.CONTEXT_VALIDATION)
+
         self.context["type"] = "scitoken"
 
         self.key_pass = self.context["key_pass"].encode() or None


### PR DESCRIPTION
Addressing generators' errors observed by @rynge

Improving the refactored credentials context:
- Context validation errors were masked when they should not have been

The credential loading loop should fail when there is an error in the context, but should still allow failed attempts to load when multiple types are possible