### PR TITLE
Switched cat_consts to add lines in batches

### DIFF
--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -5,7 +5,11 @@
 
 # IMPORTANT
 # These functions use the variable $glidein_config
-# gconfig_add() (and gconfig_add_unsafe and gconfig_add_safe) all require $glidein_config, otherwise they exit
+# gconfig_add() (and gconfig_add_unsafe, gconfig_add_safe and gconfig_add_multi) all require $glidein_config, otherwise they exit
+# gconfig_add_multi() adds many "key value" lines (read from stdin, one per line) in a single
+#  read-modify-write pass, instead of one full glidein_config rewrite per call like gconfig_add().
+#  Use it instead of looping over gconfig_add() when adding more than a few lines at once
+#  (e.g. merging in a constants file), especially on slow/networked filesystems.
 # gconfig_get() takes an optional file name as second parameter.  $glidein_config is used if that is not provided.
 #  The function exits if neither are provided/defined
 # gconfig_trim() is quitting (return 1) if $glidein_config is not defined
@@ -156,6 +160,78 @@ gconfig_add() {
 
 # alias add_config_line=gconfig_add  # This is not working w/ bats
 add_config_line(){ gconfig_add "$@"; }
+
+##################################################
+# Add many lines to the config file in a single read-modify-write pass.
+# gconfig_add() does a grep + cp + grep + mv of the WHOLE glidein_config
+# file for every single call. That is fine for a handful of ad-hoc
+# additions, but calling it once per line in a loop (e.g. to merge in a
+# constants file) makes the total cost grow with both the number of
+# lines added AND the size of glidein_config, and each of those file
+# operations is a full round trip on network/shared filesystems (e.g.
+# NFS-backed worker node scratch), which can turn a few hundred
+# constants into a multi-minute (or script-timeout-triggering) operation.
+# gconfig_add_multi() does the equivalent of gconfig_add() for a whole
+# batch of lines, but only copies/rewrites glidein_config ONCE.
+# Input: lines to add are read from stdin, one per line, each formatted
+#   as "var_name var_value..." (i.e. what gconfig_add's "$@" would have
+#   been). If the same var_name appears more than once, only the last
+#   occurrence (within stdin, and vs. any pre-existing value) is kept,
+#   matching glidein_config's "last line for a key wins" convention.
+# Uses global variable glidein_config
+gconfig_add_multi() {
+    [[ -z "${glidein_config}" ]] && { warn "Error: glidein_config variable not defined. Required by gconfig_add_multi. Forcing exit."; exit 1; }
+    local tmp_lines="${glidein_config}.$$.lines.tmp"
+    cat > "${tmp_lines}"
+    if [[ ! -s "${tmp_lines}" ]]; then
+        # Nothing to add
+        rm -f "${tmp_lines}"
+        return 0
+    fi
+    # Add the values also to a log that will help troubleshoot problems (one dd for the whole batch)
+    sed 's/^/MUL'"$$"' /' "${tmp_lines}" | dd bs=$GWSM_CONFIG_LINE_MAX 2>/dev/null >> "${glidein_config}.history"
+    # Keep only the last occurrence of each key within the batch itself
+    local tmp_dedup="${glidein_config}.$$.dedup.tmp"
+    $TAC "${tmp_lines}" | awk '!x[$1]++' | $TAC > "${tmp_dedup}"
+    mv "${tmp_dedup}" "${tmp_lines}"
+    # Build an extended-regex pattern file (one "^key " pattern per line) to strip
+    # any pre-existing occurrences of these keys from glidein_config in one grep pass
+    local tmp_keys="${glidein_config}.$$.keys.tmp"
+    cut -d ' ' -f 1 "${tmp_lines}" | sed -e 's/^/^/' -e 's/$/ /' > "${tmp_keys}"
+    local tmp_config1="${glidein_config}.$$.1.tmp"
+    local tmp_config2="${glidein_config}.$$.2.tmp"
+    if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+        # Fallback to cp and chmod for file systems that do not support "-p" (e.g.: ACL not available)
+        warn "Trying cp/chown combination since cp -p failed"
+        local permissions
+        permissions=$(stat -c "%a" "${glidein_config}")
+        if ! cp "${glidein_config}" "${tmp_config1}"; then
+            warn "Error writing ${tmp_config1}"
+            rm -f "${tmp_config1}" "${tmp_lines}" "${tmp_keys}"
+            exit 1
+        fi
+        if ! chmod "$permissions" "${tmp_config1}"; then
+            warn "File copied but original file permissions cannot be set. Continuing"
+        fi
+    fi
+    local ec=0
+    # OR needed to avoid set -e problems when the file is empty
+    grep -vE -f "${tmp_keys}" "${tmp_config1}" > "${tmp_config2}" || ec=$?
+    if [[ "$ec" -gt 1 ]]; then
+        warn "Error writing ${tmp_config2} with grep"
+        rm -f "${tmp_config1}" "${tmp_config2}" "${tmp_lines}" "${tmp_keys}"
+        exit 1
+    fi
+    rm -f "${tmp_config1}" "${tmp_keys}"
+    cat "${tmp_lines}" >> "${tmp_config2}"
+    rm -f "${tmp_lines}"
+    if ! mv "${tmp_config2}" "${glidein_config}"; then
+        warn "Error renaming processed ${tmp_config2} into ${glidein_config}"
+        exit 1
+    fi
+}
+
+add_config_lines_multi() { gconfig_add_multi; }
 
 # Unsafe version, should be used only when sequentiality is guaranteed,
 # add_config_line... are the only writing functions, and only one call at the time happen.

--- a/creation/web_base/add_config_line.source
+++ b/creation/web_base/add_config_line.source
@@ -181,7 +181,7 @@ add_config_line(){ gconfig_add "$@"; }
 # Uses global variable glidein_config
 gconfig_add_multi() {
     [[ -z "${glidein_config}" ]] && { warn "Error: glidein_config variable not defined. Required by gconfig_add_multi. Forcing exit."; exit 1; }
-    local tmp_lines="${glidein_config}.$$.lines.tmp"
+    local tmp_lines="${glidein_config}.$$.newlines.tmp"
     cat > "${tmp_lines}"
     if [[ ! -s "${tmp_lines}" ]]; then
         # Nothing to add
@@ -191,12 +191,12 @@ gconfig_add_multi() {
     # Add the values also to a log that will help troubleshoot problems (one dd for the whole batch)
     sed 's/^/MUL'"$$"' /' "${tmp_lines}" | dd bs=$GWSM_CONFIG_LINE_MAX 2>/dev/null >> "${glidein_config}.history"
     # Keep only the last occurrence of each key within the batch itself
-    local tmp_dedup="${glidein_config}.$$.dedup.tmp"
+    local tmp_dedup="${glidein_config}.$$.newlinesdedup.tmp"
     $TAC "${tmp_lines}" | awk '!x[$1]++' | $TAC > "${tmp_dedup}"
     mv "${tmp_dedup}" "${tmp_lines}"
     # Build an extended-regex pattern file (one "^key " pattern per line) to strip
     # any pre-existing occurrences of these keys from glidein_config in one grep pass
-    local tmp_keys="${glidein_config}.$$.keys.tmp"
+    local tmp_keys="${glidein_config}.$$.newlineskeys.tmp"
     cut -d ' ' -f 1 "${tmp_lines}" | sed -e 's/^/^/' -e 's/$/ /' > "${tmp_keys}"
     local tmp_config1="${glidein_config}.$$.1.tmp"
     local tmp_config2="${glidein_config}.$$.2.tmp"
@@ -230,8 +230,6 @@ gconfig_add_multi() {
         exit 1
     fi
 }
-
-add_config_lines_multi() { gconfig_add_multi; }
 
 # Unsafe version, should be used only when sequentiality is guaranteed,
 # add_config_line... are the only writing functions, and only one call at the time happen.

--- a/creation/web_base/cat_consts.sh
+++ b/creation/web_base/cat_consts.sh
@@ -48,6 +48,15 @@ nr_lines=0
 if [ -n "$consts_file" ]; then
     echo "# --- Provided $dir_id constants  ---" >> "$glidein_config"
     # merge constants
+    # Collect all the "var_name var_value" lines first and add them to glidein_config
+    # in a single gconfig_add_multi() pass at the end, instead of one gconfig_add() call
+    # (a full glidein_config copy+grep+rename) per constant. That per-line approach is
+    # fine for a handful of values, but its cost grows with both the number of constants
+    # and the size of glidein_config, and each file operation is a full round trip on
+    # network/shared worker-node scratch filesystems -- enough at some sites to make
+    # this script run past the custom-script timeout. See glideinwms issue with
+    # cat_consts.sh timing out on NFS-backed OSG_WN_TMP.
+    consts_lines=""
     while read line
     do
         # disable globbing but keep the splitting in $line
@@ -56,9 +65,13 @@ if [ -n "$consts_file" ]; then
 	# var_name keeps lines w/ no separator
 	var_name="`echo "$line" | cut -f 1 | sed -e 's/[[:space:]]*$//'`"
 	var_value="`echo "$line" | cut -s -f 2- | sed -e 's/[[:space:]]*$//'`"
-        ( set -f; gconfig_add $var_name "$var_value" )
+        consts_lines="${consts_lines}$( set -f; echo $var_name "$var_value" )
+"
         let ++nr_lines
     done < "$consts_file"
+    if [ -n "$consts_lines" ]; then
+        printf '%s' "$consts_lines" | gconfig_add_multi
+    fi
     echo "# --- End $dir_id constants       ---" >> "$glidein_config"
 fi
 

--- a/creation/web_base/cat_consts.sh
+++ b/creation/web_base/cat_consts.sh
@@ -69,7 +69,7 @@ if [ -n "$consts_file" ]; then
 "
         let ++nr_lines
     done < "$consts_file"
-    # TODO: given multiline input, this could be optimized without parsing the file with somethig like:
+    # TODO: given multiline input, this could be optimized without parsing the file with something like:
     #   grep -v "^#" "$consts_file" | sed -E -e 's/^[[:blank:]]*//' -e 's/[[:blank:]]+/ /' -e 's/[[:blank:]]*$//'
     #   This file needs also a general update and revision (e.g. bash optimizations)
     if [ -n "$consts_lines" ]; then

--- a/creation/web_base/cat_consts.sh
+++ b/creation/web_base/cat_consts.sh
@@ -69,6 +69,9 @@ if [ -n "$consts_file" ]; then
 "
         let ++nr_lines
     done < "$consts_file"
+    # TODO: given multiline input, this could be optimized without parsing the file with somethig like:
+    #   grep -v "^#" "$consts_file" | sed -E -e 's/^[[:blank:]]*//' -e 's/[[:blank:]]+/ /' -e 's/[[:blank:]]*$//'
+    #   This file needs also a general update and revision (e.g. bash optimizations)
     if [ -n "$consts_lines" ]; then
         printf '%s' "$consts_lines" | gconfig_add_multi
     fi


### PR DESCRIPTION
We are still seeing timeouts glidein startup timeouts on some sites with slower filesystems. The extreme case of this is always failing in cat_consts.sh with something like:

```
Signature OK for main:cat_consts.q8pfwd.sh.
=== Validation error in /mnt/nfs/scratch/osg01/glide_qbjN9X/main/cat_consts.sh ===
Command /mnt/nfs/scratch/osg01/glide_qbjN9X/main/cat_consts.sh killed by timeout (600 s)
```

Part of the problem is the large number of constants being passed in. This mostly comes from the many different HTCondor tarballs we have to support, and it seems like there is nothing we can do about that.

This PR provides a performance improvement for cat_consts.sh, by batching the update. Details:

1. creation/web_base/add_config_line.source - added gconfig_add_multi(). It does the equivalent of gconfig_add() for a whole batch of "key value" lines (read from stdin), but copies/greps/renames glidein_config once for the whole batch instead of once per key. It preserves the existing semantics: last value wins per key (both within the batch and vs. pre-existing entries), and still logs everything to glidein_config.history. gconfig_add(), gconfig_add_safe(), etc. are untouched.
2. creation/web_base/cat_consts.sh - instead of calling gconfig_add once per line while looping over the entry's consts_file, it now accumulates all the lines and does a single gconfig_add_multi call at the end. nr_lines counting is preserved (the loop stays out of any subshell/pipe so it can still increment in place).

Why this addresses your timeout: the old loop did a full grep + cp + grep + mv of the (growing) glidein_config file per constant. On a site like this one where the whole glidein sandbox lives on a slow shared filesystem (including OSG_WN_TMP), each of those file ops is a network round trip, and with dozens/hundreds of constants that adds up fast - easily enough to blow past the 600s script timeout that killed cat_consts.sh in your log, even though the same entry runs fine on local-disk sites.
