### PR TITLE
Changing `run_with_timeout`'s default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes since the last release
 
 ### Changed defaults / behaviours
 
+-   Changed the default value for custom scripts timeout to 0 seconds. This also changes the default behavior for the execution of custom scripts to not time out; from timing out after 600s to not using a timeout value. When custom scripts timeout value is non-zero, the behavior remains unchanged, i.e. after timing out, scripts are killed with SIGTERM followed by SIGKILL (PR #688)
+
 ### Deprecated / removed options and commands
 
 ### Security Related Fixes

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -16,7 +16,7 @@
 #LOGFILE="cvmfs_all.log"
 #exec &> $LOGFILE
 
-# Using run_with_timeout from glidein_paths.source sourced in glidein_startup.sh
+# Can use run_with_timeout from glidein_paths.source sourced in glidein_startup.sh to enable watchdog timer for sites where glidein enters a hanging state during pre-requisite system checks for on-demand CVMFS setup.
 
 variables_reset() {
 	# DESCRIPTION: This function lists and initializes the common variables
@@ -106,7 +106,9 @@ detect_local_cvmfs() {
 	CVMFS_ROOT="/cvmfs"
 	repo_name=oasis.opensciencegrid.org
 	# Second check...
-	if [[ -f "$CVMFS_ROOT/$repo_name"/.cvmfsdirtab || "$(run_with_timeout -s KILL 120 ls -A "$CVMFS_ROOT/$repo_name")" ]] &>/dev/null
+    # uncomment the following line instead to enable the use of watchdog timer
+    # if [[ -f "$CVMFS_ROOT/$repo_name"/.cvmfsdirtab || "$(run_with_timeout -s KILL 0 ls -A "$CVMFS_ROOT/$repo_name")" ]] &>/dev/null
+	if [[ -f "$CVMFS_ROOT/$repo_name"/.cvmfsdirtab || "$(ls -A "$CVMFS_ROOT/$repo_name")" ]] &>/dev/null
 	then
 		loginfo "Validating CVMFS with ${repo_name}..."
 		true
@@ -177,7 +179,9 @@ perform_system_check() {
     unshare -U true &>/dev/null
     GWMS_IS_UNPRIV_USERNS_ENABLED=$?
 
-    run_with_timeout -s KILL 120 check_fuse_installed
+    # uncomment the following line to enable the use of watchdog timer
+    # run_with_timeout -s KILL 0 check_fuse_installed
+    check_fuse_installed
     GWMS_IS_FUSE_INSTALLED=$?
 
     if [[ $GWMS_OS_VERSION_MAJOR -ge 9 ]]; then

--- a/creation/web_base/glidein_paths.source
+++ b/creation/web_base/glidein_paths.source
@@ -27,12 +27,12 @@ robust_realpath() {
     fi
 }
 
-run_with_timeout () {
+run_with_timeout() {
     # run_with_timeout [-s SIGNAL] [TIMEOUT] command, options and arguments (order is important)
     # if $1=-s, $2 signal to use to kill after timeout (otherwise the next will be $1)
     # $3 timeout (if numeric, otherwise the next is $1/$3)
     # $4 - command and arguments
-    local timeout=10
+    local timeout=0
     local sig=TERM
     if [[ $1 = "-s" ]]; then sig=$2; shift 2; fi
     if [[ $1 =~ ^[0-9]+$ ]]; then timeout=$1; shift; fi

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -37,7 +37,7 @@ GWMS_MULTIUSER_GLIDEIN=
 # This should never happen only when using GlExec. Not in Singularity, not w/o sudo mechanisms.
 # Comment the following line if GlExec or similar will not be used
 #GWMS_MULTIUSER_GLIDEIN=true
-GWMS_CUSTOM_SCRIPTS_TIMEOUT=600
+GWMS_CUSTOM_SCRIPTS_TIMEOUT=0
 # Default GWMS log server
 GWMS_LOGSERVER_ADDRESS='https://fermicloud152.fnal.gov/log'
 

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -1442,7 +1442,16 @@ MAX_STARTD_LOG          I       10000000        +                               
                 Timeout in seconds for the custom scripts executed by the
                 Glidein. The script is killed with SIGTERM after timeout seconds
                 are passed. It is not guaranteed for the script to quit given
-                the signal used. 0 means no timeout.
+                the signal used. Default value is 0, which translates to no
+                timeout.<br /><br />
+
+                This variable allows the timeout value used by the Glidein
+                startup script to be configured. By default, the script uses the
+                hardcoded GWMS_CUSTOM_SCRIPTS_TIMEOUT value. When
+                GLIDEIN_CUSTOM_SCRIPTS_TIMEOUT is defined in the configuration,
+                its value is used to evaluate and set
+                GWMS_CUSTOM_SCRIPTS_TIMEOUT at runtime, overriding the default
+                hardcoded value. <b>Must be a parameter.</b>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
The `run_with_timeout` function was introduced as a watchdog timer recently as Jeff Dost (Factory Ops) and Mats Rynge (Frontend Ops) had encountered a situation where the execution of `cvmfs_helper_funcs.sh` was found hanging on a site (prior to the timeout function being added) which was resulting in all the Glideins to fail.

The idea behind the timeout function is as follows:
* if the command supplied to the `run_with_timeout function` takes long to run and does not complete within the set timeout, then the command execution is killed.
* if the command supplied to the `run_with_timeout function` does not take too long to run and it completes within the set timeout, then the program execution flow resumes.

The watchdog timer is a parallel process and does not interfere with the execution flow. Just the invocation of the watchdog timer is something that is added to the regular flow. However, in at least two instances with a 3.11.4 factory, it was observed that the execution of `cvmfs_helper_funcs.sh` and `cvmfs_setup.sh` resulted in an unusually long delay in completing the execution of these scripts. 

As part of troubleshooting the long delay problem, it was found that removing the `run_with_timeout` invocations as well as disabling the invocations by setting the timeout to 0, there were no delays seen. In contrast, when the timeout function was present, delays were observed.

With the watchdog timer's timeout set to 120 seconds, an interesting behavior was observed -- Upon tracking the timestamps before and after the timer function invocations, when the watchdog timer function is invoked inside `detect_local_cvmfs` function, the following was seen:
```
Mon Jul 20 23:46:15 UTC 2026
Mon Jul 20 23:48:15 UTC 2026
```
which shows a timeout of 120 seconds.

But, with the watchdog timer function invoked in `perform_system_check` function, the following was seen:
```
Mon Jul 20 23:48:15 UTC 2026
Mon Jul 20 23:48:15 UTC 2026
```

Rather than completely removing the timeout, this PR changes the default from 120 seconds to timeout disabled. We found that it will be useful to leave the code in there in case it's needed since the operators can enable the timeout and further investigation can be conducted, should the problem of hanging sites is ever encountered.

