### PR TITLE
Migrating `glidein_status` tool from Python 2 to Python 3

### DIFF
--- a/tools/glidein_status.py
+++ b/tools/glidein_status.py
@@ -6,6 +6,7 @@
 """Equivalent to condor_status, but with glidein specific info"""
 
 import argparse
+import functools
 import os.path
 import sys
 import time
@@ -254,7 +255,7 @@ def main():
     data = cs.stored_data
     keys = list(data.keys())
 
-    keys.sort(machine_cmp)
+    keys.sort(key=functools.cmp_to_key(machine_cmp))
 
     counts_header = (
         "Total",
@@ -388,9 +389,9 @@ def main():
     ckeys = list(counts.keys())
 
     if summarize == "site":
-        ckeys.sort(ltotal_cmp)
+        ckeys.sort(key=functools.cmp_to_key(ltotal_cmp))
     else:  # default is entry
-        ckeys.sort(entry_cmp)
+        ckeys.sort(key=functools.cmp_to_key(entry_cmp))
 
     if len(ckeys) > 1:
         print()  # put a space before the entry names


### PR DESCRIPTION
Fixes #422.

In Python2, a comparison function `cmp` accepted two arguments. Python 3 removed direct support for the comparison function. 

While the ideal way forward is to use key function, a function `cmp_to_key()` in `functools` is available as part of the standard Python library that helps serve as a transitionary tool for converting Python 2 code to Python 3. This function takes the two-argument comparison function and returns a callable key object that the sorting algorithms can use. Ideally, it is recommended to define a key function but that would require us to know the in and outs of the existing comparison functions in order to rewrite the old-style comparison functions. Perhaps something to eventually consider doing when the time is right (since the `glidein_status` tool is not currently being used in comparison with other tools as learned from our stakeholders).