### PR TITLE
Add support for credentials secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@ SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## Changes Since Last Release OR vX.Y.Z \[yyyy-mm-dd\]
+
+Changes since the last release
+
+### New features / functionalities
+
+-   Added framework support for encrypted credentials and implemented for RSA keys and key pairs (PR #640)
+-   Added snapshot to `get_request_credentials()` in credential plugins to allow for targeted dynamic request credentials (PR #640)
+
+### Changed defaults / behaviours
+
+### Deprecated / removed options and commands
+
+### Security Related Fixes
+
+### Bug Fixes
+
+-   Python Cryptography changed some type names spelling. Added import statements to be compatible with both old and new spellings (PR #683, PR #687)
+-   Fixed `populate_group_security` in the configuration management to work with the new credentials and to handle correctly proxy ID lists for X509 DN extraction (PR #640)
+
+### Testing / Development
+
+### Known Issues
+
 ## v3.11.4 \[2026-05-08\]
 
 All M2Crypto requirements removed. Includes all changes and fixes in v3.10.18, plus a couple more fixes like pilot ARM submission.

--- a/creation/lib/cvWParamDict.py
+++ b/creation/lib/cvWParamDict.py
@@ -10,7 +10,7 @@ import os.path
 import shutil
 
 from glideinwms.frontend.glideinFrontendLib import getGlideinCpusNum
-from glideinwms.lib.credentials import x509
+from glideinwms.lib.credentials import CredentialError, x509
 from glideinwms.lib.credentials.utils import load_context
 from glideinwms.lib.generators import generator_context_errors, GeneratorContextError
 from glideinwms.lib.util import str2bool
@@ -1203,6 +1203,7 @@ def populate_common_descript(descript_dict, params):
             "trust_domain": "ProxyTrustDomains",
             "type": "ProxyTypes",
             "purpose": "CredentialPurposes",
+            "secret": "CredentialSecrets",
             "context": "CredentialContexts",
             # credential files probably should be handles as a list, each w/ name and path
             # or the attributes ending in _file are files
@@ -1451,16 +1452,19 @@ def populate_group_security(client_security, params, sub_params, group_name):
                         dn = x509.X509Cert(path=proxy_fname).subject
                         # don't worry about conflict... there is nothing wrong if the DN is listed twice
                         pilot_dns.append(dn)
-                    except SystemExit:
+                    except CredentialError:
                         print("...Failed to extract DN from %s, but continuing" % proxy_fname)
                 else:
                     # pool
                     pool_idx_list_expanded_strings = get_pool_list(pel)
                     for idx in pool_idx_list_expanded_strings:
                         real_proxy_fname = f"{proxy_fname}{idx}"
-                        dn = x509.X509Cert(path=real_proxy_fname).subject
-                        # don't worry about conflict... there is nothing wrong if the DN is listed twice
-                        pilot_dns.append(dn)
+                        try:
+                            dn = x509.X509Cert(path=real_proxy_fname).subject
+                            # don't worry about conflict... there is nothing wrong if the DN is listed twice
+                            pilot_dns.append(dn)
+                        except CredentialError:
+                            print("...Failed to extract DN from %s, but continuing" % real_proxy_fname)
 
     client_security["pilot_DNs"] = pilot_dns
 

--- a/creation/lib/cvWParams.py
+++ b/creation/lib/cvWParams.py
@@ -315,6 +315,12 @@ class VOFrontendParams(cWParams.CommonParams):
             "Python mapping with a context for credential generators",
             None,
         )
+        proxy_defaults["secret"] = (
+            None,
+            "fname or bytestring",
+            "Secret or password for the serialized credential (file name or value)",
+            None,
+        )
         proxy_defaults["trust_domain"] = ("OSG", "grid_type", "Trust Domain", None)
         proxy_defaults["creation_script"] = (None, "command", "Script to re-create credential", None)
         proxy_defaults["update_frequency"] = (None, "int", "Update proxy when there is this much time left", None)

--- a/doc/frontend/configuration.html
+++ b/doc/frontend/configuration.html
@@ -797,8 +797,9 @@ SPDX-License-Identifier: Apache-2.0
               type=&quot;<i>grid_proxy</i>&quot;
               absfname=&quot;<i>proxyfile</i>&quot;
               purpose=&quot;<i>request</i>&quot;
-              [keyabsfname=&quot;<i>keyfile</i>&quot;]
-              [pilotabsfname=&quot;<i>proxyfile</i>&quot;]
+              [keyabsfname=&quot;<i>keyfile</i>&quot;] [secret=<i
+                >secretfile or secret</i
+              >] [pilotabsfname=&quot;<i>proxyfile</i>&quot;]
               security_class=&quot;<i>frontend</i>&quot;
               trust_domain=&quot;<i>id</i>&quot;
               [creation_script=&quot;<i>creationcommand</i>&quot;]
@@ -820,7 +821,9 @@ SPDX-License-Identifier: Apache-2.0
               <li>
                 <b>key_pair</b>: A key pair stored with the public key in
                 <i>absfname</i> location and the private key in
-                <i>keyabsfname</i> location.
+                <i>keyabsfname</i> location. The private key may be encrypted
+                with a secret/password in <i>secret</i> (path of the file
+                containing the secret or secret itself).
               </li>
               <li>
                 <b>username_password</b>: A username/password combination with

--- a/frontend/glideinFrontendConfig.py
+++ b/frontend/glideinFrontendConfig.py
@@ -597,6 +597,7 @@ class ElementMergedDescript:
             "ProxyTrustDomains",
             "ProxyTypes",
             "CredentialPurposes",
+            "CredentialSecrets",
             "CredentialContexts",
             "CredentialGenerators",
             "ProxyKeyFiles",

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -361,6 +361,7 @@ def format_condor_dict(data):
 
 
 # DEPRECATED: use glideinwms.lib.credentials.Credential
+#             this class does not handle new credential attributes like scope and secret (CredentialSecrets)
 class LegacyCredential:
     """A class representing a credential used for GlideinWMS.
 

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -1211,7 +1211,7 @@ class MultiAdvertiseWork:
         return count
 
     def renew_and_load_credentials(self):
-        """Get the list of proxies, invoke the `renew()` scripts if any, and read the credentials in memory.
+        """Get the list of credentials, invoke the `renew()` scripts if any, and read the credentials in memory.
 
         Modifies the self.request_credentials variable.
         """
@@ -1230,7 +1230,7 @@ class MultiAdvertiseWork:
         return nr_credentials
 
     def initialize_advertise_batch(self, adname_prefix="gfi_ad_batch"):
-        """Initialize the variables that are used for batch avertisement
+        """Initialize the variables that are used for batch advertisement
 
         Args:
             adname_prefix (str, optional): The adname prefix to use. Defaults to "gfi_ad_batch".
@@ -1243,8 +1243,8 @@ class MultiAdvertiseWork:
         return classadSupport.generate_classad_filename(prefix=adname_prefix)
 
     def do_advertise_batch(self, filename_dict, remove_files=True):
-        """
-        Advertise the classad files in the dictionary provided
+        """Advertise the classad files in the dictionary provided
+
          The keys are the factory names, while the elements are lists of files
         Safe to run in parallel, guaranteed to not modify the self object state.
         """
@@ -1252,8 +1252,8 @@ class MultiAdvertiseWork:
             self.do_advertise_batch_one(factory_pool, filename_dict[factory_pool], remove_files)
 
     def do_advertise_batch_one(self, factory_pool, filename_arr, remove_files=True):
-        """
-        Advertise to a Factory the ClassAd files provided
+        """Advertise to a Factory the ClassAd files provided
+
         Safe to run in parallel, guaranteed to not modify the self object state.
         """
         # Advertise all the files
@@ -1269,8 +1269,8 @@ class MultiAdvertiseWork:
         return tuple(set(self.global_pool).union(set(self.factory_queue.keys())))
 
     def do_global_advertise(self, adname=None, create_files_only=False, reset_unique_id=True):
-        """
-        Advertise globals with credentials
+        """Advertise globals with credentials
+
         Returns a dictionary of files that still need to be advertised.
           The key is the factory pool, while the element is a list of file names
         Expects that the credentials have been already loaded.
@@ -1286,8 +1286,8 @@ class MultiAdvertiseWork:
         return unpublished_files
 
     def do_global_advertise_one(self, factory_pool, adname=None, create_files_only=False, reset_unique_id=True):
-        """
-        Advertise globals with credentials to one factory
+        """Advertise globals with credentials to one factory
+
         Returns the list of files that still need to be advertised.
         Expects that the credentials have been already loaded.
         """
@@ -1318,11 +1318,9 @@ class MultiAdvertiseWork:
         return []  # no files left to be advertised
 
     def createGlobalAdvertiseWorkFile(self, factory_pool):
-        """
-        Create the advertise file for globals with credentials
-        Expects the object variables
-         adname and x509_proxies_data
-        to be set.
+        """Create the advertise file for globals with credentials
+
+        Expects the object variables, adname and x509_proxies_data to be set.
         """
         global advertiseGCGCounter
 
@@ -1504,11 +1502,9 @@ class MultiAdvertiseWork:
         return values[0]
 
     def createAdvertiseWorkFile(self, factory_pool, params_obj, key_obj=None, file_id_cache=None):
-        """
-        Create the advertise file
-        Expects the object variables
-          adname, unique_id and x509_proxies_data
-        to be set.
+        """Create the advertise file
+
+        Expects the object variables, adname, unique_id and x509_proxies_data to be set.
         """
 
         cred_filename_arr = []

--- a/frontend/glideinFrontendPlugins.py
+++ b/frontend/glideinFrontendPlugins.py
@@ -30,7 +30,7 @@ from glideinwms.lib.credentials import (
 
 ################################################################################
 #                                                                              #
-####    Proxy plugins                                                       ####
+####    Proxy plugins    - OLD definition                                   ####
 #                                                                              #
 # All plugins implement the following interface:                               #
 #   __init_(config_dir,proxy_list)                                             #
@@ -55,11 +55,40 @@ from glideinwms.lib.credentials import (
 #     trust_domain will limit the returned credentials to a particular domain  #
 #                                                                              #
 ################################################################################
+# TODO: the new and old plugin interfaces are different and incompatible
+#   The old ones are not inheriting from CredentialsPlugin, are independent classes
+#   The interface is only specified in the comment above
 
 
 # TODO: Add type annotations to this class
 class CredentialsPlugin(ABC):
-    """Base class for all credential plugins"""
+    """Base class for all credential plugins
+
+    All plugins implement the following interface:
+    `__init__(config_dir, security_bundle)`
+      Constructor, config_dir may be used for internal config/cache files
+    `get_required_job_attributes()`
+      Return the list of required condor_q attributes
+    `get_required_classad_attributes()`
+      Return the list of required condor_status attributes
+    `update_usermap(condorq_dict, condorq_dict_types, status_dict, status_dict_types)`
+      Update usermap.  This is called once per iteration
+    `get_credentials(credential_type=None, trust_domain=None, credential_purpose=None, snapshot: Optional[str])`
+      Return a list of credentials that match the input criteria
+      This is called in two places, once in globals to return all credentials
+      and once when advertising actual requests.
+      If called multiple times, it is guaranteed that if the index is the same,
+      the credential/proxy is (logically) the same.
+      `credential_purpose` will filter the returned credentials to a particular purpose
+      `credential_type` will filter the returned credentials to a particular type
+      `trust_domain` will filter the returned credentials to a particular domain
+    `get_parameters(self, snapshot: Optional[str] = None) -> Mapping[ParameterName, Parameter]`
+      Return a list of parameters.
+    `get_request_credentials(self, snapshot: Optional[str] = None) -> List[RequestCredential]`
+      Return a list of credentials for requests.
+    `assign_work(self, req_creds: Iterable[RequestCredential], params_obj: AdvertiseParams, auth_set: AuthenticationSet)`
+      Determine the Glideins for each credential.
+    """
 
     def __init__(self, config_dir: str, security_bundle: SecurityBundle):
         self.security_bundle = security_bundle
@@ -77,7 +106,7 @@ class CredentialsPlugin(ABC):
         return self.security_bundle.parameters
 
     def get_required_job_attributes(self):
-        """what job attributes are used by this plugin
+        """what job (condor_q) attributes are used by this plugin
 
         Returns:
             list: used job attributes, none
@@ -85,10 +114,10 @@ class CredentialsPlugin(ABC):
         return []
 
     def get_required_classad_attributes(self):
-        """what glidein attributes are used by this plugin
+        """what Glidein (condor_status) attributes are used by this plugin
 
         Returns:
-            list: used glidein attributes, none
+            list: used Glidein attributes, none
         """
         return []
 
@@ -146,7 +175,7 @@ class CredentialsPlugin(ABC):
         pass
 
     @abstractmethod
-    def get_request_credentials(self) -> List[RequestCredential]:
+    def get_request_credentials(self, snapshot: Optional[str] = None) -> List[RequestCredential]:
         pass
 
     @abstractmethod
@@ -228,13 +257,16 @@ class CredentialsBasic(CredentialsPlugin):
             params_dict[param.name] = param
         return params_dict
 
-    def get_request_credentials(self) -> List[RequestCredential]:
+    def get_request_credentials(self, snapshot: Optional[str] = None) -> List[RequestCredential]:
         """Get the request credentials
+
+        Args:
+            snapshot (str, optional): get credentials from a dynamic snapshot if available
 
         Returns:
             list: list of request credentials
         """
-        req_creds = self.get_credentials(credential_purpose=CredentialPurpose.REQUEST)
+        req_creds = self.get_credentials(credential_purpose=CredentialPurpose.REQUEST, snapshot=snapshot)
         req_creds = [RequestCredential(cred) for cred in req_creds]
         return req_creds
 

--- a/lib/credentials/credentials.py
+++ b/lib/credentials/credentials.py
@@ -23,6 +23,9 @@ from glideinwms.lib import logSupport, subprocessSupport
 from glideinwms.lib.defaults import force_bytes
 from glideinwms.lib.util import hash_nc
 
+# MMDB will be used  - from cryptography.hazmat.primitives import serialization
+
+
 T = TypeVar("T")
 
 
@@ -170,6 +173,7 @@ class Credential(ABC, Generic[T]):
         self,
         string: Optional[Union[str, bytes]] = None,
         path: Optional[str] = None,
+        secret: Optional[str] = None,
         purpose: Optional[CredentialPurpose] = None,
         trust_domain: Optional[str] = None,
         security_class: Optional[str] = None,
@@ -181,6 +185,8 @@ class Credential(ABC, Generic[T]):
         Args:
             string (Optional[Union[str, bytes]]): The credential string.
             path (Optional[str]): The path to the credential file.
+            secret (Optional[str]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it.
             purpose (Optional[CredentialPurpose]): The purpose of the credential.
             trust_domain (Optional[str]): The trust domain of the credential.
             security_class (Optional[str]): The security class of the credential.
@@ -189,7 +195,9 @@ class Credential(ABC, Generic[T]):
         """
 
         self._string = None
+        self._string_original = None
         self.path = path
+        self.secret = secret
         self.purpose = purpose
         self.trust_domain = trust_domain
         self.security_class = security_class
@@ -199,7 +207,7 @@ class Credential(ABC, Generic[T]):
         except ValueError as err:
             raise CredentialError(f"Invalid minimum lifetime: {minimum_lifetime}") from err
         if string or path:
-            self.load(string, path)
+            self.load(string, path, secret)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(string={self.string!r}, path={self.path!r}, purpose={self.purpose!r}, trust_domain={self.trust_domain!r}, security_class={self.security_class!r})"
@@ -208,6 +216,12 @@ class Credential(ABC, Generic[T]):
         return self.string.decode() if self.string else ""
 
     def __renew__(self) -> None:
+        """Renew the credential using the creation_script.
+
+        Raises:
+            NotImplementedError: If the creation_script is not implemented.
+            RuntimeError: If the credential renewal failed.
+        """
         if not self.creation_script:
             raise NotImplementedError("Renewal not implemented for this credential type")
         if self.valid:
@@ -225,16 +239,13 @@ class Credential(ABC, Generic[T]):
     @property
     def string(self) -> Optional[bytes]:
         """Credential string."""
-
         return self._string
 
     @property
     def id(self) -> str:
         """Credential unique identifier."""
-
         if not str(self.string):
             raise CredentialError("Credential not initialized")
-
         return hash_nc(
             f"{str(self._id_attribute)}{self.purpose}{self.trust_domain}{self.security_class}{self.cred_type}", 8
         )
@@ -242,7 +253,6 @@ class Credential(ABC, Generic[T]):
     @property
     def purpose(self) -> Optional[CredentialPurpose]:
         """Credential purpose."""
-
         return self._purpose[0]
 
     @purpose.setter
@@ -262,9 +272,9 @@ class Credential(ABC, Generic[T]):
     @property
     def purpose_alias(self) -> Optional[str]:
         """Credential purpose alias."""
-
         if self._purpose[0] is not None:
             return self._purpose[1] or self._purpose[0].value
+        return None
 
     @property
     def valid(self) -> bool:
@@ -278,18 +288,46 @@ class Credential(ABC, Generic[T]):
 
     @staticmethod
     @abstractmethod
-    def decode(string: Union[str, bytes]) -> T:
+    def decode(string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> T:
         """Decode the given string to provide the credential.
+
+        If provided, can use the optional secret to decode the credential.
 
         For dynamic credentials, this is providing a contextualized generator,
         given both the generator module and the context.
 
         Args:
             string (bytes): The string to decode.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it.
 
         Returns:
             T: The decoded value.
         """
+
+    @staticmethod
+    def encode(
+        credential: T, secret: Optional[Union[str, bytes]] = None, string: Optional[Union[str, bytes]] = None
+    ) -> bytes:
+        """Encode the given credential to provide the string.
+
+        If provided, can use the optional secret to encode the credential.
+
+        The base class method returns the optional `string` argument.
+        Credential classes are expected to implement more specific encodings using the credential,
+        for example, returning a credential not encrypted with a passphrase also when the original string was.
+        It is up to the credential class how to use the optional string argument.
+
+        Args:
+            credential (T): The credential to encode.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it. Defaults to None.
+            string (Optional[Union[str, bytes]]): The encoded string. Defaults to None.
+
+        Returns:
+            bytes: The encoded string. None if the string is not provided. This will be different in child classes.
+        """
+        return force_bytes(string)
 
     @abstractmethod
     def invalid_reason(self) -> Optional[str]:
@@ -299,61 +337,99 @@ class Credential(ABC, Generic[T]):
             str or None: The reason why the credential is invalid. None if the credential is valid.
         """
 
-    def load_from_string(self, string: Union[str, bytes]) -> None:
+    def load_from_string(self, string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> None:
         """Load the credential from a string.
 
+        If secret is provided, will try to interpret it as a file and load the content, otherwise use the secret itself,
+        converted to bytes if a string, to decode the credential.
+
         Args:
-            string (bytes): The credential string to load.
+            string (Union[str, bytes]): The credential string to load.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it. Defaults to None.
 
         Raises:
             CredentialError: If the input string is not of type bytes or if the credential cannot be loaded from the string.
         """
-
         string = force_bytes(string)
         if not isinstance(string, bytes):
             raise CredentialError("Credential string must be bytes")
+        if secret:
+            if os.path.isfile(secret):
+                try:
+                    with open(secret, "rb") as secret_file:
+                        secret_data = secret_file.read()
+                        secret = secret_data.strip()
+                except OSError:
+                    # If unable to read the file, consider `secret` as the secret value
+                    pass
+            secret = force_bytes(secret)
+            if not isinstance(secret, bytes):
+                raise CredentialError("Credential secret (password) must be bytes")
         try:
-            self.decode(string)
+            decoded = self.decode(string, secret)
         except Exception as err:
             raise CredentialError(f"Could not load credential from string: {string}") from err
-        self._string = string
+        if secret:
+            self._string_original = string
+            try:
+                self._string = self.encode(decoded, None, string)
+            except Exception as err:
+                raise CredentialError(f"Could not store unencrypted credential from string: {string}") from err
+        else:
+            self._string = string
 
-    def load_from_file(self, path: Optional[str] = None) -> None:
+    def load_from_file(self, path: Optional[str] = None, secret: Optional[Union[str, bytes]] = None) -> None:
         """Load credentials from a file.
 
         Args:
-            path (str): The path to the credential file.
+            path (str): The path to the credential file. Defaults to `self.path` if not provided or empty.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential,
+                e.g. a key password or the path to the file storing it.
+                Defaults to `self.secret` if both the secret and the path are not provided or empty.`
 
         Raises:
             CredentialError: If the specified file does not exist.
         """
 
-        path = path or self.path
+        if not path:
+            path = self.path
+            secret = secret or self.secret
 
         if not os.path.isfile(path):
             raise CredentialError(f"Credential file {path} does not exist or wrong file or directory permissions")
         with open(path, "rb") as cred_file:
-            self.load_from_string(cred_file.read())
+            self.load_from_string(cred_file.read().strip(), secret)
         self.path = path
+        self.secret = secret
 
-    def load(self, string: Optional[Union[str, bytes]] = None, path: Optional[str] = None) -> None:
+    def load(
+        self,
+        string: Optional[Union[str, bytes]] = None,
+        path: Optional[str] = None,
+        secret: Optional[Union[str, bytes]] = None,
+    ) -> None:
         """Load credentials from either a string or a file.
         If both are defined, the string takes precedence.
 
         Args:
-            string (Optional[bytes]): The credentials string to load.
-            path (Optional[str]): The path to the file containing the credentials.
+            string (Optional[Union[str, bytes]]): The credentials string to load. Defaults to None.
+            path (Optional[str]): The path to the file containing the credentials. Defaults to None.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it. Defaults to None.
 
         Raises:
             CredentialError: If neither `string` nor `path` is specified.
         """
 
         if string:
-            self.load_from_string(string)
+            self.load_from_string(string, secret)
             if path:
                 self.path = path
+            if secret:
+                self.secret = secret
         elif path:
-            self.load_from_file(path)
+            self.load_from_file(path, secret)
         else:
             raise CredentialError("No string or path specified")
 
@@ -376,6 +452,7 @@ class Credential(ABC, Generic[T]):
             trust_domain=self.trust_domain,
             security_class=self.security_class,
             cred_type=self.cred_type,
+            secret=self.secret,
         )
 
     def save_to_file(
@@ -475,17 +552,22 @@ class CredentialPair:
         path: Optional[str] = None,
         private_string: Optional[bytes] = None,
         private_path: Optional[str] = None,
+        secret: Optional[Union[str, bytes]] = None,
         purpose: Optional[CredentialPurpose] = None,
         trust_domain: Optional[str] = None,
         security_class: Optional[str] = None,
     ) -> None:
         """Initialize a CredentialPair object.
 
+        All arguments default to None if not provided.
+
         Args:
             string (Optional[bytes]): The string representation of the public credential.
             path (Optional[str]): The path to the public credential file.
             private_string (Optional[bytes]): The string representation of the private credential.
             private_path (Optional[str]): The path to the private credential file.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the private credential,
+                e.g. a key password or the path to the file storing it.
             purpose (Optional[CredentialPurpose]): The purpose of the credential.
             trust_domain (Optional[str]): The trust domain of the credential.
             security_class (Optional[str]): The security class of the credential.
@@ -498,11 +580,11 @@ class CredentialPair:
 
         credential_class = self.__class__.__bases__[1]
         super(credential_class, self).__init__(  # pylint: disable=bad-super-call
-            string, path, purpose, trust_domain, security_class
+            string, path, None, purpose, trust_domain, security_class
         )
         private_credential_class = credential_of_type(self.private_cred_type)  # pylint: disable=no-member
         self.private_credential = private_credential_class(
-            private_string, private_path, purpose, trust_domain, security_class
+            private_string, private_path, secret, purpose, trust_domain, security_class
         )
 
     def renew(self) -> None:
@@ -532,6 +614,7 @@ class CredentialPair:
             path=self.path,  # pylint: disable=no-member # type: ignore[attr-defined]
             private_string=self.private_credential.string,
             private_path=self.private_credential.path,
+            secret=self.private_credential.secret,
             purpose=self.purpose,  # pylint: disable=no-member # type: ignore[attr-defined]
             trust_domain=self.trust_domain,  # pylint: disable=no-member # type: ignore[attr-defined]
             security_class=self.security_class,  # pylint: disable=no-member # type: ignore[attr-defined]
@@ -684,6 +767,7 @@ def create_credential(
     string: Optional[Union[str, bytes]] = None,
     path: Optional[str] = None,
     purpose: Optional[CredentialPurpose] = None,
+    secret: Optional[Union[str, bytes]] = None,
     trust_domain: Optional[str] = None,
     security_class: Optional[str] = None,
     cred_type: Optional[CredentialType] = None,
@@ -693,15 +777,19 @@ def create_credential(
 ) -> Credential:
     """Creates a credential object.
 
+    All arguments default to None if not provided. minimum_lifetime defaults to 0, no minimum.
+
     Args:
         string (bytes, optional): The credential as a byte string.
         path (str, optional): The path to the credential file.
+        secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+            the path to the file storing it.
         purpose (CredentialPurpose, optional): The purpose of the credential.
         trust_domain (str, optional): The trust domain of the credential.
         security_class (str, optional): The security class of the credential.
         cred_type (CredentialType, optional): The type of the credential.
         creation_script (str, optional): The script used to create the credential.
-        minimum_lifetime (Union[int, str], optional): The minimum lifetime of the credential in seconds.
+        minimum_lifetime (Union[int, str], optional): The minimum lifetime of the credential in seconds. Defaults to 0, no minimum.
         context (Mapping, optional): The context to use for decoding the credential.
 
     Returns:
@@ -724,13 +812,15 @@ def create_credential(
         except CredentialError as err:
             failed_attempts.append(err)  # Likely credential type incompatible with input
         except Exception as err:
-            raise CredentialError(f'Unexpected error loading credential: string="{string}", path="{path}"') from err
+            raise CredentialError(
+                f'Unexpected error loading credential: string="{string}", path="{path}", secret="{secret}"'
+            ) from err
     if failed_attempts:
         raise CredentialError(
-            f'Could not load credential: string="{string}", path="{path}". {len(failed_attempts)} attempts failed with CredentialError.'
+            f'Could not load credential: string="{string}", path="{path}", secret="{secret}". {len(failed_attempts)} attempts failed with CredentialError.'
         ) from failed_attempts[-1]
     else:
-        raise CredentialError(f'Could not load credential: string="{string}", path="{path}"')
+        raise CredentialError(f'Could not load credential: string="{string}", path="{path}", secret="{secret}"')
 
 
 def create_credential_pair(
@@ -738,6 +828,7 @@ def create_credential_pair(
     path: Optional[str] = None,
     private_string: Optional[bytes] = None,
     private_path: Optional[str] = None,
+    secret: Optional[Union[str, bytes]] = None,
     purpose: Optional[CredentialPurpose] = None,
     trust_domain: Optional[str] = None,
     security_class: Optional[str] = None,
@@ -748,17 +839,21 @@ def create_credential_pair(
 ) -> CredentialPair:
     """Creates a credential pair object.
 
+    All arguments default to None if not provided. minimum_lifetime defaults to 0, no minimum.
+
     Args:
         string (bytes, optional): The public credential as a byte string.
         path (str, optional): The path to the public credential file.
         private_string (bytes, optional): The private credential as a byte string.
         private_path (str, optional): The path to the private credential file.
+        secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+            the path to the file storing it.
         purpose (CredentialPurpose, optional): The purpose of the credentials.
         trust_domain (str, optional): The trust domain of the credentials.
         security_class (str, optional): The security class of the credentials.
         cred_type (CredentialPairType, optional): The type of the credential pair.
         creation_script (str, optional): The script used to create the credentials.
-        minimum_lifetime (Union[int, str], optional): The minimum lifetime of the credentials in seconds.
+        minimum_lifetime (Union[int, str], optional): The minimum lifetime of the credentials in seconds. Defaults to 0, no minimum.
         context (Mapping, optional): The context to use for decoding the credentials.
 
     Returns:
@@ -782,14 +877,14 @@ def create_credential_pair(
             failed_attempts.append(err)  # Likely credential type incompatible with input
         except Exception as err:
             raise CredentialError(
-                f'Unexpected error loading credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}"'
+                f'Unexpected error loading credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}", secret="{secret}"'
             ) from err
     if failed_attempts:
         raise CredentialError(
-            f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}". {len(failed_attempts)} attempts failed with CredentialError.'
+            f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}", secret="{secret}". {len(failed_attempts)} attempts failed with CredentialError.'
         ) from failed_attempts[-1]
     raise CredentialError(
-        f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}"'
+        f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}", secret="{secret}"'
     )
 
 

--- a/lib/credentials/dynamic.py
+++ b/lib/credentials/dynamic.py
@@ -84,9 +84,14 @@ class DynamicCredential(Credential[Generator]):
 
         return self._context
 
+    # TODO: Could there be confusion between secret and context?
     @staticmethod
     def decode(string: Union[str, bytes], context: Optional[Mapping] = None) -> Generator:
         """Load the credential generator module and return it.
+
+        This implementation has the same number of parameters but different signature of the parent class.
+        Dynamic credentials use context for the generation and do not use secret to decoding serialized credentials.
+        If a secret is needed it should be added to the context and become one of the constructor arguments.
 
         Args:
             string: Generator module name or path. Can be in bytes.
@@ -208,6 +213,7 @@ class DynamicCredential(Credential[Generator]):
 
         Args:
             snapshot (str): The name of the snapshot to retrieve.
+            default (Optional[any]): A default value to return if the snapshot does not exist.
 
         Returns:
             Optional[Credential]: The snapshot of the generated credential, or None if not found.

--- a/lib/credentials/rsa.py
+++ b/lib/credentials/rsa.py
@@ -59,7 +59,17 @@ class RSAPublicKey(Credential[PublicKeyTypes]):
         return self.string
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> PublicKeyTypes:
+    def decode(string: Union[str, bytes], secret: Optional[Union[bytes, str]] = None) -> PublicKeyTypes:
+        """Decode an RSA public key.
+
+        Args:
+            string (Union[str, bytes]): The string to decode.
+            secret (Optional[Union[bytes, str]]): Since the public key is in clear, there should be no secrets.
+                Always None, ignored. Added to respect the interface.
+
+        Returns:
+            RSAPublicKey: The decoded RSA public key.
+        """
         string = force_bytes(string)
         if string.startswith(b"ssh-rsa"):
             return serialization.load_ssh_public_key(string, backend=default_backend())
@@ -209,11 +219,70 @@ class RSAPrivateKey(Credential[PrivateKeyTypes]):
         return "RSA" if self._payload else None
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> PrivateKeyTypes:
+    def decode(string: Union[str, bytes], secret: Optional[Union[bytes, str]] = None) -> PrivateKeyTypes:
+        """Decode an RSA private key.
+
+        Args:
+            string (Union[str, bytes]): The string to decode.
+            secret (Optional[Union[bytes, str]]): Password used to encrypt the private key.
+                If not provided, it will default to None for SSH keys and DEFAULT_PASSWORD for PEM keys.
+
+        Returns:
+            RSAPrivateKey: The RSA private key.
+        """
         string = force_bytes(string)
+        password = force_bytes(secret)
         if string.startswith(b"-----BEGIN OPENSSH PRIVATE KEY-----"):
-            return serialization.load_ssh_private_key(string, password=None, backend=default_backend())
-        return serialization.load_pem_private_key(string, password=DEFAULT_PASSWORD, backend=default_backend())
+            return serialization.load_ssh_private_key(string, password=password, backend=default_backend())
+        return serialization.load_pem_private_key(
+            string, password=password or DEFAULT_PASSWORD, backend=default_backend()
+        )
+
+    @staticmethod
+    def encode(
+        credential: PrivateKeyTypes,
+        secret: Optional[Union[str, bytes]] = None,
+        string: Optional[Union[str, bytes]] = None,
+    ) -> bytes:
+        """Encode the given RSA private key.
+
+        If provided, can use the optional secret to encode the key.
+
+        By default, it uses the new OpenSSH format and PEM.
+        If the optional `string` argument is not provided, it will use the same format as `string`
+        (TraditionalOpenSSL or OpenSSH).
+
+        Args:
+            credential (PrivateKeyTypes): The credential to encode.
+            secret (Optional[Union[str, bytes]]): An element that can be used to decode the credential, e.g. a key password or
+                the path to the file storing it. Defaults to the DEFAULT_PASSWORD if the TraditionalOpenSSL format is used.
+            string (Optional[Union[str, bytes]]): The encoded key. Can use a different password. Currently used only for the serialization format.
+
+        Returns:
+            bytes: The encoded key.
+        """
+        cred_format = serialization.PrivateFormat.OpenSSH
+        password = force_bytes(secret)
+        # string used only to infer properties, could be returned if there is no password in both.
+        # Generally password could be different
+        if string:
+            string = force_bytes(string)
+            if not string.startswith(b"-----BEGIN OPENSSH PRIVATE KEY-----"):
+                cred_format = serialization.PrivateFormat.TraditionalOpenSSL
+                password = password or DEFAULT_PASSWORD
+
+        if password is None:
+            return credential.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=cred_format,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        else:
+            return credential.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=cred_format,
+                encryption_algorithm=serialization.BestAvailableEncryption(password),
+            )
 
     def invalid_reason(self) -> Optional[str]:
         """Checks if the credential is valid and returns a string if it is not.

--- a/lib/credentials/symmetric.py
+++ b/lib/credentials/symmetric.py
@@ -52,7 +52,17 @@ class SymmetricKey(Credential[Cipher]):
         return self.string
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> Cipher:
+    def decode(string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> Cipher:
+        """Decode a symmetric key.
+
+        Args:
+            string (Union[str, bytes]): The string to decode.
+            secret (Optional[Union[str, bytes]]): Since symmetric keys are generally serialized in clear,
+                there are no secrets. Always None, ignored. Added to respect the interface.
+
+        Returns:
+            Cipher: The decoded symmetric credential (Cipher object, e.g. AES).
+        """
         string = force_bytes(string)
         key = binascii.unhexlify(string.split(b",")[1].split(b":")[1])
         iv = binascii.unhexlify(string.split(b",")[2].split(b":")[1])

--- a/lib/credentials/text.py
+++ b/lib/credentials/text.py
@@ -29,7 +29,18 @@ class TextCredential(Credential[bytes]):
         return self.string
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> bytes:
+    def decode(string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> bytes:
+        """Decode text credential.
+        No changes performed. The content is cast to bytes.
+
+        Args:
+            string (Union[str, bytes]): The credential as string or bytes.
+            secret (Optional[Union[str, bytes]]): Text credentials are not encoded, there should be no secrets.
+                Always None, ignored. Added to respect the interface.
+
+        Returns:
+            bytes: The decoded text credential as a bytes object.
+        """
         return force_bytes(string)
 
     def invalid_reason(self) -> Optional[str]:

--- a/lib/credentials/tokens.py
+++ b/lib/credentials/tokens.py
@@ -60,7 +60,17 @@ class Token(Credential[Mapping]):
         return self.subject
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> Mapping:
+    def decode(string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> Mapping:
+        """Decode a JWT token.
+
+        Args:
+            string (Union[str, bytes]): The string to decode.
+            secret (Optional[Union[str, bytes]]): Since tokens are in clear, there should be no secrets.
+                Always None, ignored. Added to respect the interface.
+
+        Returns:
+            Mapping: The decoded token as a dictionary.
+        """
         if isinstance(string, bytes):
             string = string.decode()
         return jwt.decode(string.strip(), options={"verify_signature": False})

--- a/lib/credentials/utils.py
+++ b/lib/credentials/utils.py
@@ -69,6 +69,7 @@ class SecurityBundle:
         for path in element_descript["Proxies"]:
             cred_type = credential_type_from_string(element_descript["ProxyTypes"].get(path))
             purpose = element_descript["CredentialPurposes"].get(path)
+            secret = element_descript["CredentialSecrets"].get(path, None)
             trust_domain = element_descript["ProxyTrustDomains"].get(path, "None")
             security_class = element_descript["ProxySecurityClasses"].get(path, "grid")
             creation_script = element_descript["CredentialCreationScripts"].get(path, None)
@@ -78,6 +79,7 @@ class SecurityBundle:
                 credential = create_credential(
                     path=path,
                     purpose=purpose,
+                    secret=secret,
                     trust_domain=trust_domain,
                     security_class=security_class,
                     cred_type=cred_type,
@@ -91,6 +93,7 @@ class SecurityBundle:
                     path=path,
                     private_path=cred_key,
                     purpose=purpose,
+                    secret=secret,
                     trust_domain=trust_domain,
                     security_class=security_class,
                     cred_type=cred_type,

--- a/lib/credentials/x509.py
+++ b/lib/credentials/x509.py
@@ -70,7 +70,19 @@ class X509Cert(Credential[x509.Certificate]):
         return self.subject
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> x509.Certificate:
+    def decode(string: Union[str, bytes], secret: Optional[Union[str, bytes]] = None) -> x509.Certificate:
+        """Deserialize a X509 certificate or proxy from PEM encoded data.
+
+        PEM certificates are base64 decoded and have delimiters that look like `-----BEGIN CERTIFICATE-----`.
+
+        Args:
+            string (Union[str, bytes]): The credential as string or bytes.
+            secret (Optional[Union[str, bytes]]): X509 certificates are not encrypted, there should be no secrets.
+                Always None, ignored. Added to respect the interface.
+
+        Returns:
+            x509.Certificate: The decoded X509 credential.
+        """
         string = force_bytes(string)
         return x509.load_pem_x509_certificate(string)
 

--- a/lib/defaults.py
+++ b/lib/defaults.py
@@ -89,7 +89,7 @@ def force_bytes(instr, encoding=BINARY_ENCODING_CRYPTO):
         ValueError: If it detects an improper str conversion (b'' around the string).
     """
     if isinstance(instr, str):
-        # raise Exception("ALREADY str!")  # Use this for investigations
+        # Convert only strings (preserve numbers or None)
         if instr.startswith("b'") and len(instr) > 2 and instr.endswith("'"):
             # This may cause errors with the random strings generated for unit tests, which may start with "b'"
             raise ValueError(
@@ -102,6 +102,7 @@ def force_bytes(instr, encoding=BINARY_ENCODING_CRYPTO):
 
 def force_str(inbytes, encoding=BINARY_ENCODING_CRYPTO):
     """Forces the output to be str, decoding the input if it is a bytestring (bytes).
+    None is preserved. Everything else returns an error.
 
     Args:
         inbytes (Union[str, bytes]): String to be converted.
@@ -114,6 +115,8 @@ def force_str(inbytes, encoding=BINARY_ENCODING_CRYPTO):
         ValueError: If it detects an improper str conversion (b'' around the string) or
             the input is neither string nor bytes.
     """
+    if inbytes is None:
+        return inbytes
     if isinstance(inbytes, str):
         # raise Exception("ALREADY str!")
         if inbytes.startswith("b'"):

--- a/unittests/test_glideinFrontendPlugins.py
+++ b/unittests/test_glideinFrontendPlugins.py
@@ -51,6 +51,7 @@ class fakeDescript:
             "ProxyTrustDomains": {},
             "ProxyTypes": {},
             "CredentialGenerators": {},
+            "CredentialSecrets": {},
             "ProxyKeyFiles": {},
             "ProxyPilotFiles": {},
             "ProxyVMIds": {},


### PR DESCRIPTION
Added framework support for encrypted credentials and implemented for RSA keys and key pairs.
Credential files and strings may be protected by a secret (password/passphrase) when imported in GlideinWMS. Credentials are then stored and forwarded in clear.
This fixes ssh keys errors seen in BOSCO, which uses password protected keys in its setup.

Included a couple more fixes:
- Fixed `populate_group_security` in the configuration management to work with the new credentials and to handle correctly proxy ID lists for X509 DN extraction
 - Added snapshot to plugin's get_request_credentials() to allow for targeted dynamic request credentials. May need to add the credential type and trust domain as well in the selection
 - Improved docstrings in frontend/glideinFrontendInterface.py


The PR includes a workaround for the uppercase cryptography types. This will be removed once PR #687 is merged