### PR TITLE
Adding quotes to heredoc delimiter in wrapper script to avoid expansion at evaluation time

### DIFF
--- a/creation/web_base/condor_startup.sh
+++ b/creation/web_base/condor_startup.sh
@@ -146,7 +146,7 @@ wrapper_list=$(gconfig_get WRAPPER_LIST "$config_file")
 #
 # TODO: should it skip the wrapper if WRAPPER_LIST is empty?
 condor_job_wrapper="condor_job_wrapper.sh"
-cat > "$condor_job_wrapper" <<EOF
+cat > "$condor_job_wrapper" <<"EOF"
 #!/bin/sh
 
 # This script is started just before the user job


### PR DESCRIPTION
Adding quotes to heredoc delimiter in wrapper script to avoid expansion at evaluation time

This fixes #641