### PR TITLE
Retrieving GLIDEIN_SINGULARITY_BINDPATHs from glidein_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ Changes since the last release
 
 ### New features / functionalities
 
--   item one of the list
--   item N
-
 ### Changed defaults / behaviours
 
 ### Deprecated / removed options and commands
@@ -21,6 +18,8 @@ Changes since the last release
 ### Bug Fixes
 
 -   Fix incorrect Arch requirement for ARM pilots (Issue #661, PR #662)
+-   Sanitize cvmfs repos list to protect against Arbitrary Code Execution attack (PR #678)
+-   Retrieve GLIDEIN_SINGULARITY_BINDPATH from glidein_config instead of the environment so it is not ignored (Issue #703, PR #704)
 
 ### Testing / Development
 

--- a/creation/web_base/singularity_lib.sh
+++ b/creation/web_base/singularity_lib.sh
@@ -1202,14 +1202,17 @@ singularity_get_binds() {
     local retv=  # default controlled from outside ($2)
     local checks=$1
 
-    # Get singularity binds from GLIDEIN_SINGULARITY_BINDPATH, GLIDEIN_SINGULARITY_BINDPATH_DEFAULT,
+    # Get singularity binds from glidein_config (GLIDEIN_SINGULARITY_BINDPATH, GLIDEIN_SINGULARITY_BINDPATH_DEFAULT),
     # invoker adds default /cvmfs (via $2),
     # add overrides, and remove non existing src (checks=e) - if src is not existing Singularity will error (not run)
-
-    info_dbg "Singularity binds: OVERRIDE:$3, BINDPATH:$GLIDEIN_SINGULARITY_BINDPATH, BINDPATH_DEFAULT:$GLIDEIN_SINGULARITY_BINDPATH_DEFAULT, DEFAULT:$2, CHECKS($checks)"
+    local singularity_bindpath
+    local singularity_bindpath_default
+    singularity_bindpath=$(gwms_from_config GLIDEIN_SINGULARITY_BINDPATH)
+    singularity_bindpath_default=$(gwms_from_config GLIDEIN_SINGULARITY_BINDPATH_DEFAULT)
+    info_dbg "Singularity binds: OVERRIDE:$3, BINDPATH:$singularity_bindpath, BINDPATH_DEFAULT:$singularity_bindpath_default, DEFAULT:$2, CHECKS($checks)"
     [[ -n "$3" ]] && retv="${retv}$3,"
-    [[ -n "$GLIDEIN_SINGULARITY_BINDPATH" ]] && retv="${retv}$GLIDEIN_SINGULARITY_BINDPATH,"
-    [[ -n "$GLIDEIN_SINGULARITY_BINDPATH_DEFAULT" ]] && retv="${retv}$GLIDEIN_SINGULARITY_BINDPATH_DEFAULT,"
+    [[ -n "$singularity_bindpath" ]] && retv="${retv}$singularity_bindpath,"
+    [[ -n "$singularity_bindpath_default" ]] && retv="${retv}$singularity_bindpath_default,"
     [[ -n "$2" ]] && retv="${retv}$2"
 
     # Check all mount points


### PR DESCRIPTION
Retrieving GLIDEIN_SINGULARITY_BINDPATH and GLIDEIN_SINGULARITY_BINDPATH_DEFAULT from glidein_config instead of the environment. 
This way both are always used in both jobs and custom scripts, not just when in the environment.

This fixes #703 