### PR TITLE
factory: fix GLIDEIN_OVERLOAD_ENABLED handling for 3.11 frontends (Fixes #713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since the last release
 -   Python Cryptography changed some type names spelling. Added import statements to be compatible with both old and new spellings (PR #683, PR #687)
 -   Fixed `populate_group_security` in the configuration management to work with the new credentials and to handle correctly proxy ID lists for X509 DN extraction (PR #640)
 -   Fixed bug in IdTokenGenerator introduced in PR #667 (PR #702)
+-   Fixed `GLIDEIN_OVERLOAD_ENABLED` handling in factory for 3.11 frontends (PR #714, Issue #713)
 
 ### Testing / Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes since the last release
 -   Python Cryptography changed some type names spelling. Added import statements to be compatible with both old and new spellings (PR #683, PR #687)
 -   Fixed `populate_group_security` in the configuration management to work with the new credentials and to handle correctly proxy ID lists for X509 DN extraction (PR #640)
 -   Fixed bug in IdTokenGenerator introduced in PR #667 (PR #702)
--   Fixed `GLIDEIN_OVERLOAD_ENABLED` handling in factory for 3.11 frontends (PR #714, Issue #713)
+-   Fixed `GLIDEIN_OVERLOAD_ENABLED` handling in factory for 3.11 frontends (Issue #713, PR #714)
 
 ### Testing / Development
 

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -2521,7 +2521,7 @@ def get_submit_environment_v3_11(
         exe_env.append(f"IDENTITY_CREDENTIALS={','.join(id_cred_paths)}")
 
         # This is used to set the "+GlideinOverloadEnabled" param in the condor jdl
-        # This is the attribute that goes in the activity log and it used for monitoring.
+        # This is the attribute that goes in the activity log and it is used for monitoring.
         exe_env.append("GLIDEIN_OVERLOAD_ENABLED=%s" % glidein_overloaded_bool)
 
         # The parameter list to be added to the arguments for glidein_startup.sh

--- a/factory/glideFactoryLib.py
+++ b/factory/glideFactoryLib.py
@@ -2479,6 +2479,24 @@ def get_submit_environment_v3_11(
         jobAttributes = glideFactoryConfig.JobAttributes(entry_name)
         signatures = glideFactoryConfig.SignatureFile()
 
+        # For documentation
+        # CAVEAT #1: Overloading choice is applied on a "submission cycle base"
+        # CAVEAT #2: cgWCreate will only add "job_ad_information_attrs=GlideinOverloadEnabled" at reconfigure looking at the Factory
+        #            Frontend values will be ignored :(
+        # If it is const="False" in the factory, then jobAttributes will return None, and we get the param
+        # The param will either be the frontend value, or the factory one
+        # If const="True" then we'll just get the jobAttributes and ignore the params
+        glidein_overloaded_bool = False
+        glidein_overloaded = jobAttributes.data.get("GLIDEIN_OVERLOAD_ENABLED", False) or params.get(
+            "GLIDEIN_OVERLOAD_ENABLED", False
+        )
+        if glidein_overloaded:
+            glidein_overloaded_bool = overloadToBool(glidein_overloaded, log)
+            # Keeping it for convenience until we know for sure new OVERLOAD works in prod
+            # log.debug(f"OVERLOAD evaluated to: {glidein_overloaded_bool}")
+            # Overwriting the param with the "collapsed" boolean (66% => True/False)
+            params["GLIDEIN_OVERLOAD_ENABLED"] = str(glidein_overloaded_bool)
+
         exe_env = ["GLIDEIN_ENTRY_NAME=%s" % entry_name]
         scitoken = submit_credentials.security_credentials.find(
             cred_type=CredentialType.SCITOKEN, purpose=CredentialPurpose.REQUEST
@@ -2501,6 +2519,10 @@ def get_submit_environment_v3_11(
                 if cred_path(cred.private_credential):
                     id_cred_paths.append(cred_path(cred.private_credential))
         exe_env.append(f"IDENTITY_CREDENTIALS={','.join(id_cred_paths)}")
+
+        # This is used to set the "+GlideinOverloadEnabled" param in the condor jdl
+        # This is the attribute that goes in the activity log and it used for monitoring.
+        exe_env.append("GLIDEIN_OVERLOAD_ENABLED=%s" % glidein_overloaded_bool)
 
         # The parameter list to be added to the arguments for glidein_startup.sh
         params_str = ""

--- a/unittests/test_factory_glideFactoryLib.py
+++ b/unittests/test_factory_glideFactoryLib.py
@@ -55,6 +55,8 @@ from glideinwms.factory.glideFactoryLib import (
     days2sec,
     env_list2dict,
     FactoryConfig,
+    get_submit_environment,
+    get_submit_environment_v3_11,
     getCondorQCredentialList,
     getCondorQData,
     getCondorStatusData,
@@ -65,6 +67,7 @@ from glideinwms.factory.glideFactoryLib import (
     getQStatusStale,
     hrs2sec,
     isGlideinUnrecoverable,
+    overloadToBool,
     secClass2Name,
     set_condor_integrity_checks,
     which,
@@ -651,22 +654,67 @@ class TestInSubmitEnvironment(unittest.TestCase):
         assert False
 
 
+class TestOverloadToBool(unittest.TestCase):
+    def test_overload_to_bool(self):
+        self.assertTrue(overloadToBool(True))
+        self.assertFalse(overloadToBool(False))
+        self.assertTrue(overloadToBool("true"))
+        self.assertTrue(overloadToBool("TRUE"))
+        self.assertFalse(overloadToBool("false"))
+        self.assertFalse(overloadToBool("FALSE"))
+        self.assertIn(overloadToBool("66%"), [True, False])
+
+
 class TestGetSubmitEnvironment(unittest.TestCase):
-    @unittest.skip("for now")
-    def test_get_submit_environment(self):
-        # self.assertEqual(
-        #     expected,
-        #     get_submit_environment(
-        #         entry_name,
-        #         client_name,
-        #         submit_credentials,
-        #         client_web,
-        #         params,
-        #         idle_lifetime,
-        #         log,
-        #         factoryConfig))
-        # assert False # TODO: implement your test here
-        assert False
+    @mock.patch("glideinwms.factory.glideFactoryConfig.SignatureFile")
+    @mock.patch("glideinwms.factory.glideFactoryConfig.JobAttributes")
+    @mock.patch("glideinwms.factory.glideFactoryConfig.JobDescript")
+    @mock.patch("glideinwms.factory.glideFactoryConfig.GlideinDescript")
+    def test_get_submit_environment_v3_11_overload(
+        self, mock_glideinDescript, mock_jobDescript, mock_jobAttributes, mock_signatures
+    ):
+        mock_glideinDescript.return_value.data = {
+            "GlideinName": "gname",
+            "FactoryName": "fname",
+            "WebURL": "http://web.url",
+        }
+        mock_jobDescript.return_value.data = {
+            "Schedd": "schedd",
+            "Verbosity": "info",
+            "StartupDir": "/tmp",
+            "SubmitSlotsLayout": "partitionable",
+            "GridType": "condor",
+        }
+        mock_jobAttributes.return_value.data = {}
+        mock_signatures.return_value.data = {
+            "main_descript": "main_d",
+            "main_sign": "main_s",
+            "entry_entry1_descript": "entry_d",
+            "entry_entry1_sign": "entry_s",
+        }
+
+        mock_creds = mock.MagicMock()
+        mock_creds.security_credentials.find.return_value = None
+        mock_creds.identity_credentials.find.return_value = None
+        mock_creds.identity_credentials.values.return_value = []
+        mock_creds.security_class = "sec_class"
+        mock_creds.username = "user"
+        mock_creds.id = "cred_id"
+
+        params = {"GLIDEIN_OVERLOAD_ENABLED": "true"}
+        env = get_submit_environment_v3_11(
+            "entry1",
+            "client1",
+            mock_creds,
+            None,
+            params,
+            1200,
+            log=FakeLogger(),
+        )
+
+        self.assertIn("GLIDEIN_OVERLOAD_ENABLED=True", env)
+        self.assertEqual(params["GLIDEIN_OVERLOAD_ENABLED"], "True")
+        self.assertIn("GLIDEIN_PARAM_GLIDEIN_OVERLOAD_ENABLED=True", env)
 
 
 class TestIsGlideinWithinHeldLimits(unittest.TestCase):

--- a/unittests/test_factory_glideFactoryLib.py
+++ b/unittests/test_factory_glideFactoryLib.py
@@ -55,7 +55,6 @@ from glideinwms.factory.glideFactoryLib import (
     days2sec,
     env_list2dict,
     FactoryConfig,
-    get_submit_environment,
     get_submit_environment_v3_11,
     getCondorQCredentialList,
     getCondorQData,

--- a/unittests/test_factory_glideFactoryLib.py
+++ b/unittests/test_factory_glideFactoryLib.py
@@ -693,6 +693,7 @@ class TestGetSubmitEnvironment(unittest.TestCase):
         }
 
         mock_creds = mock.MagicMock()
+        mock_creds.auth_set.supports.return_value = False
         mock_creds.security_credentials.find.return_value = None
         mock_creds.identity_credentials.find.return_value = None
         mock_creds.identity_credentials.values.return_value = []


### PR DESCRIPTION
### Description
When a Frontend 3.11 requests glideins from Factory 3.11, the `submit_credentials` object contains an `auth_set` attribute, which causes the Factory to call `get_submit_environment_v3_11` instead of `get_submit_environment`.

However, `get_submit_environment_v3_11` was missing the `GLIDEIN_OVERLOAD_ENABLED` handling present in `get_submit_environment`.

### Impact
1. **Pilot Overloading Disabled**: Parameter values like `"66%"` were not evaluated/collapsed into `"True"` or `"False"` booleans via `overloadToBool()`. In pilot scripts (`glidein_cpus_setup.sh`, `glidein_memory_setup.sh`), `if [[ "${GLIDEIN_OVERLOAD_ENABLED,,}" == "true" ]]` compares `"66%"` against `"true"`, which evaluates to false. Thus, slot overloading is completely disabled for pilots requested by 3.11 Frontends.
2. **Monitoring Artifacts**: `GLIDEIN_OVERLOAD_ENABLED` environment variable was not set for submission, and raw strings (e.g. `66%`) were propagated to monitoring tools/ClassAds instead of evaluated booleans.

### Fix
- Added `GLIDEIN_OVERLOAD_ENABLED` processing via `overloadToBool()` in `get_submit_environment_v3_11` to update `params["GLIDEIN_OVERLOAD_ENABLED"]`.
- Added `GLIDEIN_OVERLOAD_ENABLED` environment variable definition for submission in `get_submit_environment_v3_11`.
- Added unit test cases for `overloadToBool` and `get_submit_environment_v3_11` in `unittests/test_factory_glideFactoryLib.py`.

Fixes #713.