### PR TITLE
Made IdTokenGenerator more robust, using the Entry name when GLIDEIN_Site is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All M2Crypto requirements removed. Includes all changes and fixes in v3.10.18, p
 
 ### Bug Fixes
 
+-   IdTokenGenerator more robust, using the Entry name when GLIDEIN_Site is not available (PR #667)
+
 ### Testing / Development
 
 ### Known Issues

--- a/doc/tags.yaml
+++ b/doc/tags.yaml
@@ -809,4 +809,5 @@ v3_11_4:
   Tarball: false
   Feature:
   Bug fix:
+    - IdTokenGenerator more robust, using the Entry name when GLIDEIN_Site is not available (PR#667)
   NOTE:

--- a/factory/glideFactoryConfig.py
+++ b/factory/glideFactoryConfig.py
@@ -30,6 +30,7 @@ from glideinwms.lib import credentials
 ############################################################
 
 
+# TODO: Verify the difference form glideFactoryInterface.FactoryConfig and if these can be unified
 class FactoryConfig:
     """Holds default configuration file names for the factory.
 
@@ -224,7 +225,7 @@ class JoinConfigFile(ConfigFile):
 
 
 class GlideinDescript(ConfigFile):
-    """Represents the Glidein description configuration file.
+    """Represents the Glidein(Factory and HTCondor services) description configuration file.
 
     This class loads the glidein.descript file and processes its content,
     including handling of public key type values.

--- a/factory/glideFactoryConfig.py
+++ b/factory/glideFactoryConfig.py
@@ -30,7 +30,7 @@ from glideinwms.lib import credentials
 ############################################################
 
 
-# TODO: Verify the difference form glideFactoryInterface.FactoryConfig and if these can be unified
+# TODO: Verify the difference from glideFactoryInterface.FactoryConfig and if these can be unified
 class FactoryConfig:
     """Holds default configuration file names for the factory.
 
@@ -225,7 +225,7 @@ class JoinConfigFile(ConfigFile):
 
 
 class GlideinDescript(ConfigFile):
-    """Represents the Glidein(Factory and HTCondor services) description configuration file.
+    """Represents the Glidein (Factory and HTCondor services) description configuration file.
 
     This class loads the glidein.descript file and processes its content,
     including handling of public key type values.

--- a/factory/glideFactoryInterface.py
+++ b/factory/glideFactoryInterface.py
@@ -40,6 +40,7 @@ advertiseGlobalCounter = 0
 #        pass
 
 
+# TODO: Verify the difference form glideFactoryConfig.FactoryConfig and if these can be unified
 class FactoryConfig:
     def __init__(self):
         """Initialize a FactoryConfig object with default values.
@@ -416,9 +417,9 @@ class EntryClassad(classadSupport.Classad):
         similar for glidein_submits, glidein_params, glidein_monitor_monitors and the other dictionaries.
 
         Args:
-            factory_name (str): Name of the Factory.
-            glidein_name (str): Name of the resource in the glideclient classad.
-            entry_name (str): Name of the resource in the glidefactory classad.
+            factory_name (str): Name of the Factory (from the config file root. Defaults to hostname if not set).
+            glidein_name (str): Name of the Factory/Glidein installation (from the config file root and glidefactoryglobal)
+            entry_name (str): Name of the resource/entry in the configuration file and glidefactory classad.
             trust_domain (str): Trust domain for this entry.
             auth_method (str): Authentication methods supported in glidein submission (e.g. grid_proxy, scitoken).
             supported_signtypes (list): Supported sign types (e.g. ['sha1']).

--- a/factory/glideFactoryInterface.py
+++ b/factory/glideFactoryInterface.py
@@ -40,7 +40,7 @@ advertiseGlobalCounter = 0
 #        pass
 
 
-# TODO: Verify the difference form glideFactoryConfig.FactoryConfig and if these can be unified
+# TODO: Verify the difference from glideFactoryConfig.FactoryConfig and if these can be unified
 class FactoryConfig:
     def __init__(self):
         """Initialize a FactoryConfig object with default values.

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -128,11 +128,16 @@ class FactoryConfig:
         self.client_proxies_base_dir = None
 
     def config_whoamI(self, factory_name, glidein_name):
-        """Configure Factory and glidein names.
+        """Configure Factory and Glidein names.
+
+        These values normally come from the Factory configuration file. They are both set in the root node for
+        the whole Factory config file:
+        - `factory_name` defaults to the Factory hostname if missing in the configuration file.
+        - `glidein_name` is required.
 
         Args:
-            factory_name (str): Name of the Factory.
-            glidein_name (str): Name of the glidein.
+            factory_name (str): Name of the Factory
+            glidein_name (str): Name of the Glidein
         """
         self.factory_name = factory_name
         self.glidein_name = glidein_name

--- a/frontend/glideinFrontendConfig.py
+++ b/frontend/glideinFrontendConfig.py
@@ -18,6 +18,7 @@ from glideinwms.lib import hash_crypto, util
 ############################################################
 
 
+# TODO: Verify the difference form glideinFrontendInterface.FrontendConfig and if these can be unified
 class FrontendConfig:
     """Configuration class for the Frontend component of GlideinWMS.
 

--- a/frontend/glideinFrontendConfig.py
+++ b/frontend/glideinFrontendConfig.py
@@ -18,7 +18,7 @@ from glideinwms.lib import hash_crypto, util
 ############################################################
 
 
-# TODO: Verify the difference form glideinFrontendInterface.FrontendConfig and if these can be unified
+# TODO: Verify the difference from glideinFrontendInterface.FrontendConfig and if these can be unified
 class FrontendConfig:
     """Configuration class for the Frontend component of GlideinWMS.
 

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -490,7 +490,7 @@ class glideinFrontendElement:
         del forkm_obj
 
         self.globals_dict = {}
-        self.glidein_dict = {}
+        self.glidein_dict = {}  # Dictionary with glidefactory classad elements
         self.factoryclients_dict = {}
         self.condorq_dict = {}
 
@@ -702,7 +702,9 @@ class glideinFrontendElement:
             glideid_str = f"{request_name}@{factory_pool_node}"
             self.processed_glideid_strs.append(glideid_str)
 
-            glidein_el = self.glidein_dict[glideid]
+            glidein_el = self.glidein_dict[
+                glideid
+            ]  # Contains the glidefactory classad attributes for one entry/resource
             glidein_in_downtime = safe_boolcomp(glidein_el["attrs"].get("GLIDEIN_In_Downtime", False), True)
 
             count_jobs = {}  # straight match
@@ -2104,8 +2106,8 @@ class glideinFrontendElement:
 
         Returns:
             dict: A dictionary mapping (factory_pool_node, glidein name, frontend identity at factory pool)
-                to their corresponding glidein attribute dictionaries. Only trusted entries with matching
-                identities are included.
+                to their corresponding glidein attribute dictionaries (i.e. the content of the glidefactory classad).
+                Only trusted entries with matching identities are included.
         """
         # Query glidefactory ClassAd
         try:

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -30,6 +30,7 @@ from glideinwms.lib.util import hash_nc
 ############################################################
 
 
+# TODO: Verify the difference form glideinFrontendConfig.FrontendConfig and if these can be unified
 class FrontendConfig:
     """Configuration class for the Frontend component of GlideinWMS.
 

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -30,7 +30,7 @@ from glideinwms.lib.util import hash_nc
 ############################################################
 
 
-# TODO: Verify the difference form glideinFrontendConfig.FrontendConfig and if these can be unified
+# TODO: Verify the difference from glideinFrontendConfig.FrontendConfig and if these can be unified
 class FrontendConfig:
     """Configuration class for the Frontend component of GlideinWMS.
 

--- a/frontend/glideinFrontendPlugins.py
+++ b/frontend/glideinFrontendPlugins.py
@@ -159,7 +159,7 @@ class CredentialsPlugin(ABC):
 class CredentialsBasic(CredentialsPlugin):
     """This plugin returns all credentials
 
-    This is can be a very useful default policy
+    This is a very useful default policy
     """
 
     def get_credential(self, cred_id, snapshot=None):
@@ -258,7 +258,11 @@ class CredentialsBasic(CredentialsPlugin):
 
 ###########################################################
 ### Proxy plugins are deprecated and should not be used ###
+## You should use plugins inheriting form CredentialsPlugin
 ###########################################################
+
+# TODO: Some of the functionalities are no more needed with the new credentials and generators
+#   other should be reviewed and implemented using the new framework
 
 
 class ProxyFirst:

--- a/frontend/glideinFrontendPlugins.py
+++ b/frontend/glideinFrontendPlugins.py
@@ -258,7 +258,7 @@ class CredentialsBasic(CredentialsPlugin):
 
 ###########################################################
 ### Proxy plugins are deprecated and should not be used ###
-## You should use plugins inheriting form CredentialsPlugin
+## You should use plugins inheriting from CredentialsPlugin
 ###########################################################
 
 # TODO: Some of the functionalities are no more needed with the new credentials and generators

--- a/lib/credentials/credentials.py
+++ b/lib/credentials/credentials.py
@@ -769,6 +769,7 @@ def create_credential_pair(
     """
 
     credential_types = [cred_type] if cred_type else CredentialPairType
+    failed_attempts = []
     for c_type in credential_types:
         try:
             credential_class = credential_of_type(c_type)
@@ -777,12 +778,16 @@ def create_credential_pair(
                 cred_args = [param.name for param in cred_args if param.name != "self"]
                 kwargs = {key: value for key, value in locals().items() if key in cred_args and value is not None}
                 return credential_class(**kwargs)
-        except CredentialError:
-            pass
+        except CredentialError as err:
+            failed_attempts.append(err)  # Likely credential type incompatible with input
         except Exception as err:
             raise CredentialError(
                 f'Unexpected error loading credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}"'
             ) from err
+    if failed_attempts:
+        raise CredentialError(
+            f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}". {len(failed_attempts)} attempts failed with CredentialError.'
+        ) from failed_attempts[-1]
     raise CredentialError(
         f'Could not load credential pair: string="{string}", path="{path}", private_string="{private_string}", private_path="{private_path}"'
     )

--- a/lib/generators/generators.py
+++ b/lib/generators/generators.py
@@ -59,7 +59,7 @@ class GeneratorContext(dict):
 
         Example:
             context.validate({
-                "user": (str),  # Mandatory string with name
+                "user": (str),  # Mandatory string with the user's name
                 "group": (str,),  # Mandatory string with group
                 "permissions": ((list, None), []),  # Optional list with permissions, defaults to empty list if missing
                                                     # If set to None, it will stay None

--- a/lib/token_util.py
+++ b/lib/token_util.py
@@ -145,7 +145,8 @@ def sign_token(identity, issuer, kid, master_key, duration=None, scope=None):
         issuer (str): The IDTOKEN issuer, typically an HTCondor Collector.
         kid (str): The Key ID.
         master_key (bytes): The encryption key.
-        duration (int, optional): Number of seconds the IDTOKEN is valid. Default is infinity (None).
+        duration (int, optional): Number of seconds the IDTOKEN is valid. Default is infinity (None or 0).
+            Negative values will generate already expired tokens.
         scope (str, optional): Permissions the IDTOKEN grants. Default is everything (None).
 
     Returns:

--- a/plugins/IdTokenGenerator.py
+++ b/plugins/IdTokenGenerator.py
@@ -28,12 +28,13 @@ class IdTokenGenerator(CredentialGenerator):
     HOSTNAME is the fully qualified domain name of the host where the token is generated, and
     NAME is the GLIDEIN_Site attribute form the resource/entry classad and configuration in the Factory, or
     the name of the resource/entry from the classad and configuration in the Factory if GLIDEIN_Site is not specified.
-    This aims to create different subjects for different resources/entries to avoid the reuse of tokes from potentially
+    This aims to create different subjects for different resources/entries to avoid the reuse of tokens from potentially
     compromised resources.
 
     The issuer defaults to the HTCondor TRUST_DOMAIN when not specified in the context.
 
     A duration of 0 seconds means that the token will never expire. A negative value will generate expired tokens.
+    None or a missing value from the context is used to load the duration via the IDTokenLifetime attribute or use the default.
     The default duration (if not in the context or IDTokenLifetime) is 24 hours.
 
     The default password file name is the username (if not in the context or IDTokenKeyname), all uppercase.
@@ -44,10 +45,10 @@ class IdTokenGenerator(CredentialGenerator):
             {
                 "password": (str, ""),
                 "scope": (str, ""),
-                "duration": (int, 0),
+                "duration": ((int, None), None),
                 "minimum_lifetime": (int, 0),
                 "identity": (str, ""),
-                "issuer": (str, None),
+                "issuer": ((str, None), None),
             }
         )
         self.context["type"] = "idtoken"
@@ -71,9 +72,10 @@ class IdTokenGenerator(CredentialGenerator):
 
         scope = self.context["scope"] or "condor:/READ condor:/ADVERTISE_STARTD condor:/ADVERTISE_MASTER"
 
-        duration = (
-            self.context["duration"] or int(kwargs["elementDescript"].merged_data.get("IDTokenLifetime", 24)) * 3600
-        )
+        # Context validation will set duration to None if missing
+        duration = self.context["duration"]
+        if duration is None:
+            duration = int(kwargs["elementDescript"].merged_data.get("IDTokenLifetime", 24)) * 3600
 
         identity = self.context["identity"]
         if not identity:


### PR DESCRIPTION
Made IdTokenGenerator more robust, using the Entry name when GLIDEIN_Site is not available
Also:
- Improved documentation of IdTokenGenerator and other components
- Improved create_credential_pair error logging, making it similar to create_credential

