### PR TITLE
Standardize reading/writing of tokens to remove/add newline characters

### DIFF
--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -1803,7 +1803,7 @@ def generate_log_tokens(glidein_main_dicts):
             try:
                 # Write the factory token
                 with open(token_filepath, "w") as tkfile:
-                    tkfile.write(token)
+                    tkfile.write(f"{token}\n")
                 # Write to url_dirs.desc
                 with open(os.path.join(entry_dir, "url_dirs.desc"), "a") as url_dirs_desc:
                     url_dirs_desc.write(f"{recipient_url} {recipient_safe_url}\n")

--- a/creation/web_base/logging_utils.source
+++ b/creation/web_base/logging_utils.source
@@ -107,10 +107,10 @@ _glog_init_tokens() {
         local vofe_token_name="TODO"    # TODO: get the name of the frontend + group
         if [ -f "tokens/${recip_dir}/${vofe_token_name}" ]; then
             # Use the token signed by the frontend
-            tokens_arr["${recip}"]=$(cat tokens/${recip_dir}/${vofe_token_name}.jwt)
+            tokens_arr["${recip}"]=$(tr -d '[:space:]' < "tokens/${recip_dir}/${vofe_token_name}.jwt")
         elif [ -f "tokens/${recip_dir}/default.jwt" ]; then
             # Use the token signed by the factory
-            tokens_arr["${recip}"]=$(cat tokens/"${recip_dir}"/default.jwt)
+            tokens_arr["${recip}"]=$(tr -d '[:space:]' < "tokens/${recip_dir}/default.jwt")
         else
             warn "_glog_init_tokens: could not find any valid token for ${recip}"
             # TODO: maybe fail only for this recipient, still serving the others?

--- a/creation/web_base/update_proxy.py
+++ b/creation/web_base/update_proxy.py
@@ -122,6 +122,7 @@ def main():
                 with open(idtokens_file) as idtf:
                     for line in idtf.readlines():
                         idtoken_data += line
+            idtoken_data.strip()
             compressed_credential = compress_credential(credential_data)
             update_credential(fname_compressed, f"{idtoken_data}####glidein_credentials={compressed_credential}")
             # in branch_v3_2 after migration_3_1 WAS: update_credential(fname_compressed, compressed_credential)

--- a/factory/glideFactoryCredentials.py
+++ b/factory/glideFactoryCredentials.py
@@ -169,6 +169,7 @@ def update_credential_file(username, client_id, credential_data, request_clientn
         with open(fname_mapped_idtoken) as idtf:
             for line in idtf.readlines():
                 idtoken_data += line
+            idtoken_data.strip()
         safe_update(
             fname_compressed, b"%s####glidein_credentials=%s" % (force_bytes(idtoken_data), compressed_credential)
         )

--- a/factory/glideFactoryEntry.py
+++ b/factory/glideFactoryEntry.py
@@ -1162,6 +1162,7 @@ def unit_work_v3(
     condortoken_file = os.path.join(submit_credentials.cred_dir, condortokenbase)
     condortoken_data = decrypted_params.get(condortoken)
     if condortoken_data:
+        condortoken_data = f"{condortoken_data.strip()}\n"
         fd, tmpnm = tempfile.mkstemp(dir=submit_credentials.cred_dir)
         try:
             entry.log.info(f"frontend_token supplied, writing to {condortoken_file}")

--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -1236,7 +1236,7 @@ class glideinFrontendElement:
                     # The token file is read as text file below. Writing fixed to be consistent
                     with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=tkn_dir) as fd:
                         os.chmod(fd.name, 0o600)
-                        fd.write(tkn_str)
+                        fd.write(f"{tkn_str.strip()}\n")
                         os.replace(fd.name, tkn_file)
                     logSupport.log.debug("created token %s" % tkn_file)
                 elif os.path.exists(tkn_file):

--- a/logserver/getjwt.py
+++ b/logserver/getjwt.py
@@ -87,7 +87,7 @@ else:
     try:
         # Write the token to a text file
         with open(token_filepath, "w") as tkfile:
-            tkfile.write(token)
+            tkfile.write(f"{token}\n")
         log(f"Token for {args.log_url} ({urllib.parse.quote(args.log_url, '')}) written to {token_filepath}")
     except OSError:
         log(f"ERROR: Unable to create JWT file: {token_filepath}")

--- a/logserver/jwt.php
+++ b/logserver/jwt.php
@@ -35,7 +35,7 @@ if ($debug) {
 
 $key = trim(file_get_contents($secretKeyFile)) ?: $defaultSecretKey;
 if (! $key) {
-    exit("JWT key is not set. Aborting.")
+    exit("JWT key is not set. Aborting.");
 }
 
 $payload = [
@@ -50,7 +50,7 @@ echo "Encoding/decoding payload using key: <$key>\n";
 if ($argc>1) {
     if ($argc==2) {
         echo "Decoding token in $argv[1]\n";
-        $jwt = file_get_contents($argv[1]);
+        $jwt = trim(file_get_contents($argv[1]));
         print_r($jwt);
         $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
         print_r($decoded);
@@ -61,8 +61,8 @@ if ($argc>1) {
         $jwt = JWT::encode($payload_array, $key, 'HS256');
         print_r($jwt);
         echo "Saving token to $argv[2]\n";
-        file_put_contents($argv[2], $jwt);
-        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        file_put_contents($argv[2], $jwt . "\n");
+        $decoded = JWT::decode(trim($jwt), new Key($key, 'HS256'));
         print_r($decoded);
     }
 } else {


### PR DESCRIPTION
Closes #639.

This PR adds a newline character (`\n`) anywhere a token is written to a file, that didn't already do so, and strips whitespace (including `\n`) when reading tokens.