### PR TITLE
Removal of deprecated type aliases in `cryptography` library

### DIFF
--- a/lib/credentials/rsa.py
+++ b/lib/credentials/rsa.py
@@ -16,7 +16,7 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
-from cryptography.hazmat.primitives.asymmetric.types import PRIVATE_KEY_TYPES, PUBLIC_KEY_TYPES
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes, PublicKeyTypes
 
 from glideinwms.lib.credentials import Credential, CredentialError, CredentialPair, CredentialPairType, CredentialType
 from glideinwms.lib.credentials.symmetric import SymmetricKey
@@ -25,7 +25,7 @@ from glideinwms.lib.defaults import force_bytes
 DEFAULT_PASSWORD = b"default"
 
 
-class RSAPublicKey(Credential[PUBLIC_KEY_TYPES]):
+class RSAPublicKey(Credential[PublicKeyTypes]):
     """Represents an RSA public key credential.
 
     Attributes:
@@ -50,7 +50,7 @@ class RSAPublicKey(Credential[PUBLIC_KEY_TYPES]):
         return self.string
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> PUBLIC_KEY_TYPES:
+    def decode(string: Union[str, bytes]) -> PublicKeyTypes:
         string = force_bytes(string)
         if string.startswith(b"ssh-rsa"):
             return serialization.load_ssh_public_key(string, backend=default_backend())
@@ -156,7 +156,7 @@ class RSAPublicKey(Credential[PUBLIC_KEY_TYPES]):
         return self.verify(data, binascii.a2b_hex(signature))
 
 
-class RSAPrivateKey(Credential[PRIVATE_KEY_TYPES]):
+class RSAPrivateKey(Credential[PrivateKeyTypes]):
     """Represents an RSA private key credential.
 
     Attributes:
@@ -200,7 +200,7 @@ class RSAPrivateKey(Credential[PRIVATE_KEY_TYPES]):
         return "RSA" if self._payload else None
 
     @staticmethod
-    def decode(string: Union[str, bytes]) -> PRIVATE_KEY_TYPES:
+    def decode(string: Union[str, bytes]) -> PrivateKeyTypes:
         string = force_bytes(string)
         if string.startswith(b"-----BEGIN OPENSSH PRIVATE KEY-----"):
             return serialization.load_ssh_private_key(string, password=None, backend=default_backend())

--- a/lib/credentials/x509.py
+++ b/lib/credentials/x509.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Optional, Union
 
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PUBLIC_KEY_TYPES
+from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 
 from glideinwms.lib.credentials import Credential, CredentialPair, CredentialPairType, CredentialType
 from glideinwms.lib.defaults import force_bytes
@@ -24,7 +24,7 @@ class X509Cert(Credential[x509.Certificate]):
         cred_type (CredentialType): The type of the credential.
         extension (str): The file extension for the credential.
         subject (Optional[str]): The subject (aka Distinguished Name (DN)) of the certificate.
-        pub_key (Optional[CERTIFICATE_PUBLIC_KEY_TYPES]): The public key of the certificate.
+        pub_key (Optional[CertificatePublicKeyTypes]): The public key of the certificate.
         not_before_time (Optional[datetime]): The not-before time of the certificate.
         not_after_time (Optional[datetime]): The not-after time of the certificate.
     """
@@ -38,7 +38,7 @@ class X509Cert(Credential[x509.Certificate]):
         return "/" + "/".join(self._payload.subject.rfc4514_string().split(",")[::-1]) if self._payload else None
 
     @property
-    def pub_key(self) -> Optional[CERTIFICATE_PUBLIC_KEY_TYPES]:
+    def pub_key(self) -> Optional[CertificatePublicKeyTypes]:
         """X.509 public key."""
         return self._payload.public_key() if self._payload else None
 


### PR DESCRIPTION
When working on #631, observed that the [pylint checks were failing](https://github.com/glideinWMS/glideinwms/actions/runs/28628366621/job/84899770576). This PR introduces a fix for the failing pylint checks.

Upon inspection, the pylint checks installed `cryptography` v49.0.0, a required dependency for GlideinWMS 3.11.x. Although type aliases were deprecated in cryptography v40.0.0 in favor of standard PascalCase naming conventions, type aliases are permanently removed starting cryptography version 49.0.0. This PR replaces the use of deprecated, all-caps aliases with its updated PascalCase equivalents. See `cryptography`'s [CHANGELOG](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#4900---2026-06-12) for details.

With regards to Python compatibility for `cryptography`, Python 3.9 or later is required starting cryptography v48.0.0, as per [their documentation](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#4800---2026-05-04). 