### PR TITLE
Fixed reference to Entry name in entry dictionary, bug introduced in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes since the last release
 
 -   Python Cryptography changed some type names spelling. Added import statements to be compatible with both old and new spellings (PR #683, PR #687)
 -   Fixed `populate_group_security` in the configuration management to work with the new credentials and to handle correctly proxy ID lists for X509 DN extraction (PR #640)
+-   Fixed bug in IdTokenGenerator introduced in PR #667 (PR #702)
 
 ### Testing / Development
 

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -308,9 +308,26 @@ def findGlideinClientMonitoring(factory_pool, factory_identity, my_name, additio
     return format_condor_dict(data)
 
 
+# TODO: This function deletes some elements form the input, then it makes a copy possibly not to delete those
+#  elements form the sub-dictionaries. This seems inconsistent. Check if input can be freely modified.
 def format_condor_dict(data):
-    """
-    Formats the data from the condor call.
+    """Formats the data from the condor call in a new dictionary.
+
+    It strips the names in frontendConfig.condor_reserved_names in the base and sub-dictionaries.
+    The stripping from `data` modifies the input parameter itself.
+    Then it splits the ClassAd attributes in 3 sub-dictionaries:
+    - the ones starting with frontendConfig.glidein_param_prefix are in `["params"]`
+    - the ones starting with frontendConfig.glidein_monitor_prefix are in `["monitor"]`
+    - all the others in `["attrs"]
+    The sub-dictionaries returned are a copy of the input sub-dictionaries.
+    Note that it is not a deepcopy because the components are not modified.
+
+    Args:
+        data (dict): The glidefactory ClassAd data returned from condor status
+
+    Returns:
+        dict: A formatted dictionary of the Entry data. It has 3 sub-dictionaries: params, monitor, and attrs.
+
     """
 
     reserved_names = frontendConfig.condor_reserved_names

--- a/plugins/IdTokenGenerator.py
+++ b/plugins/IdTokenGenerator.py
@@ -79,11 +79,18 @@ class IdTokenGenerator(CredentialGenerator):
 
         identity = self.context["identity"]
         if not identity:
+            # Prefer optional "GLIDEIN_Site", otherwise use "EntryName" (always there, added from the Entry name)
             try:
                 identity = f"{kwargs['glidein_el']['attrs']['GLIDEIN_Site']}@{socket.gethostname()}"
             except KeyError:
-                # GLIDEIN_Site is not mandatory, the name is
-                identity = f"{kwargs['glidein_el']['name']}@{socket.gethostname()}"
+                try:
+                    # If there is an exception here, this should propagate and crash the execution
+                    identity = f"{kwargs['glidein_el']['attrs']['EntryName']}@{socket.gethostname()}"
+                except Exception as err:
+                    raise RuntimeError(
+                        "Unable to determine Entry identity in IdToken generation due to malformed"
+                        " glidefactory ClassAd or bad generator invocation."
+                    ) from err
 
         minimum_lifetime = self.context["minimum_lifetime"] or 0
 


### PR DESCRIPTION
Fixes the IdTokenGenerator Entry Name reference. This bug was introduced in PR #667.
The Entry name can be referred as `entry['attrs']['EntryName']`, not `entry['name']`.

Also:
- Raises a more clearer RuntimeError in case of errors.
- Improves also the glidefactory ClassAd parsing function docstring.

This PR supersedes #694 PR, fixes #693 issue
