### PR TITLE
Change IDTOKENS_FILE to point to path in glidein and unset JOB_TOKENS

### DIFF
--- a/creation/lib/cgWCreate.py
+++ b/creation/lib/cgWCreate.py
@@ -185,9 +185,6 @@ class GlideinSubmitDictFile(cgWDictFile.CondorJDLDictFile):
                 enc_input_files.append(token_tgz_file)
                 token_list.append(token_tgz_file)
 
-        if token_list:
-            self.add_environment("JOB_TOKENS='" + ",".join(token_list) + "'")
-
         # Get the list of log recipients specified from the Factory for this entry
         factory_recipients = get_factory_log_recipients(entry)
         frontend_recipients = []  # TODO: change when adding support for LOG_RECIPIENTS_CLIENT

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -2134,8 +2134,6 @@ done
 # changes we need to show up in the job here
 # 1. Need IDTOKENS_FILE to be set to the correct path of the idtokens file in the glidein
 export IDTOKENS_FILE=$(gconfig_get GLIDEIN_CONDOR_TOKEN "${glidein_config}")
-# 2. At this point, JOB_TOKENS points at a file that's not accessible from the glidein, so just unset it.
-unset JOB_TOKENS
 
 ##############################
 # Start the glidein main script

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -2134,6 +2134,8 @@ done
 # changes we need to show up in the job here
 # 1. Need IDTOKENS_FILE to be set to the correct path of the idtokens file in the glidein
 export IDTOKENS_FILE=$(gconfig_get GLIDEIN_CONDOR_TOKEN "${glidein_config}")
+# 2. At this point, JOB_TOKENS points at a file that's not accessible from the glidein, so just unset it.
+unset JOB_TOKENS
 
 ##############################
 # Start the glidein main script

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -2144,7 +2144,6 @@ glog_write "glidein_startup.sh" "file" "${glidein_config}" "debug"
 if ! glog_send; then          # checkpoint
     echo "Failed to checkpoint Glidein Logging"
 fi
-
 echo "# --- Last Script values ---" >> "${glidein_config}"
 last_startup_time=$(date +%s)
 ((validation_time=last_startup_time-startup_time)) || true

--- a/creation/web_base/glidein_startup.sh
+++ b/creation/web_base/glidein_startup.sh
@@ -2130,6 +2130,11 @@ do
     fi
 done
 
+# At this point, all of the file except for the glidein main script have been executed.  Make any environment
+# changes we need to show up in the job here
+# 1. Need IDTOKENS_FILE to be set to the correct path of the idtokens file in the glidein
+export IDTOKENS_FILE=$(gconfig_get GLIDEIN_CONDOR_TOKEN "${glidein_config}")
+
 ##############################
 # Start the glidein main script
 gconfig_add "GLIDEIN_INITIALIZED" "1"
@@ -2139,6 +2144,7 @@ glog_write "glidein_startup.sh" "file" "${glidein_config}" "debug"
 if ! glog_send; then          # checkpoint
     echo "Failed to checkpoint Glidein Logging"
 fi
+
 echo "# --- Last Script values ---" >> "${glidein_config}"
 last_startup_time=$(date +%s)
 ((validation_time=last_startup_time-startup_time)) || true


### PR DESCRIPTION
Closes #281 .

1. This PR changes the value of the environment variable `IDTOKENS_FILE` in the glidein (and payload job) to point to the location in the glidein of the IDTOKEN.  Since it is identical to the already-existing value `GLIDEIN_CONDOR_TOKEN`, `IDTOKENS_FILE` just points there.
2. `JOB_TOKENS` is currently set to point to the tarball containing all the tokens in the glidein before it is unpacked.  The glidein startup script deletes that tarball, so there is no reason for the running glidein or the payload job to have that value set.  This PR unsets `JOB_TOKENS` upon glidein startup.

Validated by running job from workspace containers (https://github.com/glideinWMS/containers/tree/main/workspaces) with modified code, and inspecting glidein logs and job stdout.