### PR TITLE
Harden IdTokenGenerator identity fallback

### DIFF
--- a/plugins/IdTokenGenerator.py
+++ b/plugins/IdTokenGenerator.py
@@ -79,11 +79,22 @@ class IdTokenGenerator(CredentialGenerator):
 
         identity = self.context["identity"]
         if not identity:
+            glidein_el = kwargs.get("glidein_el")
+            kwargs_keys = sorted(kwargs.keys())
+            glidein_el_keys = sorted(glidein_el.keys()) if isinstance(glidein_el, dict) else None
             try:
-                identity = f"{kwargs['glidein_el']['attrs']['GLIDEIN_Site']}@{socket.gethostname()}"
-            except KeyError:
-                # GLIDEIN_Site is not mandatory, the name is
-                identity = f"{kwargs['glidein_el']['name']}@{socket.gethostname()}"
+                # GLIDEIN_Site is optional. Fall back to EntryName, then legacy top-level name.
+                attrs = glidein_el["attrs"]
+                identity_name = attrs.get("GLIDEIN_Site") or attrs.get("EntryName") or glidein_el.get("name")
+                if not identity_name:
+                    raise KeyError("GLIDEIN_Site/EntryName/name")
+                identity = f"{identity_name}@{socket.gethostname()}"
+            except Exception as err:
+                raise RuntimeError(
+                    "Unable to determine IDTOKEN identity from kwargs['glidein_el']. "
+                    f"Received kwargs keys={kwargs_keys}, "
+                    f"glidein_el keys={glidein_el_keys}, glidein_el={glidein_el!r}"
+                ) from err
 
         minimum_lifetime = self.context["minimum_lifetime"] or 0
 


### PR DESCRIPTION
## Summary
- handle missing GLIDEIN_Site without crashing
- use attrs.EntryName as fallback before legacy top-level name
- raise a clearer RuntimeError with kwargs and glidein_el debug context when identity cannot be derived

## Root Cause
IdTokenGenerator assumed that if attrs.GLIDEIN_Site is missing, a top-level name exists. In the frontend flow, attrs.EntryName is commonly present while top-level name may be absent.

## Change
Updated identity derivation in plugins/IdTokenGenerator.py:
- identity_name = attrs.get("GLIDEIN_Site") or attrs.get("EntryName") or glidein_el.get("name")
- if all are missing, raise RuntimeError with:
  - kwargs keys
  - glidein_el keys
  - full glidein_el representation

## Validation
- syntax and workspace diagnostics checked for the modified file

Fixes #693