### PR TITLE
Use native systemd (systemctl command) in spec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changes since the last release
 
 ### Known Issues
 
-## v3.10.17 \[2025-11-10\]
+## v3.10.17 \[2025-11-13\]
 
 Added support for HTCondor v2 Python bindings and other small features and fixes.
 
@@ -33,13 +33,14 @@ Added support for HTCondor v2 Python bindings and other small features and fixes
 -   Recognize EL/CentOS 10 worker nodes to select the correct HTCondor tarball (PR #600)
 -   Factory monitoring now showing Client Requested Idle Glideins; only keeping track of Factory adjusted Idle (PR# #606, Issue #520)
 -   Added support for HTCondor Python bindings v2. If available, v1 is still preferred (PR #608)
--   Added a reconfig/upgrade warning when user job wrapper scripts require more than sh or contain an exec statement (Issue #584, PR #610)
+-   Added a reconfig/upgrade warning when user job wrapper scripts require more than sh or contain an exec statement (Issue #584, PR #610, PR #618)
 
 ### Changed defaults / behaviours
 
 -   Prevented memory spikes during factory reconfiguration by copying Condor tarballs instead of loading them into memory (PR #602, Issue #601)
 -   Reuse Condor tarballs across reconfigurations by generating hash-based filenames from file metadata instead of timestamps (PR #604, Issue #603)
 -   Removed ownership and HTCondor checks connected to GWMS 3.5 migration (PR #608)
+-   Removed dependency from SysVInit in spec file and package install. Using native Systemd (PR #617)
 
 ### Deprecated / removed options and commands
 
@@ -47,7 +48,11 @@ Added support for HTCondor v2 Python bindings and other small features and fixes
 
 ### Bug Fixes
 
+-   Remove coral frontend from first page animation (PR #605)
+
 ### Testing / Development
+
+-   Improved Frontend docstrings (PR #574)
 
 ### Known Issues
 

--- a/creation/reconfig_frontend
+++ b/creation/reconfig_frontend
@@ -8,9 +8,6 @@
 import os
 import os.path
 import signal
-
-# import copy
-# import subprocess
 import sys
 import tempfile
 
@@ -135,7 +132,7 @@ if __name__ == "__main__":
 
     if os.geteuid() == 0:
         print2(
-            "NOTE: Executing reconfig_frontend as user 'root' is not allowed. Use the frontend user instead. For rpm based installations, use the 'service gwms-frontend <start|stop|reconfig|...>' command to perform gwms-frontend operations"
+            "NOTE: Executing reconfig_frontend as user 'root' is not allowed. Use the frontend user instead. For rpm based installations, use the 'systemctl <start|stop|reload|...> gwms-frontend' command to perform gwms-frontend operations"
         )
 
     force_name = None

--- a/creation/reconfig_glidein
+++ b/creation/reconfig_glidein
@@ -3,10 +3,7 @@
 # SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Description:
-#  This program updates a glidein factory directory structure
-#  based on a configuration file
-
+"""This program updates a Glidein Factory directory structure based on a configuration file."""
 
 import os
 import os.path
@@ -16,9 +13,6 @@ import sys
 import tarfile
 import tempfile
 
-# from glideinwms.creation.lib import cWConsts
-# from glideinwms.creation.lib import cgWParams
-# from glideinwms.creation.lib import cgWDictFile
 from glideinwms.creation.lib import cgWConsts, cgWCreate, cgWParamDict, factoryXmlConfig, xslt
 from glideinwms.factory import glideFactoryConfig, glideFactoryLib, glideFactoryMonitorAggregator
 from glideinwms.lib import logSupport
@@ -196,7 +190,7 @@ if __name__ == "__main__":
 
     if os.geteuid() == 0:
         print(
-            "NOTE: Executing reconfig_glidein as user 'root' is not allowed. Use the factory user instead. For rpm based installations, use the 'service gwms-factory <start|stop|reconfig|...>' command to perform gwms-factory operations"
+            "NOTE: Executing reconfig_glidein as user 'root' is not allowed. Use the factory user instead. For rpm based installations, use the 'systemctl <start|stop|reload|...> gwms-factory' command to perform gwms-factory operations"
         )
 
     force_name = None

--- a/doc/tags.yaml
+++ b/doc/tags.yaml
@@ -674,3 +674,22 @@ v3_10_16:
   NOTE:
     - Added httpd configuration to enhance security by disabling version headers and trace (PR#578)
     - Since 3.10.15, all job wrapper scripts must be "POSIX" compatible to be able to run on small images with Busybox. Added a relaxation in 3.10.16, setting `set +o posix` when Bash is available (PR#587)
+
+v3_10_17:
+  Date: November 13, 2025
+  Series: Stable
+  Tarball: false
+  Feature:
+    - Recognize EL/CentOS 10 worker nodes to select the correct HTCondor tarball (PR#600)
+    - Factory monitoring now showing Client Requested Idle Glideins; only keeping track of Factory adjusted Idle (PR#606, Issue#520)
+    - Added support for HTCondor Python bindings v2. If available, v1 is still preferred (PR#608)
+    - Added a reconfig/upgrade warning when user job wrapper scripts require more than sh or contain an exec statement (Issue#584, PR#610, PR#618)
+    - Removed dependency from SysVInit in spec file and package install. Using native Systemd (PR#617)
+    - Improved Frontend docstrings (PR#574)
+  Bug fix:
+    - Prevented memory spikes during Factory reconfiguration by copying Condor tarballs instead of loading them into memory (PR#602, Issue#601)
+    - Reuse Condor tarballs across reconfigurations by generating hash-based filenames from file metadata instead of timestamps (PR#604, Issue#603)
+    - Remove coral frontend from first page animation (PR#605)
+    - Removed ownership and HTCondor checks connected to GWMS 3.5 migration (PR#608)
+  NOTE:
+    - Job wrapper scripts must be "POSIX" compatible. Bash is enabled when available but not guaranteed. Also, scripts should not include `exec`. GlideinWMS will print a warning during reconfiguration.


### PR DESCRIPTION
Switched spec file to use native systemd (systemctl) instead of sysVinit compatibility (service).

Previously, GWMS required the SystemV Init compatibility RPMs because of its use of the service command during the RPM installation.