### PR TITLE
get_tarballs.py: validate DEFAULT_TARBALL_VERSION and fail on invalid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since the last release
 -   item N
 
 ### Changed defaults / behaviours
+-   gettarballs.py now has an improved management of default tarballs
 
 ### Deprecated / removed options and commands
 


### PR DESCRIPTION
Also, protect when the default tarball is not downloaded (maybe not available?)