### PR TITLE
Improve troubleshooting of request credentials match

### DIFF
--- a/frontend/glideinFrontendConfig.py
+++ b/frontend/glideinFrontendConfig.py
@@ -492,6 +492,7 @@ class ElementMergedDescript:
         frontend_data (dict): The frontend configuration data loaded from the `FrontendDescript` class.
         element_data (dict): The element configuration data for the specified group loaded from the `ElementDescript` class.
         group_name (str): The name of the group being configured.
+        merged_data (dict): The combined group and global configuration data. Added by `self._merge()` invoked during initialization.
     """
 
     def __init__(self, base_dir, group_name):

--- a/frontend/glideinFrontendInterface.py
+++ b/frontend/glideinFrontendInterface.py
@@ -23,6 +23,8 @@ from glideinwms.lib import (
 from glideinwms.lib.credentials import AuthenticationMethod, CredentialPurpose, SymmetricKey, x509
 from glideinwms.lib.util import hash_nc
 
+# from glideinwms.tools.wmsXMLView import entry_name  - commented because unused
+
 ############################################################
 #
 # Configuration
@@ -1165,7 +1167,7 @@ class MultiAdvertiseWork:
             glidein_params (dict, optional): The parameters associated with the Glidein. Defaults to an empty dictionary.
             glidein_monitors (dict, optional): The monitoring parameters for the Glidein. Defaults to an empty dictionary.
             glidein_monitors_per_cred (dict, optional): Monitoring parameters for each credential. Defaults to an empty dictionary.
-            key_obj (FactoryKeys4Advertise, optional): The key object used for advertising the Glidein. Defaults to None.
+            key_obj (FactoryKeys4Advertise, optional): The key object used for encryption when advertising the Glidein. Defaults to None.
             glidein_params_to_encrypt (dict, optional): The parameters to encrypt. Defaults to None.
             security_name (str, optional): The security name associated with the request. Defaults to None.
             remove_excess_str (str, optional): The strategy for handling excess Glideins. Defaults to None.
@@ -1419,13 +1421,25 @@ class MultiAdvertiseWork:
     def do_advertise_one(
         self, factory_pool, file_id_cache=None, adname=None, create_files_only=False, reset_unique_id=True
     ):
-        """
-        Do the advertising of requests for one factory
+        """Do the advertising of requests for one Factory
+
+        Consider the requests for one Factory.
+        Create the ClassAd files for the requests via createAdvertiseWorkFile, handle the exceptions if needed,
+        remove the requests from the queue, advertise via HTCondor if desired.
+
         Returns the list of files that still need to be advertised.
         Expects that the credentials have already been loaded.
+
+        Args:
+            factory_pool (str): The factory pool to use
+            file_id_cache (CredentialCache, optional): A CredentialCache. Defaults to None.
+            adname (str, optional): The name of the ClassAd file name. Defaults to None (generated in the function)
+            create_files_only (bool, optional): Skip the HTCondor advertising if True. Defaults to False
+            reset_unique_id (bool, optional): If True, reset the unique_id to 1. Defaults to True
+
+        Returns:
+            list: list of files that still need to be advertised.
         """
-        # the different indentation is due to code refactoring
-        # this way the diff was minimized
         if factory_pool not in list(self.factory_queue.keys()):
             # nothing to be done, prevent failure
             return []
@@ -1445,6 +1459,7 @@ class MultiAdvertiseWork:
         if frontendConfig.advertise_use_multi:
             filename_arr.append(self.adname)
         for el in self.factory_queue[factory_pool]:
+            # Loop through the requests for this Factory (list of tuples AdvertiseParams, FactoryKeys4Advertise)
             params_obj, key_obj = el
             try:
                 filename_arr_el = self.createAdvertiseWorkFile(
@@ -1456,9 +1471,31 @@ class MultiAdvertiseWork:
             except NoCredentialException:
                 filename_arr = []  # don't try to advertise
                 logSupport.log.warning(
-                    "No security credentials match for factory pool %s, not advertising request;"
-                    " if this is not intentional, check for typos frontend's credential "
-                    "trust_domain and type, vs factory's pool trust_domain and auth_method" % factory_pool
+                    f"No usable security credentials for factory pool {factory_pool}, not advertising request;"
+                    " this may be a trust_domain/type mismatch, or invalid credentials (e.g. expired token/proxy), or missing parameter."
+                    " Check frontend credentials trust_domain/type against factory trust_domain/auth_method and credentials validity"
+                )
+                # TODO: cred, the credential in request_credentials (debug_str) did not specify the snapshot (entry), so the message may be incomplete
+                #   what happens if no snapshot is specified in the credential?
+                request_credentials_debug_summary = (
+                    ";".join([i.debug_str() for i in self.request_credentials]) or "<no credentials>"
+                )
+                req_name = params_obj.request_name
+                factory_trust, factory_auth = self.factory_constraint.get(req_name, ("<unknown>", "<unknown>"))
+                logSupport.log.debug(
+                    "Credential debug for request '%s': required trust_domain=%s auth_method=%s; loaded request credentials: %s"
+                    % (req_name, factory_trust, factory_auth, request_credentials_debug_summary)
+                )
+                entry_name = params_obj.glidein_name.split("@")[0]
+                snapshots_list = ";".join(
+                    [
+                        self.descript_obj.credentials_plugin.get_credential(i.credenial.id, entry_name).debug_str()
+                        for i in self.request_credentials
+                    ]
+                )
+                logSupport.log.debug(
+                    "Credential debug for request '%s': entry=%s, required trust_domain=%s auth_method=%s; loaded request credential snapshots: %s"
+                    % (req_name, entry_name, factory_trust, factory_auth, snapshots_list)
                 )
             except condorExe.ExeError:
                 filename_arr = []  # don't try to advertise
@@ -1519,12 +1556,26 @@ class MultiAdvertiseWork:
         logSupport.log.debug(f"Found {prefix} = {values[0]} from file {filename}")
         return values[0]
 
+    # TODO: verify that createAdvertiseWorkFile is correct. Names and function content seem to have inconsistencies
     def createAdvertiseWorkFile(self, factory_pool, params_obj, key_obj=None, file_id_cache=None):
-        """Create the advertise file
+        """Create the advertise (ClassAd) file
 
         Expects the object variables, adname, unique_id and x509_proxies_data to be set.
-        """
 
+        Args:
+            factory_pool (str): The factory pool to advertise (name used only when logging errors)
+            params_obj (AdvertiseParams): The parameters to advertise (from the queue of factory_pool)
+            key_obj (FactoryKeys4Advertise, optional): The key object used for advertising the Glidein.
+                Defaults to None. If missing, the parameters to encrypt cannot be encrypted and are missing.
+            file_id_cache (dict): Not used
+
+        Returns:
+            list: list of ClassAd files which include credentials among other things
+
+        Raises:
+            NoCredentialException: if there are no request credentials at all or if none of these match
+                the Factory Entry requirements
+        """
         cred_filename_arr = []
 
         logSupport.log.debug("In create Advertise work")
@@ -1540,10 +1591,34 @@ class MultiAdvertiseWork:
         auth_set = factory_auth.match(self.descript_obj.credentials_plugin.security_bundle)
         if not auth_set:
             logSupport.log.debug(
-                f'The available credentials do not match the requirements of factory pool {factory_pool} entry "{params_obj.request_name}". Not advertising request. '
-                f"Available credentials: {str(self.descript_obj.credentials_plugin.security_bundle)} "
+                f'The available and valid credentials do not match the requirements of factory pool {factory_pool} entry "{params_obj.request_name}". Not advertising request. '
+                f"Available valid credentials and parameters: {str(self.descript_obj.credentials_plugin.security_bundle)} "
                 f"Required credentials: {str(factory_auth)}"
             )
+
+            # TODO: cred, the credential in request_credentials (debug_str) did not specify the snapshot (entry), so the message may be incomplete
+            #   what happens if no snapshot is specified in the credential?
+            request_credentials_debug_summary = (
+                ";".join([i.debug_str() for i in self.request_credentials]) or "<no credentials>"
+            )
+            req_name = params_obj.request_name
+            factory_trust, factory_auth = self.factory_constraint.get(req_name, ("<unknown>", "<unknown>"))
+            logSupport.log.debug(
+                "Credential debug for request '%s': required trust_domain=%s auth_method=%s; loaded request credentials: %s"
+                % (req_name, factory_trust, factory_auth, request_credentials_debug_summary)
+            )
+            entry_name = params_obj.glidein_name.split("@")[0]
+            snapshots_list = ";".join(
+                [
+                    self.descript_obj.credentials_plugin.get_credential(i.credenial.id, entry_name).debug_str()
+                    for i in self.request_credentials
+                ]
+            )
+            logSupport.log.debug(
+                "Credential debug for request '%s': entry=%s, required trust_domain=%s auth_method=%s; loaded request credential snapshots: %s"
+                % (req_name, entry_name, factory_trust, factory_auth, snapshots_list)
+            )
+
             raise NoCredentialException
         params_obj.glidein_params_to_encrypt["AuthSet"] = pickle.dumps(auth_set)
 
@@ -1699,6 +1774,9 @@ class MultiAdvertiseWork:
                 # TODO: Should we revert the changes done to advertiseGCCounter[classad_name]?
 
             cred_filename_arr.append(fname)
+
+            # TODO: Confusing multiple elements: fname is a ClassAd file that can contain multiple credentials
+            #       cred_filename_arr is an array of ad files which include credentials among other things
 
             logSupport.log.debug(
                 f"Advertising credential {cred.path} "  # type: ignore[attr-defined]

--- a/frontend/glideinFrontendPlugins.py
+++ b/frontend/glideinFrontendPlugins.py
@@ -833,7 +833,15 @@ def createCredentialList(elementDescript):
 
 
 def createRequestBundle(elementDescript):
-    """Creates a list of Credentials for a proxy plugin"""
+    """Creates a list of Credentials for a proxy plugin
+
+    Args:
+        elementDescript (dict): The combined group+global Frontend configuration
+            as stored in glideinFrontendConfig.ElementMergedDescript.merged_data
+
+    Returns:
+        SecurityBundle: the combined list of Credentials
+    """
     security_bundle = SecurityBundle()
     security_bundle.load_from_element(elementDescript)
     return security_bundle

--- a/lib/credentials/credentials.py
+++ b/lib/credentials/credentials.py
@@ -210,7 +210,39 @@ class Credential(ABC, Generic[T]):
             self.load(string, path, secret)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(string={self.string!r}, path={self.path!r}, purpose={self.purpose!r}, trust_domain={self.trust_domain!r}, security_class={self.security_class!r})"
+        return f"{self.__class__.__name__}(string={self.string!r}, path={self.path!r}, secret={self.secret!r}, purpose={self.purpose!r}, trust_domain={self.trust_domain!r}, security_class={self.security_class!r})"
+
+    def debug_str(self) -> str:
+        """Returns a string representation of the credential for debugging.
+
+        This method is safe from exception, so it may be used in error messages without the risk to mask exceptions.
+        This method is also safe for logging, no secure content is printed.
+
+        Returns:
+            str: The string representation of the credential, including ID and validity but excluding class,
+                string and secret (safe for logging).
+        """
+        try:
+            cred_id = self.id
+        except CredentialError:
+            cred_id = "<credential not initialized>"
+        try:
+            invalid_reason = self.invalid_reason()
+            valid = self.valid
+        except Exception as err:
+            # invalid_reason() may be complex, protecting against possible bugs raising exceptions
+            invalid_reason = f"<error: {err}>"
+            valid = False
+        return "id={id},class={cla},path={path},type={typ},trust_domain={trust},purpose={purpose},valid={valid},invalid_reason={reason}".format(
+            id=cred_id,
+            cla=self.__class__.__name__,
+            path=getattr(self, "path", "<unavailable>"),
+            typ=getattr(self, "cred_type", "<unavailable>"),
+            trust=getattr(self, "trust_domain", "<unavailable>"),
+            purpose=getattr(self, "purpose", "<unavailable>"),
+            valid=valid,
+            reason=invalid_reason,
+        )
 
     def __str__(self) -> str:
         return self.string.decode() if self.string else ""
@@ -332,6 +364,8 @@ class Credential(ABC, Generic[T]):
     @abstractmethod
     def invalid_reason(self) -> Optional[str]:
         """Checks the validity of the credential and returns the reason why the credential is invalid.
+
+        This method should be safe. If an exception is raised, the credential code has a bug to fix.
 
         Returns:
             str or None: The reason why the credential is invalid. None if the credential is valid.
@@ -710,6 +744,18 @@ class RequestCredential:
 
     def get_usage_details(self):
         return self.req_idle, self.req_max_run
+
+    def debug_str(self) -> str:
+        """Returns a string representation of the request credential for debugging.
+
+        This method is safe from exception, so it may be used in error messages without the risk to mask exceptions.
+        This method is also safe for logging, no secure content is printed.
+
+        Returns:
+            str: The string representation of the request credential, including debug representation of the credential
+        """
+        cred = self.credential._debug_str() if self.credential else "<undefined credential>"
+        return f"{cred},advertise={self.advertise}"
 
 
 def credential_type_from_string(string: str) -> Union[CredentialType, CredentialPairType]:

--- a/lib/credentials/tokens.py
+++ b/lib/credentials/tokens.py
@@ -42,18 +42,39 @@ class Token(Credential[Mapping]):
 
     @property
     def issue_time(self) -> Optional[datetime]:
-        """Token issue time."""
-        return datetime.fromtimestamp(self._payload.get("iat", None)) if self._payload else None
+        """Token issue time. None if the token is undefined or the claim not defined"""
+        if not self._payload:
+            return None
+        try:
+            return datetime.fromtimestamp(self._payload["iat"])
+        except (KeyError, TypeError, ValueError, OverflowError, OSError):
+            # KeyError if the claim is not defined in the token
+            # The other 4 errors are for invalid values or OS misconfigurations (from datetime.fromtimestamp)
+            return None
 
     @property
     def not_before_time(self) -> Optional[datetime]:
-        """Token not-before time."""
-        return datetime.fromtimestamp(self._payload.get("nbf", None)) if self._payload else None
+        """Token not-before time. None if the token is undefined or the claim not defined"""
+        if not self._payload:
+            return None
+        try:
+            return datetime.fromtimestamp(self._payload["nbf"])
+        except (KeyError, TypeError, ValueError, OverflowError, OSError):
+            # KeyError if the claim is not defined in the token
+            # The other 4 errors are for invalid values or OS misconfigurations (from datetime.fromtimestamp)
+            return None
 
     @property
     def expiration_time(self) -> Optional[datetime]:
-        """Token expiration time."""
-        return datetime.fromtimestamp(self._payload.get("exp", None)) if self._payload else None
+        """Token expiration time. None if the token is undefined or the claim not defined"""
+        if not self._payload:
+            return None
+        try:
+            return datetime.fromtimestamp(self._payload["exp"])
+        except (KeyError, TypeError, ValueError, OverflowError, OSError):
+            # KeyError if the claim is not defined in the token
+            # The other 4 errors are for invalid values or OS misconfigurations (from datetime.fromtimestamp)
+            return None
 
     @property
     def _id_attribute(self) -> Optional[str]:
@@ -80,9 +101,9 @@ class Token(Credential[Mapping]):
 
         Following are the reasons for an invalid token:
         1. Token was not initialized
-        2. Token is not yet valid
-        3. Expired token
-        4. Lifetime of the token is too short.
+        2. Token is not yet valid (if not_before_time is provided)
+        3. Expired token (if expiration_time is provided)
+        4. Lifetime of the token is too short (if expiration_time is provided).
 
         Note: This function checks only the validity of the credential but does not perform verification of the credential.
 
@@ -91,12 +112,13 @@ class Token(Credential[Mapping]):
         """
         if not self._payload:
             return "Token not initialized."
-        if datetime.now() < self.not_before_time:
+        if self.not_before_time is not None and datetime.now() < self.not_before_time:
             return "Token not yet valid."
-        if datetime.now() > self.expiration_time:
-            return "Token expired."
-        if (self.expiration_time - datetime.now()).total_seconds() < self.minimum_lifetime:
-            return "Token lifetime too short."
+        if self.expiration_time is not None:
+            if datetime.now() > self.expiration_time:
+                return "Token expired."
+            if (self.expiration_time - datetime.now()).total_seconds() < self.minimum_lifetime:
+                return "Token lifetime too short."
         return None  # no reason for invalidity found, so credential is valid
 
 

--- a/lib/credentials/utils.py
+++ b/lib/credentials/utils.py
@@ -28,7 +28,9 @@ from glideinwms.lib.credentials import (
 
 
 class SecurityBundle:
-    """Represents a security bundle used for submitting jobs.
+    """Represents a security bundle with credentials and parameters used for submitting jobs.
+
+    This is coming from the client (Frontend) and is forwarded to the Factory
 
     Attributes:
         credentials (CredentialDict): The credentials in the security bundle.
@@ -60,10 +62,13 @@ class SecurityBundle:
         self.parameters.add(parameter)
 
     def load_from_element(self, element_descript):
-        """Load the security bundle from an element descriptor.
+        """Load the security bundle from a client (Frontend) Element descriptor (group+global configuration).
 
         Args:
-            element_descript (ElementDescriptor): The element descriptor to load from.
+            element_descript (dict): The Frontend element and global configuration to load the credentials from.
+                As in glideinFrontendConfig.ElementMergedDescript.merged_data.
+                The credentials absfnames (path or generator class) are stored in the "Proxies" list.
+                Everything else is stored in dictionaries (one per attribute) keyed by absfname
         """
 
         for path in element_descript["Proxies"]:
@@ -88,6 +93,7 @@ class SecurityBundle:
                     context=context,
                 )
             else:
+                # Assuming CredentialPair
                 cred_key = element_descript["ProxyKeyFiles"].get(path, None)
                 credential = create_credential_pair(
                     path=path,
@@ -115,6 +121,13 @@ class SecurityBundle:
         return f"SecurityBundle(credentials={self.credentials}, parameters={self.parameters})"
 
     def __str__(self):
+        """Return a comma separated string with all the credentials and parameters types.
+
+        The format is "<cred_type>" and "<param_name>(<param_type>)"
+
+        Returns:
+            str: A comma separated string with all the credentials and parameters types
+        """
         cred_types = [f"{cred.cred_type:s}" for cred in self.credentials.values()]
         cred_types += [f"{param.name:s}({param.param_type:s})" for param in self.parameters.values()]
         return f"[{','.join(cred_types)}]"


### PR DESCRIPTION
This PR improves the misleading warning in `do_advertise_one()` mentioning the possibility of expired credentials as culprit for the failure to find request credentials for a given request.

It also fixes the JWT credential that could throw exceptions due to missing claims when checking its validity.

Furthermore it improves the docstrings in `glideinFrontendLibrary.py`

This fixes #695 and supersedes #696 and #705

It is currently in draft, while deciding if the debug messages should be moved to `createAdvertiseWorkFile()`, where the exception is risen. Also to decide which debug message to use, the one with or without snapshot. 