### PR TITLE
Added a compatibility import for the type names changed in cryptography v40+

### DIFF
--- a/lib/credentials/rsa.py
+++ b/lib/credentials/rsa.py
@@ -16,11 +16,20 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
-from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes, PublicKeyTypes
 
 from glideinwms.lib.credentials import Credential, CredentialError, CredentialPair, CredentialPairType, CredentialType
 from glideinwms.lib.credentials.symmetric import SymmetricKey
 from glideinwms.lib.defaults import force_bytes
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes, PublicKeyTypes
+except ImportError:
+    # TODO: remove try-except once cryptography>=v40. EL9 RPM has v36
+    from cryptography.hazmat.primitives.asymmetric.types import PRIVATE_KEY_TYPES, PUBLIC_KEY_TYPES
+
+    PrivateKeyTypes = PRIVATE_KEY_TYPES
+    PublicKeyTypes = PUBLIC_KEY_TYPES
+
 
 DEFAULT_PASSWORD = b"default"
 

--- a/lib/credentials/x509.py
+++ b/lib/credentials/x509.py
@@ -11,10 +11,17 @@ from datetime import datetime, timezone
 from typing import Optional, Union
 
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 
 from glideinwms.lib.credentials import Credential, CredentialPair, CredentialPairType, CredentialType
 from glideinwms.lib.defaults import force_bytes
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
+except ImportError:
+    # TODO: remove try-except once cryptography>=v40. EL9 RPM has v36
+    from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PUBLIC_KEY_TYPES
+
+    CertificatePublicKeyTypes = CERTIFICATE_PUBLIC_KEY_TYPES
 
 
 class X509Cert(Credential[x509.Certificate]):


### PR DESCRIPTION
EL9 python3-cryptography RPM includes v36 that has only the uppercase names. The try-except will allow compatibility with both new and old syntax. This can be removed once only cryptography v40+ is used